### PR TITLE
Try to fix MANIFEST.in to include all of auslib/migrate

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include auslib/migrate/migrate.cfg
+recursive-include auslib/migrate *
+recursive-exclude * *.py[co]


### PR DESCRIPTION
This worked fine locally, but my latest pull request is failing because the balrog sdist that gets generated doesn't include auslib/migrate/versions. I'm guessing this is because they are .py files, but there's no __init__.py. Since it really isn't a proper Python module I think the best idea is to include them in the MANIFEST.in...let's see if that works.