### PR TITLE
Add coveralls support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -23,3 +23,4 @@ omit =
     */test_*
     */vendor/*
     */site-packages/*
+    */site.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -22,5 +22,5 @@ exclude_lines =
 omit =
     */test_*
     */vendor/*
-    */site-packages/*
-    */site.py
+    # Omit base python and installed packages
+    */python*/lib/python*/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,25 @@
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+    # 'pass' generally means 'this won't be called'
+    ^ *pass *$
+
+omit =
+    */test_*
+    */vendor/*
+    */site-packages/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ after_success:
 notifications:
   irc:
     channels:
-      - "irc.mozilla.org#callek"
+      - "irc.mozilla.org#releng"
     on_success: always
     on_failure: always
     template:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - "pip install rednose coverage coveralls"
 
 script:
-  - PYTHONPATH=vendor/lib/python nosetests -v --rednose --force-color auslib/test
+  - PYTHONPATH=vendor/lib/python nosetests -v --with-coverage --rednose --force-color auslib/test
   - coverage run -a scripts/test-rules.py -v
   - pyflakes $(find . \( -iname "*.py" -or -iname "*.wsgi" \) -not -path "*vendor*")
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ python:
 install:
   - "pip install -r requirements/dev.txt"
   - "pip install -r requirements/compiled.txt"
-  - "pip install rednose coverage"
+  - "pip install rednose coverage coveralls"
 
 script:
-  - PYTHONPATH=vendor/lib/python nosetests --with-coverage -v auslib/test
+  - PYTHONPATH=vendor/lib/python nosetests -v --rednose --force-color auslib/test
   - coverage run -a scripts/test-rules.py -v
   - pyflakes $(find . \( -iname "*.py" -or -iname "*.wsgi" \) -not -path "*vendor*")
 
@@ -22,7 +22,7 @@ after_success:
 notifications:
   irc:
     channels:
-      - "irc.mozilla.org#releng"
+      - "irc.mozilla.org#callek"
     on_success: always
     on_failure: always
     template:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,27 @@ python:
 install:
   - "pip install -r requirements/dev.txt"
   - "pip install -r requirements/compiled.txt"
+  - "pip install rednose coverage"
 
 script:
-  - PYTHONPATH=vendor/lib/python nosetests -v auslib/test
-  - scripts/test-rules.py -v
+  - PYTHONPATH=vendor/lib/python coverage run nosetests -v auslib/test
+  - coverage run -a scripts/test-rules.py -v
   - pyflakes $(find . \( -iname "*.py" -or -iname "*.wsgi" \) -not -path "*vendor*")
+
+after_success:
+  - coveralls --rcfile coveragerc
 
 # currently cannot customise per user fork, see:
 # https://github.com/travis-ci/travis-ci/issues/1094
+# please comment out this section in your personal fork!
 notifications:
-  irc: "irc.mozilla.org#releng"
-  on_success: always
-  on_failure: always
+  irc:
+    channels:
+      - "irc.mozilla.org#releng"
+    on_success: always
+    on_failure: always
+    template:
+      - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
+      - "Change view : %{compare_url}"
+      - "Build details : %{build_url}"
+      - "Commit message : %{commit_message}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - "pip install rednose coverage"
 
 script:
-  - PYTHONPATH=vendor/lib/python coverage run nosetests -v auslib/test
+  - PYTHONPATH=vendor/lib/python nosetests --with-coverage -v auslib/test
   - coverage run -a scripts/test-rules.py -v
   - pyflakes $(find . \( -iname "*.py" -or -iname "*.wsgi" \) -not -path "*vendor*")
 


### PR DESCRIPTION
This PR adds coverage back into balrog job runs (its currently covered in jenkins) and exports the report to coveralls.io

Also adds rednose (so we get pretty travis output) and adjusts IRC notification format along the same lines as the rest of our stuff as @petemoore has done.

Latest coveralls from my fork is at https://coveralls.io/builds/1703126  (I can also squash these commits if the many-commit format is not wanted for balrog)