### PR TITLE
Allow rules to have alias'

### DIFF
--- a/auslib/admin/base.py
+++ b/auslib/admin/base.py
@@ -49,8 +49,10 @@ app.add_url_rule("/users/<username>/permissions/<path:permission>", view_func=Sp
 # Some permissions may start with a slash, and the <path> converter won"t match them, so we need an extra rule to cope.
 app.add_url_rule("/users/<username>/permissions//<path:permission>", view_func=SpecificPermissionView.as_view("specific_permission2"))
 app.add_url_rule("/rules", view_func=RulesAPIView.as_view("rules"))
+# Normal operations (get/update/delete) on rules can be done by id or alias...
 app.add_url_rule("/rules/<id_or_alias>", view_func=SingleRuleView.as_view("rule"))
-app.add_url_rule("/rules/<rule_id>/revisions", view_func=RuleHistoryAPIView.as_view("rules_revisions"))
+# ...but anything to do with history must be done by id, beacuse alias may change over time
+app.add_url_rule("/rules/<int:rule_id>/revisions", view_func=RuleHistoryAPIView.as_view("rules_revisions"))
 app.add_url_rule("/releases", view_func=ReleasesAPIView.as_view("releases"))
 app.add_url_rule("/releases/<release>", view_func=SingleReleaseView.as_view("single_release"))
 app.add_url_rule("/releases/<release>/builds/<platform>/<locale>", view_func=SingleLocaleView.as_view("single_locale"))

--- a/auslib/admin/base.py
+++ b/auslib/admin/base.py
@@ -49,7 +49,7 @@ app.add_url_rule("/users/<username>/permissions/<path:permission>", view_func=Sp
 # Some permissions may start with a slash, and the <path> converter won"t match them, so we need an extra rule to cope.
 app.add_url_rule("/users/<username>/permissions//<path:permission>", view_func=SpecificPermissionView.as_view("specific_permission2"))
 app.add_url_rule("/rules", view_func=RulesAPIView.as_view("rules"))
-app.add_url_rule("/rules/<rule_id>", view_func=SingleRuleView.as_view("rule"))
+app.add_url_rule("/rules/<id_or_alias>", view_func=SingleRuleView.as_view("rule"))
 app.add_url_rule("/rules/<rule_id>/revisions", view_func=RuleHistoryAPIView.as_view("rules_revisions"))
 app.add_url_rule("/releases", view_func=ReleasesAPIView.as_view("releases"))
 app.add_url_rule("/releases/<release>", view_func=SingleReleaseView.as_view("single_release"))

--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -9,6 +9,10 @@ import logging
 log = logging.getLogger(__name__)
 
 
+# If present, rule alias' must be a string containing at least one non-numeric character.
+RULE_ALIAS_REGEXP = "(^.*[^0-9].*$|^$)"
+
+
 class DisableableTextInput(TextInput):
     """A TextInput widget that supports being disabled."""
 
@@ -108,7 +112,7 @@ class RuleForm(Form):
     backgroundRate = IntegerField('Background Rate', validators=[Required(), NumberRange(0, 100)])
     priority = IntegerField('Priority', validators=[Required()])
     mapping = SelectField('Mapping', validators=[])
-    alias = NullableStringField('Alias', validators=[Length(0, 50), Regexp("(^.*[^0-9].*$|^$)")])
+    alias = NullableStringField('Alias', validators=[Length(0, 50), Regexp(RULE_ALIAS_REGEXP)])
     product = NullableStringField('Product', validators=[Length(0, 15)])
     version = NullableStringField('Version', validators=[Length(0, 10)])
     buildID = NullableStringField('BuildID', validators=[Length(0, 20)])
@@ -128,7 +132,7 @@ class EditRuleForm(DbEditableForm):
     backgroundRate = IntegerField('Background Rate', validators=[Optional(), NumberRange(0, 100)])
     priority = IntegerField('Priority', validators=[Optional()])
     mapping = SelectField('Mapping', validators=[Optional()], coerce=NoneOrType(unicode))
-    alias = NullableStringField('Alias', validators=[Optional(), Length(0, 50), Regexp("(^.*[^0-9].*$|^$)")])
+    alias = NullableStringField('Alias', validators=[Optional(), Length(0, 50), Regexp(RULE_ALIAS_REGEXP)])
     product = NullableStringField('Product', validators=[Optional(), Length(0, 15)])
     version = NullableStringField('Version', validators=[Optional(), Length(0, 10)])
     buildID = NullableStringField('BuildID', validators=[Optional(), Length(0, 20)])

--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -3,7 +3,7 @@ import simplejson as json
 from flask_wtf import Form
 from wtforms import StringField, IntegerField, SelectField
 from wtforms.widgets import TextInput, FileInput, HiddenInput
-from wtforms.validators import Required, Optional, NumberRange, Length
+from wtforms.validators import Required, Optional, NumberRange, Length, Regexp
 
 import logging
 log = logging.getLogger(__name__)
@@ -108,6 +108,7 @@ class RuleForm(Form):
     backgroundRate = IntegerField('Background Rate', validators=[Required(), NumberRange(0, 100)])
     priority = IntegerField('Priority', validators=[Required()])
     mapping = SelectField('Mapping', validators=[])
+    alias = NullableStringField('Alias', validators=[Length(0, 50), Regexp("(^.*[^0-9].*$|^$)")])
     product = NullableStringField('Product', validators=[Length(0, 15)])
     version = NullableStringField('Version', validators=[Length(0, 10)])
     buildID = NullableStringField('BuildID', validators=[Length(0, 20)])
@@ -127,6 +128,7 @@ class EditRuleForm(DbEditableForm):
     backgroundRate = IntegerField('Background Rate', validators=[Optional(), NumberRange(0, 100)])
     priority = IntegerField('Priority', validators=[Optional()])
     mapping = SelectField('Mapping', validators=[Optional()], coerce=NoneOrType(unicode))
+    alias = NullableStringField('Alias', validators=[Optional(), Length(0, 50), Regexp("(^.*[^0-9].*$|^$)")])
     product = NullableStringField('Product', validators=[Optional(), Length(0, 15)])
     version = NullableStringField('Version', validators=[Optional(), Length(0, 10)])
     buildID = NullableStringField('BuildID', validators=[Optional(), Length(0, 20)])

--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 
 # If present, rule alias' must be a string containing at least one non-numeric character.
-RULE_ALIAS_REGEXP = "(^.*[^0-9].*$|^$)"
+RULE_ALIAS_REGEXP = "(^[a-zA-Z][a-zA-Z0-9-]*$|^$)"
 
 
 class DisableableTextInput(TextInput):

--- a/auslib/admin/views/rules.py
+++ b/auslib/admin/views/rules.py
@@ -84,7 +84,7 @@ class SingleRuleView(AdminView):
     # changed_by is available via the requirelogin decorator
     @requirelogin
     def _post(self, id_or_alias, transaction, changed_by):
-        # Verify that the rule_id exists.
+        # Verify that the rule_id or alias exists.
         rule = dbo.rules.getRule(id_or_alias, transaction=transaction)
         if not rule:
             return Response(status=404)
@@ -144,7 +144,7 @@ class SingleRuleView(AdminView):
 
     @requirelogin
     def _delete(self, id_or_alias, transaction, changed_by):
-        # Verify that the rule_id exists.
+        # Verify that the rule_id or alias exists.
         rule = dbo.rules.getRule(id_or_alias, transaction=transaction)
         if not rule:
             return Response(status=404)

--- a/auslib/admin/views/rules.py
+++ b/auslib/admin/views/rules.py
@@ -49,6 +49,7 @@ class RulesAPIView(AdminView):
         what = dict(backgroundRate=form.backgroundRate.data,
                     mapping=form.mapping.data,
                     priority=form.priority.data,
+                    alias=form.alias.data,
                     product=form.product.data,
                     version=form.version.data,
                     buildID=form.buildID.data,
@@ -130,7 +131,7 @@ class SingleRuleView(AdminView):
             if (request.json and k in request.json) or k in request.form:
                 what[k] = v
 
-        dbo.rules.updateRule(changed_by=changed_by, rule_id=id_or_alias, what=what,
+        dbo.rules.updateRule(changed_by=changed_by, id_or_alias=id_or_alias, what=what,
                              old_data_version=form.data_version.data, transaction=transaction)
         # find out what the next data version is
         rule = dbo.rules.getRule(id_or_alias, transaction=transaction)
@@ -160,7 +161,7 @@ class SingleRuleView(AdminView):
             cef_event('Unauthorized access attempt', CEF_ALERT, msg=msg)
             return Response(status=401, response=msg)
 
-        dbo.rules.deleteRule(changed_by=changed_by, rule_id=id_or_alias,
+        dbo.rules.deleteRule(changed_by=changed_by, id_or_alias=id_or_alias,
                              old_data_version=form.data_version.data, transaction=transaction)
 
         return Response(status=200)
@@ -205,6 +206,7 @@ class RuleHistoryAPIView(HistoryAdminView):
             'id': 'rule_id',
             'mapping': 'mapping',
             'priority': 'priority',
+            'alias': 'alias',
             'product': 'product',
             'version': 'version',
             'background_rate': 'backgroundRate',
@@ -268,6 +270,7 @@ class RuleHistoryAPIView(HistoryAdminView):
             backgroundRate=change['backgroundRate'],
             mapping=change['mapping'],
             priority=change['priority'],
+            alias=change['alias'],
             product=change['product'],
             version=change['version'],
             buildID=change['buildID'],
@@ -283,7 +286,7 @@ class RuleHistoryAPIView(HistoryAdminView):
             headerArchitecture=change['headerArchitecture'],
         )
 
-        dbo.rules.updateRule(changed_by=changed_by, rule_id=rule_id, what=what,
+        dbo.rules.updateRule(changed_by=changed_by, id_or_alias=rule_id, what=what,
                              old_data_version=old_data_version, transaction=transaction)
 
         return Response("Excellent!")

--- a/auslib/admin/views/rules.py
+++ b/auslib/admin/views/rules.py
@@ -170,7 +170,6 @@ class SingleRuleView(AdminView):
 class RuleHistoryAPIView(HistoryAdminView):
     """/rules/:id/revisions"""
 
-    # TODO: How does History work with alias? Maybe it *must* be retrieved by ID? Or take the current alias and then figure out its ID?
     def get(self, rule_id):
         rule = dbo.rules.getRule(rule_id)
         if not rule:
@@ -241,8 +240,6 @@ class RuleHistoryAPIView(HistoryAdminView):
 
     @requirelogin
     def _post(self, rule_id, transaction, changed_by):
-        rule_id = int(rule_id)
-
         change_id = None
         if request.json:
             change_id = request.json.get('change_id')

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -809,13 +809,13 @@ class Rules(AUSTable):
             return None
         return rules[0]
 
-    def updateRule(self, changed_by, rule_id, what, old_data_version, transaction=None):
+    def updateRule(self, changed_by, id_or_alias, what, old_data_version, transaction=None):
         """ Update the rule given by rule_id with the parameter what """
-        where = [self.rule_id == rule_id]
+        where = [(self.alias == id_or_alias) | (self.rule_id == id_or_alias)]
         self.update(changed_by=changed_by, where=where, what=what, old_data_version=old_data_version, transaction=transaction)
 
-    def deleteRule(self, changed_by, rule_id, old_data_version, transaction=None):
-        where = [self.rule_id == rule_id]
+    def deleteRule(self, changed_by, id_or_alias, old_data_version, transaction=None):
+        where = [(self.alias == id_or_alias) | (self.rule_id == id_or_alias)]
         self.delete(changed_by=changed_by, where=where, old_data_version=old_data_version, transaction=transaction)
 
 

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -637,6 +637,7 @@ class Rules(AUSTable):
     def __init__(self, metadata, dialect):
         self.table = Table('rules', metadata,
                            Column('rule_id', Integer, primary_key=True, autoincrement=True),
+                           Column('alias', String(50), unique=True),
                            Column('priority', Integer),
                            Column('mapping', String(100)),
                            Column('backgroundRate', Integer),
@@ -796,9 +797,12 @@ class Rules(AUSTable):
                 self.log.debug(r)
         return matchingRules
 
-    def getRuleById(self, rule_id, transaction=None):
+    def getRule(self, id_or_alias, transaction=None):
         """ Returns the unique rule that matches the give rule_id """
-        rules = self.select(where=[self.rule_id == rule_id], transaction=transaction)
+        rules = self.select(
+            where=[(self.alias == id_or_alias) | (self.rule_id == id_or_alias)],
+            transaction=transaction
+        )
         found = len(rules)
         if found > 1 or found == 0:
             self.log.debug("Found %s rules, should have been 1", found)

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -798,7 +798,7 @@ class Rules(AUSTable):
         return matchingRules
 
     def getRule(self, id_or_alias, transaction=None):
-        """ Returns the unique rule that matches the give rule_id """
+        """ Returns the unique rule that matches the give rule_id or alias."""
         rules = self.select(
             where=[(self.alias == id_or_alias) | (self.rule_id == id_or_alias)],
             transaction=transaction
@@ -810,7 +810,7 @@ class Rules(AUSTable):
         return rules[0]
 
     def updateRule(self, changed_by, id_or_alias, what, old_data_version, transaction=None):
-        """ Update the rule given by rule_id with the parameter what """
+        """ Update the rule given by rule_id or alias with the parameter what """
         where = [(self.alias == id_or_alias) | (self.rule_id == id_or_alias)]
         self.update(changed_by=changed_by, where=where, what=what, old_data_version=old_data_version, transaction=transaction)
 

--- a/auslib/migrate/versions/009_add_rule_alias.py
+++ b/auslib/migrate/versions/009_add_rule_alias.py
@@ -4,11 +4,11 @@ from sqlalchemy import Column, String, MetaData, Table
 def upgrade(migrate_engine):
     metadata = MetaData(bind=migrate_engine)
 
-    def add_alias(table):
-        alias = Column('alias', String(50), unique=True)
-        alias.create(table)
-    add_alias(Table('rules', metadata, autoload=True))
-    add_alias(Table('rules_history', metadata, autoload=True))
+    alias = Column("alias", String(50), unique=True)
+    alias.create(Table("rules", metadata, autoload=True), unique_name="alias_unique")
+
+    history_alias = Column("alias", String(50))
+    history_alias.create(Table('rules_history', metadata, autoload=True))
 
 
 def downgrade(migrate_engine):

--- a/auslib/migrate/versions/009_add_rule_alias.py
+++ b/auslib/migrate/versions/009_add_rule_alias.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, String, MetaData, Table
+
+
+def upgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+
+    def add_alias(table):
+        alias = Column('alias', String(50))
+        alias.create(table)
+    add_alias(Table('rules', metadata, autoload=True))
+    add_alias(Table('rules_history', metadata, autoload=True))
+
+
+def downgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+    Table('rules', metadata, autoload=True).c.alias.drop()
+    Table('rules_history', metadata, autoload=True).c.alias.drop()

--- a/auslib/migrate/versions/009_add_rule_alias.py
+++ b/auslib/migrate/versions/009_add_rule_alias.py
@@ -5,7 +5,7 @@ def upgrade(migrate_engine):
     metadata = MetaData(bind=migrate_engine)
 
     def add_alias(table):
-        alias = Column('alias', String(50))
+        alias = Column('alias', String(50), unique=True)
         alias.create(table)
     add_alias(Table('rules', metadata, autoload=True))
     add_alias(Table('rules_history', metadata, autoload=True))

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -110,5 +110,4 @@ class JSONTestMixin(object):
         if "format" not in qs:
             qs["format"] = "json"
         ret = self.client.get(url, query_string=qs, headers=headers)
-        self.assertEquals(ret.mimetype, 'application/json')
         return ret

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -64,7 +64,8 @@ class ViewTest(unittest.TestCase):
 }
 """)
         dbo.rules.t.insert().execute(id=1, priority=100, version='3.5', buildTarget='d', backgroundRate=100, mapping='c', update_type='minor', data_version=1)
-        dbo.rules.t.insert().execute(id=2, priority=100, version='3.3', buildTarget='d', backgroundRate=100, mapping='b', update_type='minor', data_version=1)
+        dbo.rules.t.insert().execute(id=2, alias="frodo", priority=100, version='3.3', buildTarget='d', backgroundRate=100, mapping='b', update_type='minor',
+                                     data_version=1)
         dbo.rules.t.insert().execute(id=3, priority=100, version='3.5', buildTarget='a', backgroundRate=100, mapping='a', update_type='minor', data_version=1)
         dbo.rules.t.insert().execute(id=4, product='fake', priority=80, buildTarget='d', backgroundRate=100, mapping='a', update_type='minor', data_version=1)
         dbo.rules.t.insert().execute(id=5, priority=80, buildTarget='d', version='3.3', backgroundRate=0, mapping='c', update_type='minor', data_version=1)

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -696,7 +696,7 @@ class TestReleaseHistoryView(ViewTest, JSONTestMixin):
         self.assertEqual(row['data_version'], 6)
 
     def testPostRevisionRollbackBadRequests(self):
-        # when posting you need both the rule_id and the change_id
+        # when posting you need both the release name and the change_id
         ret = self._post('/releases/CRAZYNAME/revisions', json.dumps({'change_id': 1}), content_type="application/json")
         self.assertEquals(ret.status_code, 404)
 

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -182,6 +182,10 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
         self.assertEquals(r[0]["version"], "3.5")
         self.assertEquals(r[0]["buildTarget"], "d")
 
+    def testPostAddBadAlias(self):
+        ret = self._post("/rules/1", data=dict(alias="abc#$%", data_version=1))
+        self.assertEquals(ret.status_code, 400, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+
     def testPostWithoutProduct(self):
         ret = self._post('/rules/4', username='bob',
                          data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1,

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -296,6 +296,10 @@ class TestRuleHistoryView(ViewTest, JSONTestMixin):
         got = json.loads(ret.data)
         self.assertEquals(got["count"], 0)
 
+    def testGetRefusesAlias(self):
+        ret = self._get("/rules/frodo/revisions")
+        self.assertEquals(ret.status_code, 404)
+
     def testGetRevisions(self):
         # Make some changes to a rule
         ret = self._post(

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -69,6 +69,32 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
             headerArchitecture=None,
             data_version=1,
             rule_id=1,
+            alias=None,
+            whitelist=None,
+        )
+        self.assertEquals(json.loads(ret.data), expected)
+
+    def testGetRuleByAlias(self):
+        ret = self._get("/rules/frodo")
+        expected = dict(
+            backgroundRate=100,
+            mapping="b",
+            priority=100,
+            product=None,
+            version="3.3",
+            buildID=None,
+            channel=None,
+            locale=None,
+            distribution=None,
+            buildTarget="d",
+            osVersion=None,
+            distVersion=None,
+            comment=None,
+            update_type="minor",
+            headerArchitecture=None,
+            data_version=1,
+            rule_id=2,
+            alias="frodo",
             whitelist=None,
         )
         self.assertEquals(json.loads(ret.data), expected)

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -123,6 +123,26 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
         self.assertEquals(r[0]['version'], '3.5')
         self.assertEquals(r[0]['buildTarget'], 'd')
 
+    def testPostByAlias(self):
+        # Make some changes to a rule
+        ret = self._post('/rules/frodo', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1,
+                                                   product='Firefox', channel='nightly'))
+        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+        load = json.loads(ret.data)
+        self.assertEquals(load['new_data_version'], 2)
+
+        # Assure the changes made it into the database
+        r = dbo.rules.t.select().where(dbo.rules.rule_id == 2).execute().fetchall()
+        self.assertEquals(len(r), 1)
+        self.assertEquals(r[0]['mapping'], 'd')
+        self.assertEquals(r[0]['backgroundRate'], 71)
+        self.assertEquals(r[0]['priority'], 73)
+        self.assertEquals(r[0]['data_version'], 2)
+        # And that we didn't modify other fields
+        self.assertEquals(r[0]['update_type'], 'minor')
+        self.assertEquals(r[0]['version'], '3.3')
+        self.assertEquals(r[0]['buildTarget'], 'd')
+
     def testPostJSON(self):
         data = json.dumps(dict(
             backgroundRate=71, mapping="d", priority=73, data_version=1,
@@ -144,6 +164,23 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
         self.assertEquals(r[0]['update_type'], 'minor')
         self.assertEquals(r[0]['version'], '3.5')
         self.assertEquals(r[0]['buildTarget'], 'd')
+
+    def testPostAddAlias(self):
+        # Make some changes to a rule
+        ret = self._post("/rules/1", data=dict(alias="sam", data_version=1))
+        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+        load = json.loads(ret.data)
+        self.assertEquals(load["new_data_version"], 2)
+
+        # Assure the changes made it into the database
+        r = dbo.rules.t.select().where(dbo.rules.rule_id == 1).execute().fetchall()
+        self.assertEquals(len(r), 1)
+        self.assertEquals(r[0]["alias"], "sam")
+        self.assertEquals(r[0]["data_version"], 2)
+        # And that we didn"t modify other fields
+        self.assertEquals(r[0]["update_type"], "minor")
+        self.assertEquals(r[0]["version"], "3.5")
+        self.assertEquals(r[0]["buildTarget"], "d")
 
     def testPostWithoutProduct(self):
         ret = self._post('/rules/4', username='bob',
@@ -208,6 +245,10 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
         ret = self._post("/rules/1", data=dict(mapping="uhet"))
         self.assertEquals(ret.status_code, 400)
 
+    def testPostWithBadAlias(self):
+        ret = self._post("/rules/1", data=dict(alias="3", data_version=1))
+        self.assertEquals(ret.status_code, 400)
+
     def testBadAuthPost(self):
         ret = self._badAuthPost('/rules/1', data=dict(backgroundRate=100, mapping='c', priority=100, data_version=1))
         self.assertEquals(ret.status_code, 401, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
@@ -231,6 +272,10 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
 
     def testDeleteRule(self):
         ret = self._delete('/rules/1', qs=dict(data_version=1))
+        self.assertEquals(ret.status_code, 200, msg=ret.data)
+
+    def testDeleteRuleByAlias(self):
+        ret = self._delete('/rules/frodo', qs=dict(data_version=1))
         self.assertEquals(ret.status_code, 200, msg=ret.data)
 
     def testDeleteRule404(self):

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -756,7 +756,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         what = dict(rules[0].items())
 
         what['mapping'] = 'd'
-        self.paths.updateRule(changed_by='bill', rule_id=1, what=what, old_data_version=1)
+        self.paths.updateRule(changed_by='bill', id_or_alias=1, what=what, old_data_version=1)
 
         rules = self.paths.t.select().where(self.paths.rule_id == 1).execute().fetchall()
         copy_rule = dict(rules[0].items())
@@ -765,9 +765,28 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         expected = [dict(rule_id=1, priority=100, backgroundRate=100, version='3.5', buildTarget='d', mapping='d', update_type='z', data_version=1)]
         self.assertEquals(rule, expected)
 
+    def testUpdateRuleByAlias(self):
+        rules = self.paths.t.select().where(self.paths.rule_id == 4).execute().fetchall()
+        what = dict(rules[0].items())
+
+        what['mapping'] = 'd'
+        self.paths.updateRule(changed_by='bill', id_or_alias="gandalf", what=what, old_data_version=1)
+
+        rules = self.paths.t.select().where(self.paths.rule_id == 4).execute().fetchall()
+        copy_rule = dict(rules[0].items())
+        rule = self._stripNullColumns([copy_rule])
+
+        expected = [dict(rule_id=4, alias="gandalf", priority=80, backgroundRate=100, buildTarget='d', mapping='d', update_type='z', data_version=1)]
+        self.assertEquals(rule, expected)
+
     def testDeleteRule(self):
-        self.paths.deleteRule(changed_by='bill', rule_id=2, old_data_version=1)
+        self.paths.deleteRule(changed_by='bill', id_or_alias=2, old_data_version=1)
         rule = self.paths.t.select().where(self.paths.rule_id == 2).execute().fetchall()
+        self.assertEquals(rule, [])
+
+    def testDeleteRuleByAlias(self):
+        self.paths.deleteRule(changed_by='bill', id_or_alias="gandalf", old_data_version=1)
+        rule = self.paths.t.select().where(self.paths.rule_id == 4).execute().fetchall()
         self.assertEquals(rule, [])
 
     def testGetNumberOfRules(self):

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -566,7 +566,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         self.paths.t.insert().execute(id=1, priority=100, version='3.5', buildTarget='d', backgroundRate=100, mapping='c', update_type='z', data_version=1)
         self.paths.t.insert().execute(id=2, priority=100, version='3.3', buildTarget='d', backgroundRate=100, mapping='b', update_type='z', data_version=1)
         self.paths.t.insert().execute(id=3, priority=100, version='3.5', buildTarget='a', backgroundRate=100, mapping='a', update_type='z', data_version=1)
-        self.paths.t.insert().execute(id=4, priority=80, buildTarget='d', backgroundRate=100, mapping='a', update_type='z', data_version=1)
+        self.paths.t.insert().execute(id=4, alias="gandalf", priority=80, buildTarget='d', backgroundRate=100, mapping='a', update_type='z', data_version=1)
         self.paths.t.insert().execute(id=5, priority=80, buildTarget='d', version='3.3', backgroundRate=0, mapping='c', update_type='z', data_version=1)
         self.paths.t.insert().execute(id=6, priority=100, buildTarget='d', mapping='a', backgroundRate=100, osVersion='foo 1', update_type='z', data_version=1)
         self.paths.t.insert().execute(
@@ -577,7 +577,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
     def testGetOrderedRules(self):
         rules = self._stripNullColumns(self.paths.getOrderedRules())
         expected = [
-            dict(rule_id=4, priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
+            dict(rule_id=4, alias="gandalf", priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
             dict(rule_id=5, priority=80, backgroundRate=0, version='3.3', buildTarget='d', mapping='c', update_type='z', data_version=1),
             dict(rule_id=6, priority=100, buildTarget='d', mapping='a', backgroundRate=100, osVersion='foo 1', update_type='z', data_version=1),
             dict(rule_id=7, priority=100, buildTarget='d', mapping='a', backgroundRate=100, osVersion='foo 2,blah 6', update_type='z', data_version=1),
@@ -614,7 +614,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         rules = self._stripNullColumns(rules)
         expected = [
             dict(rule_id=1, priority=100, backgroundRate=100, version='3.5', buildTarget='d', mapping='c', update_type='z', data_version=1),
-            dict(rule_id=4, priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
+            dict(rule_id=4, alias="gandalf", priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
         ]
         self.assertEquals(rules, expected)
 
@@ -630,7 +630,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         rules = self._stripNullColumns(rules)
         expected = [
             dict(rule_id=2, priority=100, backgroundRate=100, version='3.3', buildTarget='d', mapping='b', update_type='z', data_version=1),
-            dict(rule_id=4, priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
+            dict(rule_id=4, alias="gandalf", priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
         ]
         self.assertEquals(rules, expected)
 
@@ -646,7 +646,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         rules = self._stripNullColumns(rules)
         expected = [
             dict(rule_id=2, priority=100, backgroundRate=100, version='3.3', buildTarget='d', mapping='b', update_type='z', data_version=1),
-            dict(rule_id=4, priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
+            dict(rule_id=4, alias="gandalf", priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
             dict(rule_id=5, priority=80, backgroundRate=0, version='3.3', buildTarget='d', mapping='c', update_type='z', data_version=1),
         ]
         self.assertEquals(rules, expected)
@@ -662,7 +662,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         )
         rules = self._stripNullColumns(rules)
         expected = [
-            dict(rule_id=4, priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
+            dict(rule_id=4, alias="gandalf", priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
             dict(rule_id=6, priority=100, buildTarget='d', mapping='a', backgroundRate=100, osVersion='foo 1', update_type='z', data_version=1)
         ]
         self.assertEquals(rules, expected)
@@ -678,7 +678,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         )
         rules = self._stripNullColumns(rules)
         expected = [
-            dict(rule_id=4, priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
+            dict(rule_id=4, alias="gandalf", priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
             dict(rule_id=6, priority=100, buildTarget='d', mapping='a', backgroundRate=100, osVersion='foo 1', update_type='z', data_version=1)
         ]
         self.assertEquals(rules, expected)
@@ -694,7 +694,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         )
         rules = self._stripNullColumns(rules)
         expected = [
-            dict(rule_id=4, priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
+            dict(rule_id=4, alias="gandalf", priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
             dict(rule_id=7, priority=100, buildTarget='d', mapping='a', backgroundRate=100, osVersion='foo 2,blah 6', update_type='z', data_version=1)
         ]
         self.assertEquals(rules, expected)
@@ -728,8 +728,13 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         self.assertEquals(rules, expected)
 
     def testGetRuleById(self):
-        rule = self._stripNullColumns([self.paths.getRuleById(1)])
+        rule = self._stripNullColumns([self.paths.getRule(1)])
         expected = [dict(rule_id=1, priority=100, backgroundRate=100, version='3.5', buildTarget='d', mapping='c', update_type='z', data_version=1)]
+        self.assertEquals(rule, expected)
+
+    def testGetRuleByAlias(self):
+        rule = self._stripNullColumns([self.paths.getRule(4)])
+        expected = [dict(rule_id=4, alias="gandalf", priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1)]
         self.assertEquals(rule, expected)
 
     def testAddRule(self):


### PR DESCRIPTION
This patch adds "alias" support for rules. I decided to go with single alias per rule, and to not allow alias' to be used in history operations. I think both of these things make things simpler and more clear, but I could be convinced otherwise.

Most of this patch should be pretty straightforward. I included a change to one of the testing mixins that removes an assertion about the mime type of the response. When I added the testGetRefusesAlias test for the history view that assertion was failing, and doing so in a way that was eating the actual error. I don't really think it's adding much value (the other tests that have been using it try to parse the response as JSON anyways, so they'll fail if the response is otherwise).