### PR TITLE
Improve blob validation errors

### DIFF
--- a/auslib/admin/views/releases.py
+++ b/auslib/admin/views/releases.py
@@ -1,13 +1,11 @@
 import simplejson as json
 
-from jsonschema import ValidationError
-
 from sqlalchemy.sql.expression import null
 
 from flask import Response, jsonify, make_response, request
 
 from auslib.global_state import dbo
-from auslib.blobs.base import createBlob
+from auslib.blobs.base import createBlob, BlobValidationError
 from auslib.db import OutdatedDataError
 from auslib.log import cef_event, CEF_WARN, CEF_ALERT
 from auslib.admin.views.base import (
@@ -136,10 +134,14 @@ def changeRelease(release, changed_by, transaction, existsCallback, commitCallba
                 newReleaseData['hashFunction'] = hashFunction
             try:
                 releaseInfo = createRelease(rel, product, version, changed_by, transaction, newReleaseData)
-            except (ValidationError, ValueError) as e:
+            except BlobValidationError as e:
                 msg = "Couldn't create release: %s" % e
                 cef_event("Bad input", CEF_WARN, errors=msg, release=rel)
-                return Response(status=400, response=msg)
+                return Response(status=400, response=json.dumps({"data": e.errors}))
+            except ValueError as e:
+                msg = "Couldn't create release: %s" % e
+                cef_event("Bad input", CEF_WARN, errors=msg, release=rel)
+                return Response(status=400, response=json.dumps({"data": e.args}))
             old_data_version = 1
 
         # If the version doesn't match, just update it. This will be the case for nightlies
@@ -150,10 +152,14 @@ def changeRelease(release, changed_by, transaction, existsCallback, commitCallba
                 dbo.releases.updateRelease(name=rel, version=version,
                                            changed_by=changed_by, old_data_version=old_data_version,
                                            transaction=transaction)
-            except (ValidationError, ValueError) as e:
+            except BlobValidationError as e:
                 msg = "Couldn't update release: %s" % e
                 cef_event("Bad input", CEF_WARN, errors=msg, release=rel)
-                return Response(status=400, response=msg)
+                return Response(status=400, response=json.dumps({"data": e.errors}))
+            except ValueError as e:
+                msg = "Couldn't update release: %s" % e
+                cef_event("Bad input", CEF_WARN, errors=msg, release=rel)
+                return Response(status=400, response=json.dumps({"data": e.args}))
             old_data_version += 1
 
         extraArgs = {}
@@ -161,10 +167,14 @@ def changeRelease(release, changed_by, transaction, existsCallback, commitCallba
             extraArgs['alias'] = alias
         try:
             commitCallback(rel, product, version, incomingData, releaseInfo['data'], old_data_version, extraArgs)
-        except (ValidationError, ValueError, OutdatedDataError) as e:
+        except BlobValidationError as e:
             msg = "Couldn't update release: %s" % e
             cef_event("Bad input", CEF_WARN, errors=msg, release=rel)
-            return Response(status=400, response=msg)
+            return Response(status=400, response=json.dumps({"data": e.errors}))
+        except (ValueError, OutdatedDataError) as e:
+            msg = "Couldn't update release: %s" % e
+            cef_event("Bad input", CEF_WARN, errors=msg, release=rel)
+            return Response(status=400, response=json.dumps({"data": e.args}))
 
     new_data_version = dbo.releases.getReleases(name=release, transaction=transaction)[0]['data_version']
     if new:
@@ -242,10 +252,14 @@ class SingleReleaseView(AdminView):
                 dbo.releases.updateRelease(name=release, blob=blob, version=form.version.data,
                                            product=form.product.data, changed_by=changed_by,
                                            old_data_version=data_version, transaction=transaction)
-            except (ValidationError, ValueError) as e:
+            except BlobValidationError as e:
                 msg = "Couldn't update release: %s" % e
                 cef_event("Bad input", CEF_WARN, errors=msg)
-                return Response(status=400, response=json.dumps({"data": [msg]}))
+                return Response(status=400, response=json.dumps({"data": e.errors}))
+            except ValueError as e:
+                msg = "Couldn't update release: %s" % e
+                cef_event("Bad input", CEF_WARN, errors=msg)
+                return Response(status=400, response=json.dumps({"data": e.args}))
             data_version += 1
             return Response(json.dumps(dict(new_data_version=data_version)), status=200)
         else:
@@ -253,10 +267,14 @@ class SingleReleaseView(AdminView):
                 dbo.releases.addRelease(name=release, product=form.product.data,
                                         version=form.version.data, blob=blob,
                                         changed_by=changed_by, transaction=transaction)
-            except (ValidationError, ValueError) as e:
+            except BlobValidationError as e:
                 msg = "Couldn't update release: %s" % e
                 cef_event("Bad input", CEF_WARN, errors=msg)
-                return Response(status=400, response=json.dumps({"data": [msg]}))
+                return Response(status=400, response=json.dumps({"data": e.errors}))
+            except ValueError as e:
+                msg = "Couldn't update release: %s" % e
+                cef_event("Bad input", CEF_WARN, errors=msg)
+                return Response(status=400, response=json.dumps({"data": e.args}))
             return Response(status=201)
 
     @requirelogin
@@ -296,7 +314,7 @@ class SingleReleaseView(AdminView):
         form = DbEditableForm(request.args)
         if not form.validate():
             cef_event("Bad input", CEF_WARN, errors=form.errors)
-            return Response(status=400, response=form.errors)
+            return Response(status=400, response=json.dumps(form.errors))
 
         dbo.releases.deleteRelease(changed_by=changed_by, name=release['name'],
                                    old_data_version=form.data_version.data, transaction=transaction)
@@ -319,9 +337,9 @@ class ReleaseHistoryView(HistoryAdminView):
             page = int(request.args.get('page', 1))
             limit = int(request.args.get('limit', 10))
             assert page >= 1
-        except (ValidationError, ValueError, AssertionError) as msg:
-            cef_event("Bad input", CEF_WARN, errors=msg)
-            return Response(status=400, response=str(msg))
+        except (ValueError, AssertionError) as e:
+            cef_event("Bad input", CEF_WARN, errors=json.dumps(e.args))
+            return Response(status=400, response=json.dumps({"data": e.args}))
         offset = limit * (page - 1)
         total_count = table.t.count()\
             .where(table.name == release['name'])\
@@ -376,9 +394,12 @@ class ReleaseHistoryView(HistoryAdminView):
             dbo.releases.updateRelease(changed_by=changed_by, name=change['name'],
                                        version=change['version'], blob=blob,
                                        old_data_version=old_data_version, transaction=transaction)
-        except (ValidationError, ValueError) as e:
+        except BlobValidationError as e:
             cef_event("Bad input", CEF_WARN, errors=e.args)
-            return Response(status=400, response=e.args)
+            return Response(status=400, response=json.dumps({"data": e.errors}))
+        except ValueError as e:
+            cef_event("Bad input", CEF_WARN, errors=e.args)
+            return Response(status=400, response=json.dumps({"data": e.args}))
 
         return Response("Excellent!")
 
@@ -437,10 +458,14 @@ class ReleasesAPIView(AdminView):
                 version=form.version.data, blob=blob,
                 changed_by=changed_by, transaction=transaction
             )
-        except (ValidationError, ValueError) as e:
+        except BlobValidationError as e:
             msg = "Couldn't update release: %s" % e
             cef_event("Bad input", CEF_WARN, errors=msg)
-            return Response(status=400, response=json.dumps({"data": [msg]}))
+            return Response(status=400, response=json.dumps({"data": e.errors}))
+        except ValueError as e:
+            msg = "Couldn't update release: %s" % e
+            cef_event("Bad input", CEF_WARN, errors=msg)
+            return Response(status=400, response=json.dumps({"data": e.args}))
 
         release = dbo.releases.getReleases(
             name=name, transaction=transaction, limit=1

--- a/auslib/blobs/base.py
+++ b/auslib/blobs/base.py
@@ -76,8 +76,6 @@ class Blob(dict):
         errors = [e.message for e in validator.iter_errors(self)]
         if errors:
             raise BlobValidationError("Invalid blob! See 'errors' for details.", errors)
-        else:
-            return True
 
     def getSchema(self):
         def loadSchema():

--- a/auslib/blobs/base.py
+++ b/auslib/blobs/base.py
@@ -75,7 +75,7 @@ class Blob(dict):
         # the name of the failing property and why it failed), and return those.
         errors = [e.message for e in validator.iter_errors(self)]
         if errors:
-            raise BlobValidationError("Invalid blob!", errors)
+            raise BlobValidationError("Invalid blob! See 'errors' for details.", errors)
         else:
             return True
 

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1007,7 +1007,7 @@ class Releases(AUSTable):
         if blob.get("name"):
             # If they do, we should not let the column and the in-blob name be different.
             if name != blob["name"]:
-                raise ValueError("name in database (%s) does not match name in blob (%s)", name, blob.get("name"))
+                raise ValueError("name in database (%s) does not match name in blob (%s)" % (name, blob.get("name")))
         if self.containsForbiddenDomain(blob):
             raise ValueError("Release blob contains forbidden domain.")
 
@@ -1030,7 +1030,7 @@ class Releases(AUSTable):
             if blob.get("name"):
                 # If they do, we should not let the column and the in-blob name be different.
                 if name != blob["name"]:
-                    raise ValueError("name in database (%s) does not match name in blob (%s)", name, blob.get("name"))
+                    raise ValueError("name in database (%s) does not match name in blob (%s)" % (name, blob.get("name")))
             if self.containsForbiddenDomain(blob):
                 raise ValueError("Release blob contains forbidden domain.")
             what['data'] = blob.getJSON()

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1002,8 +1002,7 @@ class Releases(AUSTable):
         return blob
 
     def addRelease(self, name, product, version, blob, changed_by, transaction=None):
-        if not blob.isValid():
-            raise ValueError("Release blob is invalid.")
+        blob.validate()
         # Generally blobs have names, but there's no requirement that they have to.
         if blob.get("name"):
             # If they do, we should not let the column and the in-blob name be different.
@@ -1026,8 +1025,7 @@ class Releases(AUSTable):
         if version:
             what['version'] = version
         if blob:
-            if not blob.isValid():
-                raise ValueError("Release blob is invalid.")
+            blob.validate()
             # Generally blobs have names, but there's no requirement that they have to.
             if blob.get("name"):
                 # If they do, we should not let the column and the in-blob name be different.
@@ -1071,8 +1069,7 @@ class Releases(AUSTable):
                 if a not in releaseBlob['platforms']:
                     releaseBlob['platforms'][a] = {'alias': platform}
 
-        if not releaseBlob.isValid():
-            raise ValueError("New release blob is invalid.")
+        releaseBlob.validate()
         if self.containsForbiddenDomain(releaseBlob):
             raise ValueError("Release blob contains forbidden domain.")
         where = [self.name == name]

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -166,7 +166,8 @@ class TestOldVersionSpecialCases(unittest.TestCase):
 }""")
 
     def testIsValid(self):
-        self.assertTrue(self.blob.validate())
+        # Raises on error
+        self.blob.validate()
 
     def test2_0(self):
         updateQuery = {
@@ -510,8 +511,9 @@ class TestSchema2Blob(unittest.TestCase):
 """)
 
     def testIsValid(self):
-        self.assertTrue(self.blobJ2.validate())
-        self.assertTrue(self.blobK.validate())
+        # Raises on error
+        self.blobJ2.validate()
+        self.blobK.validate()
 
     def testSchema2CompleteOnly(self):
         updateQuery = {
@@ -665,7 +667,8 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
 """)
 
     def testIsValid(self):
-        self.assertTrue(self.blobJ2.validate())
+        # Raises on error
+        self.blobJ2.validate()
 
     def testCompleteOnly(self):
         updateQuery = {
@@ -888,8 +891,9 @@ class TestSchema3Blob(unittest.TestCase):
 """)
 
     def testIsValid(self):
-        self.assertTrue(self.blobF3.validate())
-        self.assertTrue(self.blobG2.validate())
+        # Raises on error
+        self.blobF3.validate()
+        self.blobG2.validate()
 
     def testSchema3MultipleUpdates(self):
         updateQuery = {
@@ -1118,7 +1122,8 @@ class TestSchema4Blob(unittest.TestCase):
 """)
 
     def testIsValid(self):
-        self.assertTrue(self.blobH2.validate())
+        # Raises on error
+        self.blobH2.validate()
 
     def testSchema4WithPartials(self):
         updateQuery = {
@@ -1258,7 +1263,8 @@ class TestSchema4Blob(unittest.TestCase):
 """)
 
         v4Blob = ReleaseBlobV4.fromV3(v3Blob)
-        self.assertTrue(v4Blob.validate())
+        # Raises on error
+        v4Blob.validate()
 
         expected = {
             "name": "g2",
@@ -1324,7 +1330,8 @@ class TestSchema4Blob(unittest.TestCase):
 """)
 
         v4Blob = ReleaseBlobV4.fromV3(v3Blob)
-        self.assertTrue(v4Blob.validate())
+        # Raises on error
+        v4Blob.validate()
 
         expected = v3Blob.copy()
         expected["schema_version"] = 4

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -7,10 +7,9 @@ import mock
 import unittest
 from xml.dom import minidom
 
-from jsonschema import ValidationError
-
 from auslib.global_state import dbo
 from auslib.errors import BadDataError
+from auslib.blobs.base import BlobValidationError
 from auslib.blobs.apprelease import ReleaseBlobBase, ReleaseBlobV1, ReleaseBlobV2, \
     ReleaseBlobV3, ReleaseBlobV4, DesupportBlob
 
@@ -1393,4 +1392,4 @@ class TestDesupportBlob(unittest.TestCase):
 
     def testBrokenDesupport(self):
         blob = DesupportBlob(name="d2", schema_version=50, foo="bar")
-        self.assertRaises(ValidationError, blob.isValid)
+        self.assertRaises(BlobValidationError, blob.validate)

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -165,7 +165,7 @@ class TestOldVersionSpecialCases(unittest.TestCase):
 }""")
 
     def testIsValid(self):
-        self.assertTrue(self.blob.isValid())
+        self.assertTrue(self.blob.validate())
 
     def test2_0(self):
         updateQuery = {
@@ -509,8 +509,8 @@ class TestSchema2Blob(unittest.TestCase):
 """)
 
     def testIsValid(self):
-        self.assertTrue(self.blobJ2.isValid())
-        self.assertTrue(self.blobK.isValid())
+        self.assertTrue(self.blobJ2.validate())
+        self.assertTrue(self.blobK.validate())
 
     def testSchema2CompleteOnly(self):
         updateQuery = {
@@ -664,7 +664,7 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
 """)
 
     def testIsValid(self):
-        self.assertTrue(self.blobJ2.isValid())
+        self.assertTrue(self.blobJ2.validate())
 
     def testCompleteOnly(self):
         updateQuery = {
@@ -887,8 +887,8 @@ class TestSchema3Blob(unittest.TestCase):
 """)
 
     def testIsValid(self):
-        self.assertTrue(self.blobF3.isValid())
-        self.assertTrue(self.blobG2.isValid())
+        self.assertTrue(self.blobF3.validate())
+        self.assertTrue(self.blobG2.validate())
 
     def testSchema3MultipleUpdates(self):
         updateQuery = {
@@ -1117,7 +1117,7 @@ class TestSchema4Blob(unittest.TestCase):
 """)
 
     def testIsValid(self):
-        self.assertTrue(self.blobH2.isValid())
+        self.assertTrue(self.blobH2.validate())
 
     def testSchema4WithPartials(self):
         updateQuery = {
@@ -1257,7 +1257,7 @@ class TestSchema4Blob(unittest.TestCase):
 """)
 
         v4Blob = ReleaseBlobV4.fromV3(v3Blob)
-        self.assertTrue(v4Blob.isValid())
+        self.assertTrue(v4Blob.validate())
 
         expected = {
             "name": "g2",
@@ -1323,7 +1323,7 @@ class TestSchema4Blob(unittest.TestCase):
 """)
 
         v4Blob = ReleaseBlobV4.fromV3(v3Blob)
-        self.assertTrue(v4Blob.isValid())
+        self.assertTrue(v4Blob.validate())
 
         expected = v3Blob.copy()
         expected["schema_version"] = 4

--- a/auslib/test/blobs/test_base.py
+++ b/auslib/test/blobs/test_base.py
@@ -55,11 +55,11 @@ class TestCreateBlob(unittest.TestCase):
                 schema_version=1,
                 name="foo",
             ))
