### PR TITLE
bug 1238944: Actually enable admin caching in admin.wsgi.

### DIFF
--- a/admin.wsgi
+++ b/admin.wsgi
@@ -25,8 +25,11 @@ if errors:
 logging.setLoggerClass(auslib.log.BalrogLogger)
 logging.basicConfig(filename=cfg.getLogfile(), level=cfg.getLogLevel(), format=auslib.log.log_format)
 
-from auslib.global_state import dbo
+from auslib.global_state import dbo, cache
 from auslib.admin.base import app as application
+
+for cache_name, cache_cfg in cfg.getCaches().iteritems():
+    cache.make_cache(cache_name, *cache_cfg)
 
 auslib.log.cef_config = auslib.log.get_cef_config(cfg.getCefLogfile())
 dbo.setDb(cfg.getDburi())

--- a/auslib/config.py
+++ b/auslib/config.py
@@ -58,6 +58,15 @@ class AUSConfig(object):
         except (NoSectionError, NoOptionError):
             return tuple()
 
+    def getCaches(self):
+        caches = {}
+        if self.cfg.has_section("caches"):
+            for cache_name in self.cfg.options("caches"):
+                size, timeout = self.cfg.get("caches", cache_name).split(",")
+                caches[cache_name] = (int(size), int(timeout))
+
+        return caches
+
 
 class AdminConfig(AUSConfig):
     required_options = {
@@ -87,12 +96,3 @@ class ClientConfig(AUSConfig):
             return tuple(a.strip() for a in self.cfg.get('site-specific', 'specialforcehosts').split(','))
         except (NoSectionError, NoOptionError):
             return None
-
-    def getCaches(self):
-        caches = {}
-        if self.cfg.has_section("caches"):
-            for cache_name in self.cfg.options("caches"):
-                size, timeout = self.cfg.get("caches", cache_name).split(",")
-                caches[cache_name] = (int(size), int(timeout))
-
-        return caches


### PR DESCRIPTION
Small follow-up...turns out I forgot that admin.wsgi wasn't already looking in the config for caches to enable. I didn't catch this locally because the new Docker-driven development uses the .wsgi files in the "uwsgi" directory, which bypass configs and enable caches directly.

On the plus side...I just did _lots_ of testing without caching that I can compare against after this lands...