### PR TITLE
Update permissions list to match new API

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1055,12 +1055,13 @@ class Permissions(AUSTable):
        option is only valid for requests through that HTTP method."""
     allPermissions = {
         'admin': [],
+        '/releases': ['method', 'product'],
         '/releases/:name': ['method', 'product'],
-        '/releases/:name/rollback': ['product'],
+        '/releases/:name/revisions': ['product'],
         '/releases/:name/builds/:platform/:locale': ['method', 'product'],
         '/rules': ['product'],
         '/rules/:id': ['method', 'product'],
-        '/rules/:id/rollback': ['product'],
+        '/rules/:id/revisions': ['product'],
         '/users/:id/permissions/:permission': ['method'],
     }
 

--- a/scripts/create-docker-containers.sh
+++ b/scripts/create-docker-containers.sh
@@ -22,7 +22,7 @@ else
     sleep 30
     docker run --rm --net host -it -v $balrog_repo:/app bhearsum/balrog:latest python scripts/manage-db.py -d mysql://balrogadmin:balrogadmin@127.0.0.1/balrog create
     docker run --rm --net host -it -v $balrog_repo:/app bhearsum/balrog:latest sh -c 'exec mysql -h 127.0.0.1 -P 3306 -u balrogadmin --password=balrogadmin balrog < /app/scripts/sample-data.sql'
-    docker run --rm --net host -it -v $balrog_repo:/app bhearsum/balrog:latest sh -c 'exec mysql -h 127.0.0.1 -P 3306 -u balrogadmin --password=balrogadmin -e "insert into permissions (username, permission, data_version) values (\"balrogadmin\", \"admin\", 0);" balrog'
+    docker run --rm --net host -it -v $balrog_repo:/app bhearsum/balrog:latest sh -c 'exec mysql -h 127.0.0.1 -P 3306 -u balrogadmin --password=balrogadmin -e "insert into permissions (username, permission, data_version) values (\"balrogadmin\", \"admin\", 1);" balrog'
 fi
 
 docker ps -a | grep -q balrog-admin


### PR DESCRIPTION
Turns out this didn't get updated when the new API was added. This patch fixes that (adds /releases, updates the rollback endpoints), and also fixes a bug in the Docker container creation script that I found while trying to test this (prevents the removal of the initial admin permission in the database).