-            blob.isValid()
+            blob.validate()
             blob = createBlob(dict(
                 schema_version=1,
                 name="foo",
             ))
-            blob.isValid()
+            blob.validate()
 
             self.assertEquals(yaml_load.call_count, 1)

--- a/auslib/test/blobs/test_settings.py
+++ b/auslib/test/blobs/test_settings.py
@@ -23,7 +23,7 @@ class TestSchemaSettings(unittest.TestCase):
     def test_basic_blob(self):
         self.blob = SettingsBlob()
         self.blob.loadJSON(_DATA)
-        self.assertTrue(self.blob.isValid())
+        self.assertTrue(self.blob.validate())
 
         update_query = {
             "product": "gg", "version": "3", "buildID": "1",

--- a/auslib/test/blobs/test_settings.py
+++ b/auslib/test/blobs/test_settings.py
@@ -23,7 +23,7 @@ class TestSchemaSettings(unittest.TestCase):
     def test_basic_blob(self):
         self.blob = SettingsBlob()
         self.blob.loadJSON(_DATA)
-        self.assertTrue(self.blob.validate())
+        self.blob.validate()
 
         update_query = {
             "product": "gg", "version": "3", "buildID": "1",

--- a/auslib/test/blobs/test_whitelist.py
+++ b/auslib/test/blobs/test_whitelist.py
@@ -21,7 +21,7 @@ class TestWhitelist(unittest.TestCase):
     def test_whitelist_blob(self):
         self.blob = WhitelistBlobV1()
         self.blob.loadJSON(_DATA)
-        self.assertTrue(self.blob.isValid())
+        self.assertTrue(self.blob.validate())
 
         update_query = {
             "product": "b2g", "version": "2.5", "buildID": "1",

--- a/auslib/test/blobs/test_whitelist.py
+++ b/auslib/test/blobs/test_whitelist.py
@@ -21,7 +21,7 @@ class TestWhitelist(unittest.TestCase):
     def test_whitelist_blob(self):
         self.blob = WhitelistBlobV1()
         self.blob.loadJSON(_DATA)
-        self.assertTrue(self.blob.validate())
+        self.blob.validate()
 
         update_query = {
             "product": "b2g", "version": "2.5", "buildID": "1",

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -6,8 +6,6 @@ import sys
 from tempfile import mkstemp
 import unittest
 
-from jsonschema import ValidationError
-
 from sqlalchemy import create_engine, MetaData, Table, Column, Integer, select
 from sqlalchemy.engine.reflection import Inspector
 
@@ -16,6 +14,7 @@ import migrate.versioning.api
 from auslib.global_state import cache
 from auslib.db import AUSDatabase, AUSTable, AlreadySetupError, \
     AUSTransaction, TransactionError, OutdatedDataError
+from auslib.blobs.base import BlobValidationError
 from auslib.blobs.apprelease import ReleaseBlobV1
 
 
@@ -1298,7 +1297,7 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
     def testUpdateReleaseInvalidBlob(self):
         blob = ReleaseBlobV1(name="2", hashFunction="sha512")
         blob['foo'] = 'bar'
-        self.assertRaises(ValidationError, self.releases.updateRelease, changed_by='bill', name='b', blob=blob, old_data_version=1)
+        self.assertRaises(BlobValidationError, self.releases.updateRelease, changed_by='bill', name='b', blob=blob, old_data_version=1)
 
     def testAddLocaleToRelease(self):
         data = {


### PR DESCRIPTION
The current state of things is that a massive jsonschema error (with the entire blob in it) will be returned if any part of the schema fails. This is really quite useless on the UI, and this patch fixes it up. I had to add a custom exception because there's post-processing of the errors to be done, and I didn't want to repeat that everywhere that we're validating blobs. I also renamed isValid to validate to make it more clear that it raises ("isValid" sounds like it should return True or False, not raise). There's a small UI patch to cope with the returning of a list instead of a string too. With both of them, we get errors like: http://people.mozilla.org/~bhearsum/sattap/bea114d5.png.