### PR TITLE
Kill version in releases table.

### DIFF
--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -96,7 +96,6 @@ class PartialReleaseForm(Form):
     # for its existence in this case.
     data_version = IntegerField('data_version', widget=HiddenInput())
     product = StringField('Product', validators=[Required()])
-    version = StringField('Version', validators=[Required()])
     hashFunction = StringField('Hash Function')
     data = JSONStringField('Data', validators=[Required()])
     schema_version = IntegerField('Schema Version')
@@ -146,7 +145,6 @@ class EditRuleForm(DbEditableForm):
 
 class CompleteReleaseForm(Form):
     name = StringField('Name', validators=[Required()])
-    version = StringField('Version', validators=[Required()])
     product = StringField('Product', validators=[Required()])
     blob = JSONStringField('Data', validators=[Required()], widget=FileInput())
     data_version = IntegerField('data_version', widget=HiddenInput())

--- a/auslib/migrate/versions/010_delete_releases_version.py
+++ b/auslib/migrate/versions/010_delete_releases_version.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, String, MetaData, Table
+
+
+def upgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+    Table('releases', metadata, autoload=True).c.version.drop()
+    Table('releases_history', metadata, autoload=True).c.version.drop()
+
+
+def downgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+
+    version = Column("version", String(25), unique=True)
+    version.create(Table("releases", metadata, autoload=True), unique_name="version_unique")
+
+    history_version = Column("version", String(25))
+    history_version.create(Table('releases_history', metadata, autoload=True))

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -29,14 +29,14 @@ class ViewTest(unittest.TestCase):
         dbo.permissions.t.insert().execute(permission='/releases/:name', username='bob', options=json.dumps(dict(product=['fake'])), data_version=1)
         dbo.permissions.t.insert().execute(permission='/rules/:id', username='bob', options=json.dumps(dict(product=['fake'])), data_version=1)
         dbo.releases.t.insert().execute(
-            name='a', product='a', version='a', data=json.dumps(dict(name='a', hashFunction="sha512", schema_version=1)), data_version=1)
+            name='a', product='a', data=json.dumps(dict(name='a', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(
-            name='ab', product='a', version='a', data=json.dumps(dict(name='ab', hashFunction="sha512", schema_version=1)), data_version=1)
+            name='ab', product='a', data=json.dumps(dict(name='ab', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(
-            name='b', product='b', version='b', data=json.dumps(dict(name='b', hashFunction="sha512", schema_version=1)), data_version=1)
+            name='b', product='b', data=json.dumps(dict(name='b', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(
-            name='c', product='c', version='c', data=json.dumps(dict(name='c', hashFunction="sha512", schema_version=1)), data_version=1)
-        dbo.releases.t.insert().execute(name='d', product='d', version='d', data_version=1, data="""
+            name='c', product='c', data=json.dumps(dict(name='c', hashFunction="sha512", schema_version=1)), data_version=1)
+        dbo.releases.t.insert().execute(name='d', product='d', data_version=1, data="""
 {
     "name": "d",
     "schema_version": 1,

--- a/auslib/test/admin/views/test_history.py
+++ b/auslib/test/admin/views/test_history.py
@@ -36,7 +36,7 @@ class TestHistoryView(ViewTest):
         data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1, name="d", hashFunction="sha512"))
         ret = self._post(
             '/releases/d',
-            data=dict(data=data, product='d', version='d', data_version=1)
+            data=dict(data=data, product='d', data_version=1)
         )
         self.assertStatusCode(ret, 200)
 
@@ -77,7 +77,7 @@ class TestHistoryView(ViewTest):
         data = json.dumps(dict(detailsUrl='blah', fakePartials=False, schema_version=1, name="d", hashFunction="sha512"))
         ret = self._post(
             '/releases/d',
-            data=dict(data=data, product='d', version='d', data_version=2)
+            data=dict(data=data, product='d', data_version=2)
         )
         self.assertStatusCode(ret, 200)
 

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -25,7 +25,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 
     def testReleasePostUpdateExisting(self):
         data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1))
-        ret = self._post('/releases/d', data=dict(data=data, product='d', version='d', data_version=1))
+        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
         self.assertStatusCode(ret, 200)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
         self.assertEqual(json.loads(ret), json.loads("""
@@ -53,31 +53,30 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 
     def testReleasePostMismatchedName(self):
         data = json.dumps(dict(name="eee", schema_version=1))
-        ret = self._post('/releases/d', data=dict(data=data, product='d', version='d', data_version=1))
+        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testReleasePostUpdateChangeHashFunction(self):
         data = json.dumps(dict(detailsUrl='blah', hashFunction="sha1024", schema_version=1))
-        ret = self._post('/releases/d', data=dict(data=data, product='d', version='d', data_version=1))
+        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testReleasePostUpdateChangeProduct(self):
         data = json.dumps(dict(detailsUrl="abc", schema_version=1))
-        ret = self._post("/releases/c", data=dict(data=data, product="h", version="c", data_version=1))
+        ret = self._post("/releases/c", data=dict(data=data, product="h", data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testReleasePostInvalidBlob(self):
         data = json.dumps(dict(uehont="uhetn", schema_version=1))
-        ret = self._post("/releases/c", data=dict(data=data, product="c", version="c", data_version=1))
+        ret = self._post("/releases/c", data=dict(data=data, product="c", data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testReleasePostCreatesNewReleasev1(self):
         data = json.dumps(dict(bouncerProducts=dict(partial='foo'), name='e', hashFunction="sha512"))
-        ret = self._post('/releases/e', data=dict(data=data, product='e', version='e', schema_version=1))
+        ret = self._post('/releases/e', data=dict(data=data, product='e', schema_version=1))
         self.assertStatusCode(ret, 201)
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
-        self.assertEqual(ret['version'], 'e')
         self.assertEqual(ret['name'], 'e')
         self.assertEqual(json.loads(ret['data']), json.loads("""
 {
@@ -92,11 +91,10 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 
     def testReleasePostCreatesNewReleasev2(self):
         data = json.dumps(dict(bouncerProducts=dict(complete='foo'), name='e', hashFunction="sha512"))
-        ret = self._post('/releases/e', data=dict(data=data, product='e', version='e', schema_version=2))
+        ret = self._post('/releases/e', data=dict(data=data, product='e', schema_version=2))
         self.assertStatusCode(ret, 201)
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
-        self.assertEqual(ret['version'], 'e')
         self.assertEqual(ret['name'], 'e')
         self.assertEqual(json.loads(ret['data']), json.loads("""
 {
@@ -116,7 +114,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 
     def testReleasePostRejectedURL(self):
         data = json.dumps(dict(platforms=dict(p=dict(locales=dict(f=dict(complete=dict(fileUrl='http://evil.com')))))))
-        ret = self._post('/releases/d', data=dict(data=data, product='d', version='d', data_version=1))
+        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testDeleteRelease(self):
@@ -141,7 +139,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
                 "hashValue": "abc",
             }
         })
-        ret = self._put('/releases/a/builds/p/l', data=dict(data=data, product='a', version='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/a/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'a').execute().fetchone()[0]
@@ -168,12 +166,12 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 
     def testLocalePutWithBadHashFunction(self):
         data = json.dumps(dict(complete=dict(filesize='435')))
-        ret = self._put('/releases/a/builds/p/l', data=dict(data=data, product='a', version='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/a/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 400)
 
     def testLocalePutWithoutPermissionForProduct(self):
         data = json.dumps(dict(complete=dict(filesize='435')))
-        ret = self._put('/releases/a/builds/p/l', username='bob', data=dict(data=data, product='a', version='a', data_version=1))
+        ret = self._put('/releases/a/builds/p/l', username='bob', data=dict(data=data, product='a', data_version=1))
         self.assertStatusCode(ret, 401)
 
     def testLocalePutForNewRelease(self):
@@ -186,7 +184,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
         })
         # setting schema_version in the incoming blob is a hack for testing
         # SingleLocaleView._put() doesn't give us access to the form
-        ret = self._put('/releases/e/builds/p/a', data=dict(data=data, product='e', version='e', hashFunction="sha512", schema_version=1))
+        ret = self._put('/releases/e/builds/p/a', data=dict(data=data, product='e', hashFunction="sha512", schema_version=1))
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'e').execute().fetchone()[0]
@@ -220,7 +218,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
                 "fileUrl": "http://good.com/blah",
             }
         })
-        ret = self._put('/releases/d/builds/p/g', data=dict(data=data, product='d', version='d', data_version=1, schema_version=1))
+        ret = self._put('/releases/d/builds/p/g', data=dict(data=data, product='d', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
@@ -263,7 +261,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
         })
         # setting schema_version in the incoming blob is a hack for testing
         # SingleLocaleView._put() doesn't give us access to the form
-        ret = self._put('/releases/e/builds/p/a', data=dict(data=data, product='e', version='e', alias='["p2"]', schema_version=1, hashFunction="sha512"))
+        ret = self._put('/releases/e/builds/p/a', data=dict(data=data, product='e', alias='["p2"]', schema_version=1, hashFunction="sha512"))
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'e').execute().fetchone()[0]
@@ -300,7 +298,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
                 "fileUrl": "http://good.com/blah",
             }
         })
-        ret = self._put('/releases/d/builds/q/g', data=dict(data=data, product='d', version='d', data_version=1, alias='["q2"]', schema_version=1))
+        ret = self._put('/releases/d/builds/q/g', data=dict(data=data, product='d', data_version=1, alias='["q2"]', schema_version=1))
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
@@ -348,7 +346,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
                 "hashValue": "abc",
             }
         })
-        data = dict(data=data, product='a', version='a', copyTo=json.dumps(['ab']), data_version=1, schema_version=1)
+        data = dict(data=data, product='a', copyTo=json.dumps(['ab']), data_version=1, schema_version=1)
         ret = self._put('/releases/a/builds/p/l', data=data)
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
@@ -395,38 +393,13 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 }
 """))
 
-    def testLocalePutChangeVersion(self):
-        data = json.dumps(dict(extv='b'))
-        ret = self._put('/releases/a/builds/p/l', data=dict(data=data, product='a', version='b', data_version=1, schema_version=1))
-        self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(dict(new_data_version=3)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'a').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads("""
-{
-    "name": "a",
-    "schema_version": 1,
-    "hashFunction": "sha512",
-    "platforms": {
-        "p": {
-            "locales": {
-                "l": {
-                    "extv": "b"
-                }
-            }
-        }
-    }
-}
-"""))
-        newVersion = select([dbo.releases.version]).where(dbo.releases.name == 'a').execute().fetchone()[0]
-        self.assertEqual(newVersion, 'b')
-
     def testLocalePutBadJSON(self):
-        ret = self._put('/releases/a/builds/p/l', data=dict(data='a', product='a', version='a'))
+        ret = self._put('/releases/a/builds/p/l', data=dict(data='a', product='a'))
         self.assertStatusCode(ret, 400)
 
     def testLocaleRejectedURL(self):
         data = json.dumps(dict(complete=dict(fileUrl='http://evil.com')))
-        ret = self._put('/releases/a/builds/p/l', data=dict(data=data, product='a', version='a', data_version=1))
+        ret = self._put('/releases/a/builds/p/l', data=dict(data=data, product='a', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testLocaleGet(self):
@@ -449,7 +422,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 
     def testLocalePutCantChangeProduct(self):
         data = json.dumps(dict(complete=dict(filesize=435)))
-        ret = self._put('/releases/a/builds/p/l', data=dict(data=data, product='b', version='a', schema_version=1))
+        ret = self._put('/releases/a/builds/p/l', data=dict(data=data, product='b', schema_version=1))
         self.assertStatusCode(ret, 400)
 
     def testLocaleGet404(self):
@@ -471,7 +444,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 #            self.assertEqual(json.loads(ret['data']), dict(name='a', hashFunction="sha512", schema_version=1))
 
     def testNewReleasePut(self):
-        ret = self._put('/releases/new_release', data=dict(name='new_release', version='11', product='Firefox',
+        ret = self._put('/releases/new_release', data=dict(name='new_release', product='Firefox',
                                                            blob="""
 {
     "name": "new_release",
@@ -492,7 +465,6 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
         r = dbo.releases.t.select().where(dbo.releases.name == 'new_release').execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'new_release')
-        self.assertEquals(r[0]['version'], '11')
         self.assertEquals(r[0]['product'], 'Firefox')
         self.assertEquals(json.loads(r[0]['data']), json.loads("""
 {
@@ -511,7 +483,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 """))
 
     def testNewReleasePutBadInput(self):
-        ret = self._put("/releases/ueohueo", data=dict(name="ueohueo", version="1", product="aa", blob="""
+        ret = self._put("/releases/ueohueo", data=dict(name="ueohueo", product="aa", blob="""
 {
     "name": "ueohueo",
     "schema_version": 3,
@@ -522,7 +494,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
         self.assertStatusCode(ret, 400)
 
     def testNewReleasePutMismatchedName(self):
-        ret = self._put("/releases/aaaa", data=dict(name="ueohueo", version="1", product="aa", blob="""
+        ret = self._put("/releases/aaaa", data=dict(name="ueohueo", product="aa", blob="""
 {
     "name": "bbbb",
     "schema_version": 3
@@ -531,7 +503,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
         self.assertStatusCode(ret, 400)
 
     def testPutExistingRelease(self):
-        ret = self._put("/releases/d", data=dict(name="d", version="3", product="Firefox", data_version=1, blob="""
+        ret = self._put("/releases/d", data=dict(name="d", product="Firefox", data_version=1, blob="""
 {
     "name": "d",
     "schema_version": 3,
@@ -543,7 +515,6 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
         r = dbo.releases.t.select().where(dbo.releases.name == 'd').execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'd')
-        self.assertEquals(r[0]['version'], '3')
         self.assertEquals(r[0]['product'], 'Firefox')
         self.assertEquals(json.loads(r[0]['data']), json.loads("""
 {
@@ -556,7 +527,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 
     def testGMPReleasePut(self):
 
-        ret = self._put('/releases/gmprel', data=dict(name='gmprel', version='5', product='GMP',
+        ret = self._put('/releases/gmprel', data=dict(name='gmprel', product='GMP',
                                                       blob="""
 {
     "name": "gmprel",
@@ -584,7 +555,6 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
         r = dbo.releases.t.select().where(dbo.releases.name == 'gmprel').execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'gmprel')
-        self.assertEquals(r[0]['version'], '5')
         self.assertEquals(r[0]['product'], 'GMP')
         self.assertEquals(json.loads(r[0]['data']), json.loads("""
 {
@@ -632,8 +602,8 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
         self.assertEquals(json.loads(ret.data), json.loads("""
 {
     "releases": [
-        {"data_version": 1, "name": "a", "product": "a", "version": "a"},
-        {"data_version": 1, "name": "ab", "product": "a", "version": "a"}
+        {"data_version": 1, "name": "a", "product": "a"},
+        {"data_version": 1, "name": "ab", "product": "a"}
     ]
 }
 """))
@@ -648,24 +618,12 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 }
 """))
 
-    def testGetReleasesNamePrefixNamesOnlyVersion(self):
-        ret = self._get("/releases", qs=dict(name_prefix='a',
-                                             names_only='1',
-                                             version="b"))
-        self.assertStatusCode(ret, 200)
-        self.assertEquals(json.loads(ret.data), json.loads("""
-{
-    "names": []
-}
-"""))
-
     def testReleasesPost(self):
         data = json.dumps(dict(bouncerProducts=dict(partial='foo'), name='e', schema_version=1, hashFunction="sha512"))
-        ret = self._post('/releases', data=dict(blob=data, name="e", product='e', version='e'))
+        ret = self._post('/releases', data=dict(blob=data, name="e", product='e'))
         self.assertStatusCode(ret, 201)
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
-        self.assertEqual(ret['version'], 'e')
         self.assertEqual(ret['name'], 'e')
         self.assertEqual(json.loads(ret['data']), json.loads("""
 {
@@ -703,7 +661,6 @@ class TestReleaseHistoryView(ViewTest, JSONTestMixin):
             data=dict(
                 data=data,
                 product='d',
-                version='222.0',
                 data_version=1,
             )
         )
@@ -714,8 +671,7 @@ class TestReleaseHistoryView(ViewTest, JSONTestMixin):
             data=dict(
                 data=data,
                 product='d',
-                version='333.0',
-                data_version=3,
+                data_version=2,
             )
         )
         self.assertStatusCode(ret, 200)
@@ -724,8 +680,8 @@ class TestReleaseHistoryView(ViewTest, JSONTestMixin):
         ret = self._get(url)
         self.assertEquals(ret.status_code, 200, msg=ret.data)
         data = json.loads(ret.data)
-        self.assertEquals(data["count"], 4)
-        self.assertEquals(len(data["revisions"]), 4)
+        self.assertEquals(data["count"], 2)
+        self.assertEquals(len(data["revisions"]), 2)
 
     def testPostRevisionRollback(self):
         # Make some changes to a release
@@ -735,39 +691,34 @@ class TestReleaseHistoryView(ViewTest, JSONTestMixin):
             data=dict(
                 data=data,
                 product='d',
-                version='222.0',
                 data_version=1,
             )
         )
         self.assertStatusCode(ret, 200)
 
-        # XXX why does the data_version increment twice?
         data = json.dumps(dict(detailsUrl='blah', fakePartials=False, schema_version=1))
         ret = self._post(
             '/releases/d',
             data=dict(
                 data=data,
                 product='d',
-                version='333.0',
-                data_version=3,
+                data_version=2,
             )
         )
         self.assertStatusCode(ret, 200)
 
         table = dbo.releases
         row, = table.select(where=[table.name == 'd'])
-        self.assertEqual(row['version'], '333.0')
-        self.assertEqual(row['data_version'], 5)
+        self.assertEqual(row['data_version'], 3)
         data = json.loads(row['data'])
         self.assertEqual(data['fakePartials'], False)
 
         query = table.history.t.count()
         count, = query.execute().first()
-        self.assertEqual(count, 2 * 2)
+        self.assertEqual(count, 2)
 
-        # Oh no! We prefer the version 222.0
         row, = table.history.select(
-            where=[table.history.version == '222.0'],
+            where=[table.history.product == 'd'],
             limit=1
         )
         change_id = row['change_id']
@@ -779,11 +730,10 @@ class TestReleaseHistoryView(ViewTest, JSONTestMixin):
 
         query = table.history.t.count()
         count, = query.execute().first()
-        self.assertEqual(count, 2 * 2 + 1)
+        self.assertEqual(count, 3)
 
         row, = table.select(where=[table.name == 'd'])
-        self.assertEqual(row['version'], '222.0')
-        self.assertEqual(row['data_version'], 6)
+        self.assertEqual(row['data_version'], 4)
 
     def testPostRevisionRollbackBadRequests(self):
         # when posting you need both the release name and the change_id
@@ -810,8 +760,7 @@ class TestReleaseHistoryView(ViewTest, JSONTestMixin):
             }
         }
 
-        data = {'name': 'settings', 'version': '1',
-                'product': 'settings', 'blob': json.dumps(blob)}
+        data = {'name': 'settings', 'product': 'settings', 'blob': json.dumps(blob)}
 
         ret = self._put('/releases/settings', data=data)
         self.assertEquals(ret.status_code, 201)
@@ -822,7 +771,6 @@ class TestReleaseHistoryView(ViewTest, JSONTestMixin):
         self.assertEquals(len(r), 1)
         rec = r[0]
         self.assertEquals(rec['name'], 'settings')
-        self.assertEquals(rec['version'], '1')
         self.assertEquals(rec['product'], 'settings')
         self.assertEquals(byteify(json.loads(rec['data'])),
                           json.loads(data['blob']))

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -40,7 +40,7 @@ class TestAUSThrottling(unittest.TestCase):
         dbo.setDb('sqlite:///:memory:')
         dbo.create()
         dbo.releases.t.insert().execute(
-            name='b', product='b', version='b', data_version=1,
+            name='b', product='b', data_version=1,
             data='{"name": "b", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}')
 
     def testThrottling100(self):

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -920,13 +920,13 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.db = AUSDatabase(self.dburi)
         self.db.create()
         self.releases = self.db.releases
-        self.releases.t.insert().execute(name='a', product='a', version='a', data=json.dumps(dict(name="a", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='a', product='a', data=json.dumps(dict(name="a", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
-        self.releases.t.insert().execute(name='ab', product='a', version='a', data=json.dumps(dict(name="ab", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='ab', product='a', data=json.dumps(dict(name="ab", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
-        self.releases.t.insert().execute(name='b', product='b', version='b', data=json.dumps(dict(name="b", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='b', product='b', data=json.dumps(dict(name="b", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
-        self.releases.t.insert().execute(name='c', product='c', version='c', data=json.dumps(dict(name="c", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='c', product='c', data=json.dumps(dict(name="c", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
 
     def testGetReleases(self):
@@ -936,7 +936,7 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.assertEquals(len(self.releases.getReleases(limit=1)), 1)
 
     def testGetReleasesWithWhere(self):
-        expected = [dict(product='b', version='b', name='b', data=dict(name="b", schema_version=1, hashFunction="sha512"), data_version=1)]
+        expected = [dict(product='b', name='b', data=dict(name="b", schema_version=1, hashFunction="sha512"), data_version=1)]
         self.assertEquals(self.releases.getReleases(name='b'), expected)
 
     def testGetReleaseBlob(self):
@@ -948,32 +948,27 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
 
     def testGetReleaseInfoAll(self):
         releases = self.releases.getReleaseInfo()
-        expected = [dict(name='a', product='a', version='a', data_version=1),
-                    dict(name='ab', product='a', version='a', data_version=1),
-                    dict(name='b', product='b', version='b', data_version=1),
-                    dict(name='c', product='c', version='c', data_version=1)]
+        expected = [dict(name='a', product='a', data_version=1),
+                    dict(name='ab', product='a', data_version=1),
+                    dict(name='b', product='b', data_version=1),
+                    dict(name='c', product='c', data_version=1)]
         self.assertEquals(releases, expected)
 
     def testGetReleaseInfoProduct(self):
         releases = self.releases.getReleaseInfo(product='a')
-        expected = [dict(name='a', product='a', version='a', data_version=1),
-                    dict(name='ab', product='a', version='a', data_version=1)]
-        self.assertEquals(releases, expected)
-
-    def testGetReleaseInfoVersion(self):
-        releases = self.releases.getReleaseInfo(version='b')
-        expected = [dict(name='b', product='b', version='b', data_version=1), ]
+        expected = [dict(name='a', product='a', data_version=1),
+                    dict(name='ab', product='a', data_version=1)]
         self.assertEquals(releases, expected)
 
     def testGetReleaseInfoNoMatch(self):
-        releases = self.releases.getReleaseInfo(product='a', version='b')
+        releases = self.releases.getReleaseInfo(product='ue')
         expected = []
         self.assertEquals(releases, expected)
 
     def testGetReleaseInfoNamePrefix(self):
         releases = self.releases.getReleaseInfo(name_prefix='a')
-        expected = [dict(name='a', product='a', version='a', data_version=1),
-                    dict(name='ab', product='a', version='a', data_version=1)]
+        expected = [dict(name='a', product='a', data_version=1),
+                    dict(name='ab', product='a', data_version=1)]
         self.assertEquals(releases, expected)
 
     def testGetReleaseInfoNamePrefixNameOnly(self):
@@ -995,13 +990,8 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
                     dict(name='ab')]
         self.assertEquals(releases, expected)
 
-    def testGetReleaseNamesVersion(self):
-        releases = self.releases.getReleaseNames(version='b')
-        expected = [dict(name='b'), ]
-        self.assertEquals(releases, expected)
-
     def testGetReleaseNamesNoMatch(self):
-        releases = self.releases.getReleaseNames(product='a', version='b')
+        releases = self.releases.getReleaseNames(product='oo')
         expected = []
         self.assertEquals(releases, expected)
 
@@ -1016,7 +1006,7 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
 
     def testAddReleaseWithNameMismatch(self):
         blob = ReleaseBlobV1(name="f", schema_version=1, hashFunction="sha512")
-        self.assertRaises(ValueError, self.releases.addRelease, "g", "g", "23.0", blob, "bill")
+        self.assertRaises(ValueError, self.releases.addRelease, "g", "g", blob, "bill")
 
     def testUpdateReleaseWithNameMismatch(self):
         newBlob = ReleaseBlobV1(name="c", schema_version=1, hashFunction="sha512")
@@ -1034,9 +1024,9 @@ class TestBlobCaching(unittest.TestCase, MemoryDatabaseMixin):
         self.db = AUSDatabase(self.dburi)
         self.db.create()
         self.releases = self.db.releases
-        self.releases.t.insert().execute(name='a', product='a', version='a', data=json.dumps(dict(name="a", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='a', product='a', data=json.dumps(dict(name="a", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
-        self.releases.t.insert().execute(name='b', product='b', version='b', data=json.dumps(dict(name="b", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='b', product='b', data=json.dumps(dict(name="b", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
         # When we started copying objects that go in or out of the cache we
         # discovered that Blob objects were not copyable at the time, due to
@@ -1163,7 +1153,6 @@ class TestBlobCaching(unittest.TestCase, MemoryDatabaseMixin):
             self.releases.addRelease(
                 name="abc",
                 product="bbb",
-                version="3.2",
                 blob=ReleaseBlobV1(name="abc", schema_version=1, hashFunction="sha512"),
                 changed_by="bill",
             )
@@ -1240,7 +1229,7 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
         self.db = AUSDatabase(self.dburi)
         self.db.create()
         self.releases = self.db.releases
-        self.releases.t.insert().execute(name='a', product='a', version='a', data_version=1, data="""
+        self.releases.t.insert().execute(name='a', product='a', data_version=1, data="""
 {
     "name": "a",
     "schema_version": 1,
@@ -1265,7 +1254,7 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
     }
 }
 """)
-        self.releases.t.insert().execute(name='b', product='b', version='b', data_version=1, data="""
+        self.releases.t.insert().execute(name='b', product='b', data_version=1, data="""
 {
     "name": "b",
     "hashFunction": "sha512",
@@ -1275,24 +1264,24 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
 
     def testAddRelease(self):
         blob = ReleaseBlobV1(name="d", hashFunction="sha512")
-        self.releases.addRelease(name='d', product='d', version='d', blob=blob, changed_by='bill')
-        expected = [('d', 'd', 'd', json.dumps(dict(name="d", schema_version=1, hashFunction="sha512")), 1)]
+        self.releases.addRelease(name='d', product='d', blob=blob, changed_by='bill')
+        expected = [('d', 'd', json.dumps(dict(name="d", schema_version=1, hashFunction="sha512")), 1)]
         self.assertEquals(self.releases.t.select().where(self.releases.name == 'd').execute().fetchall(), expected)
 
     def testAddReleaseAlreadyExists(self):
         blob = ReleaseBlobV1(name="a", hashFunction="sha512")
-        self.assertRaises(TransactionError, self.releases.addRelease, name='a', product='a', version='a', blob=blob, changed_by='bill')
+        self.assertRaises(TransactionError, self.releases.addRelease, name='a', product='a', blob=blob, changed_by='bill')
 
     def testUpdateRelease(self):
         blob = ReleaseBlobV1(name='a', hashFunction="sha512")
-        self.releases.updateRelease(name='a', product='z', version='y', blob=blob, changed_by='bill', old_data_version=1)
-        expected = [('a', 'z', 'y', json.dumps(dict(name='a', schema_version=1, hashFunction="sha512")), 2)]
+        self.releases.updateRelease(name='a', product='z', blob=blob, changed_by='bill', old_data_version=1)
+        expected = [('a', 'z', json.dumps(dict(name='a', schema_version=1, hashFunction="sha512")), 2)]
         self.assertEquals(self.releases.t.select().where(self.releases.name == 'a').execute().fetchall(), expected)
 
     def testUpdateReleaseWithBlob(self):
         blob = ReleaseBlobV1(name='b', schema_version=1, hashFunction="sha512")
-        self.releases.updateRelease(name='b', product='z', version='y', changed_by='bill', blob=blob, old_data_version=1)
-        expected = [('b', 'z', 'y', json.dumps(dict(name='b', schema_version=1, hashFunction="sha512")), 2)]
+        self.releases.updateRelease(name='b', product='z', changed_by='bill', blob=blob, old_data_version=1)
+        expected = [('b', 'z', json.dumps(dict(name='b', schema_version=1, hashFunction="sha512")), 2)]
         self.assertEquals(self.releases.t.select().where(self.releases.name == 'b').execute().fetchall(), expected)
 
     def testUpdateReleaseInvalidBlob(self):

--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -36,7 +36,7 @@ class ClientTest(unittest.TestCase):
         self.view = ClientRequestView()
         auslib.log.cef_config = auslib.log.get_cef_config(self.cef_file)
         dbo.rules.t.insert().execute(backgroundRate=100, mapping='b', update_type='minor', product='b', data_version=1)
-        dbo.releases.t.insert().execute(name='b', product='b', version='1.0', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='b', product='b', data_version=1, data="""
 {
     "name": "b",
     "schema_version": 1,
@@ -70,7 +70,7 @@ class ClientTest(unittest.TestCase):
 """)
         dbo.rules.t.insert().execute(backgroundRate=100, mapping='c', update_type='minor', product='c',
                                      distribution='default', data_version=1)
-        dbo.releases.t.insert().execute(name='c', product='c', version='10.0', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='c', product='c', data_version=1, data="""
 {
     "name": "c",
     "schema_version": 1,
@@ -95,7 +95,7 @@ class ClientTest(unittest.TestCase):
 }
 """)
         dbo.rules.t.insert().execute(backgroundRate=100, mapping='d', update_type='minor', product='d', data_version=1)
-        dbo.releases.t.insert().execute(name='d', product='d', version='20.0', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='d', product='d', data_version=1, data="""
 {
     "name": "d",
     "schema_version": 1,
@@ -121,7 +121,7 @@ class ClientTest(unittest.TestCase):
 """)
 
         dbo.rules.t.insert().execute(backgroundRate=100, mapping='e', update_type='minor', product='e', data_version=1)
-        dbo.releases.t.insert().execute(name='e', product='e', version='22.0', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='e', product='e', data_version=1, data="""
 {
     "name": "e",
     "schema_version": 1,
@@ -149,7 +149,7 @@ class ClientTest(unittest.TestCase):
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping='foxfood-whitelisted', update_type='minor', product='b2g',
                                      channel="foxfood", whitelist='b2g-whitelist', data_version=1)
         dbo.rules.t.insert().execute(priority=80, backgroundRate=100, mapping='foxfood-fallback', update_type='minor', product='b2g', data_version=1)
-        dbo.releases.t.insert().execute(name='b2g-whitelist', product='b2g', version='2.5', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='b2g-whitelist', product='b2g', data_version=1, data="""
 {
   "name": "b2g-whitelist",
   "schema_version": 3000,
@@ -161,7 +161,7 @@ class ClientTest(unittest.TestCase):
 }
 """)
 
-        dbo.releases.t.insert().execute(name='foxfood-whitelisted', product='b2g', version='2.5', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='foxfood-whitelisted', product='b2g', data_version=1, data="""
 {
     "name": "foxfood-whitelisted",
     "schema_version": 1,
@@ -184,7 +184,7 @@ class ClientTest(unittest.TestCase):
     }
 }
 """)
-        dbo.releases.t.insert().execute(name='foxfood-fallback', product='b2g', version='2.5', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='foxfood-fallback', product='b2g', data_version=1, data="""
 {
     "name": "foxfood-fallback",
     "schema_version": 1,

--- a/scripts/test-rules.py
+++ b/scripts/test-rules.py
@@ -42,20 +42,8 @@ def populateDB(testdir):
     for f in glob.glob('%s/*.json' % testdir):
         data = json.load(open(f, 'r'))
         product = data['name'].split('-')[0]
-        # JSON files can have the extv version at the top level, or in the locales
-        # If we can't find it at the top level, look for it in a locale. This is
-        # less accurate, but the best we can do.
-        version = data.get('appVersion', data.get('extv'))
-        if not version:
-            # Some platforms may have alias', we need to make sure to interpret it if it exists.
-            platform = data.get("platforms").values()[0]
-            if platform.get("alias"):
-                platform = data.get("platforms")[platform["alias"]]
-            version = platform.get('locales').values()[0].get('extv')
-            if not version:
-                raise Exception("Couldn't find version for %s" % data['name'])
-        dbo.engine.execute("INSERT INTO releases (name, product, version, data, data_version) VALUES ('%s', '%s', '%s','%s', 1)" %
-                           (data['name'], product, version, json.dumps(data)))
+        dbo.engine.execute("INSERT INTO releases (name, product, data, data_version) VALUES ('%s', '%s','%s', 1)" %
+                           (data['name'], product, json.dumps(data)))
     # TODO - create a proper importer that walks the snippet store to find hashes ?
 
 
@@ -214,10 +202,9 @@ if __name__ == "__main__":
             log.info("-" * 50)
 
         if options.dumpreleases:
-            log.info("Releases are \n(name, product, version, data):")
+            log.info("Releases are \n(name, product, data):")
             for release in dbo.releases.getReleases():
                 log.info("(%s, %s, %s, %s " % (release['name'], release['product'],
-                                               release['version'],
                                                json.dumps(release['data'], indent=2)))
             log.info("-" * 50)
 


### PR DESCRIPTION
I also improved the UI in a couple of places:
1) Use "Product: foo" in the main product display, rather than just showing the bolded product.
2) Title the "View Data" modal with release name rather than product name.