### PR TITLE
Make copying upon cache get/put optional

### DIFF
--- a/admin.wsgi
+++ b/admin.wsgi
@@ -28,6 +28,7 @@ logging.basicConfig(filename=cfg.getLogfile(), level=cfg.getLogLevel(), format=a
 from auslib.global_state import dbo, cache
 from auslib.admin.base import app as application
 
+cache.make_copies = True
 for cache_name, cache_cfg in cfg.getCaches().iteritems():
     cache.make_cache(cache_name, *cache_cfg)
 

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -3,7 +3,7 @@ import simplejson as json
 from tempfile import mkstemp
 import unittest
 
-from auslib.global_state import dbo
+from auslib.global_state import dbo, cache
 from auslib.admin.base import app
 import auslib.log
 
@@ -14,6 +14,8 @@ class ViewTest(unittest.TestCase):
 
     def setUp(self):
         self.cef_fd, self.cef_file = mkstemp()
+        cache.reset()
+        cache.make_copies = True
         app.config["SECRET_KEY"] = 'abc123'
         app.config['DEBUG'] = True
         app.config["WTF_CSRF_ENABLED"] = False

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1028,6 +1028,7 @@ class TestBlobCaching(unittest.TestCase, MemoryDatabaseMixin):
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         cache.reset()
+        cache.make_copies = True
         cache.make_cache("blob", 10, 10)
         cache.make_cache("blob_version", 10, 4)
         self.db = AUSDatabase(self.dburi)

--- a/auslib/test/util/test_cache.py
+++ b/auslib/test/util/test_cache.py
@@ -33,3 +33,44 @@ class TestMaybeCacher(unittest.TestCase):
             cache.put("cache1", "foo", "bar")
             t.return_value = 200
             self.assertEquals(cache.get("cache1", "foo"), None)
+
+    def testGetDoesntCopyByDefault(self):
+        cache = MaybeCacher()
+        cache.make_cache("cache1", 5, 5)
+        obj = [1, 2, 3]
+        # We put this into the cache manually to avoid a false pass from something .put does
+        # cache entry format is (pos, value, expiration)
+        cache.caches["cache1"].data["foo"] = (0, obj, 9999999999999999)
+        cached_obj = cache.get("cache1", "foo")
+        print obj
+        print cached_obj
+        self.assertEquals(id(obj), id(cached_obj))
+
+    def testPutDoesntCopyByDefault(self):
+        cache = MaybeCacher()
+        cache.make_cache("cache1", 5, 5)
+        obj = [1, 2, 3]
+        # We put this into the cache manually to avoid a false pass from something .get does
+        cache.put("cache1", "foo", obj)
+        cached_obj = cache.caches["cache1"].data["foo"][1]
+        self.assertEquals(id(obj), id(cached_obj))
+
+    def testCopyOnGet(self):
+        cache = MaybeCacher()
+        cache.make_cache("cache1", 5, 5)
+        cache.make_copies = True
+        obj = [1, 2, 3]
+        # We put this into the cache manually to avoid a false pass from something .put does
+        cache.caches["cache1"].data["foo"] = obj
+        cached_obj = cache.get("cache1", "foo")
+        self.assertNotEquals(id(obj), id(cached_obj))
+
+    def testCopyOnPut(self):
+        cache = MaybeCacher()
+        cache.make_cache("cache1", 5, 5)
+        cache.make_copies = True
+        obj = [1, 2, 3]
+        # We put this into the cache manually to avoid a false pass from something .get does
+        cache.put("cache1", "foo", obj)
+        cached_obj = cache.caches["cache1"].data["foo"]
+        self.assertNotEquals(id(obj), id(cached_obj))

--- a/auslib/util/cache.py
+++ b/auslib/util/cache.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from repoze.lru import ExpiringLRUCache
 
 
@@ -15,6 +17,17 @@ class MaybeCacher(object):
 
     def __init__(self):
         self.caches = {}
+        self._make_copies = False
+
+    @property
+    def make_copies(self):
+        return self._make_copies
+
+    @make_copies.setter
+    def make_copies(self, value):
+        if value not in (True, False):
+            raise TypeError("make_copies must be True or False")
+        self._make_copies = value
 
     def make_cache(self, name, maxsize, timeout):
         if name in self.caches:
@@ -41,12 +54,22 @@ class MaybeCacher(object):
             value = value_getter()
             self.put(name, key, value)
 
-        return value
+        # Copy the value to make sure the caller can't accidentally update the
+        # cached version. If they want to update it, they should call "put"
+        # explicitly.
+        if self.make_copies:
+            return deepcopy(value)
+        else:
+            return value
 
     def put(self, name, key, value):
         if name not in self.caches:
             return
 
+        # Copy the value to make sure the caller can't accicdentally update the
+        # cached version.
+        if self.make_copies:
+            value = deepcopy(value)
         return self.caches[name].put(key, value)
 
     def clear(self, name=None):

--- a/auslib/util/cache.py
+++ b/auslib/util/cache.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from repoze.lru import ExpiringLRUCache
 
 
@@ -43,18 +41,13 @@ class MaybeCacher(object):
             value = value_getter()
             self.put(name, key, value)
 
-        # Copy the value to make sure the caller can't accidentally update the
-        # cached version. If they want to update it, they should call "put"
-        # explicitly.
-        return deepcopy(value)
+        return value
 
     def put(self, name, key, value):
         if name not in self.caches:
             return
 
-        # Copy the value to make sure the caller can't accicdentally update the
-        # cached version.
-        return self.caches[name].put(key, deepcopy(value))
+        return self.caches[name].put(key, value)
 
     def clear(self, name=None):
         if name and name not in self.caches:

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -26,6 +26,7 @@ from auslib.global_state import cache, dbo
 # TODO: How to do cef logging in CloudOps? Do we need to?
 auslib.log.cef_config = auslib.log.get_cef_config("syslog")
 
+cache.make_copies = True
 # We explicitly don't want a blob_version cache here because it will cause
 # issues where we run multiple instances of the admin app. Even though each
 # app will update its caches when it updates the db, the others would still


### PR DESCRIPTION
I should preface this patch by saying I'm not terribly happy with this as a workaround for the performance issues noted in https://bugzilla.mozilla.org/show_bug.cgi?id=1238944, but it's the best I can come up with right now. Before doing this I went down the path of trying to ensure that Blobs are immutable by default. This looked like it would be relatively easy by using frozendict and a custom JSONDecoder to make sure all incoming data ends up in frozendicts. That part was easy, but we also have some parts of blobs that are arrays while in JSON format, and get converted to Python lists. Unfortunately, Array decoding is the one thing that isn't overridable in JSONDecoder (see https://hg.python.org/cpython/file/default/Lib/json/decoder.py#l283, which has hooks for objects/ints/floats/strings, but a hardcoded handler for arrays). I tried some fairly invasive hacks to work around this, none of which worked. Anything we use there would have to be rewritten significantly when we upgrade to Python 2.7 anyways, because the json implementation changed a lot from 2.6 -> 2.7. The only other way I could think of think of to make them immutable would be to walk the entire dict after initial parsing, and converting the lists to tuples then. That's pretty expensive, so I didn't think it was worthwhile pursuing.

With that all said, this should work. It essentially makes bug 1238944 a no-op for the public facing nodes, so there should be no performance issues when it re-lands. I'd like to write a few more tests, but I wanted to be sure this is a sensible path forward first.