### PR TITLE
Bug 1113111 - tracebacks when a platform exists in a blob but has no …

### DIFF
--- a/auslib/blobs/apprelease.py
+++ b/auslib/blobs/apprelease.py
@@ -58,12 +58,16 @@ class ReleaseBlobBase(Blob):
 
     def getBuildID(self, platform, locale):
         platform = self.getResolvedPlatform(platform)
-	if locale not in self['platforms'].get(platform, {}) \
+        if locale not in self['platforms'].get(platform, {}) \
                                           .get('locales', {}):
             raise BadDataError("No such locale '%s' in platform '%s'" % (locale, platform))
         try:
             return self['platforms'][platform]['locales'][locale]['buildID']
         except KeyError:
+            if platform not in self['platforms']:
+                raise BadDataError("No such platform '%s'" % (platform))
+            if 'buildID' not in self['platforms'][platform].keys():
+                raise BadDataError("No buildID for platform '%s'" % (platform))
             return self['platforms'][platform]['buildID']
 
     def _getFromRelease(self, patch):

--- a/auslib/blobs/apprelease.py
+++ b/auslib/blobs/apprelease.py
@@ -58,7 +58,8 @@ class ReleaseBlobBase(Blob):
 
     def getBuildID(self, platform, locale):
         platform = self.getResolvedPlatform(platform)
-        if locale not in self['platforms'][platform]['locales']:
+	if locale not in self['platforms'].get(platform, {}) \
+                                          .get('locales', {}):
             raise BadDataError("No such locale '%s' in platform '%s'" % (locale, platform))
         try:
             return self['platforms'][platform]['locales'][locale]['buildID']

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -73,6 +73,16 @@ class TestReleaseBlobBase(unittest.TestCase):
         blob = SimpleBlob(platforms=dict(c=dict(locales=dict(d=dict(buildID=9)))))
         self.assertRaises(BadDataError, blob.getBuildID, 'c', 'a')
 
+    def testGetBuildIDMissingPlatform(self):
+        blob = SimpleBlob(platforms=dict())
+
+        self.assertRaises(BadDataError, blob.getBuildID, 'c', 'a')
+
+    def testGetBuildIDMissingLocalesFieldInPlatform(self):
+        blob = SimpleBlob(platforms=dict(c=dict()))
+
+        self.assertRaises(BadDataError, blob.getBuildID, 'c', 'a')
+
     def testGetBuildIDMissingLocaleBuildIDAtPlatform(self):
         blob = SimpleBlob(platforms=dict(c=dict(buildID=9, locales=dict(d=dict()))))
         self.assertRaises(BadDataError, blob.getBuildID, 'c', 'a')

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -75,12 +75,18 @@ class TestReleaseBlobBase(unittest.TestCase):
 
     def testGetBuildIDMissingPlatform(self):
         blob = SimpleBlob(platforms=dict())
-
         self.assertRaises(BadDataError, blob.getBuildID, 'c', 'a')
 
     def testGetBuildIDMissingLocalesFieldInPlatform(self):
         blob = SimpleBlob(platforms=dict(c=dict()))
+        self.assertRaises(BadDataError, blob.getBuildID, 'c', 'a')
 
+    def testGetBuildIDMissingPlatformWithNoLocale(self):
+        blob = SimpleBlob(platforms=dict())
+        self.assertRaises(BadDataError, blob.getBuildID, 'c', None)
+
+    def testGetBuildIDMissingBuildIDAtPlatformAndLocale(self):
+        blob = SimpleBlob(platforms=dict(c=dict(locales=dict(d=dict()))))
         self.assertRaises(BadDataError, blob.getBuildID, 'c', 'a')
 
     def testGetBuildIDMissingLocaleBuildIDAtPlatform(self):


### PR DESCRIPTION
Changed `dict[key]` access to `dict.get(key, default)`.