### PR TITLE
Improve coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+include = auslib/*
+omit = auslib/migrate/*
+
+[report]
+show_missing = True

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
 
 commands=
     flake8 auslib scripts balrog.wsgi admin.wsgi uwsgi
-    py.test --cov=auslib --cov-report term-missing --doctest-modules auslib
+    py.test --cov=. --doctest-modules auslib
     coverage run -a scripts/test-rules.py
 
 [testenv:py26]

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ commands=
 max-line-length = 160
 exclude = .ropeproject,.tox,sandbox,build
 show-source = True
+ignore = E402
 
 [pytest]
 norecursedirs = .tox .git .hg sandbox build


### PR DESCRIPTION
While working on other patches I noticed that coverage is enabled for auslib/migrate, which is a bit silly. This patch fixes that, moves coverage to a config, and enables branch coverage for better accuracy. Still at 90% coverage, woo!