### PR TITLE
Bug 1127875 - add ability to mark releases as read only

### DIFF
--- a/auslib/admin/base.py
+++ b/auslib/admin/base.py
@@ -13,7 +13,7 @@ from auslib.admin.views.permissions import UsersView, PermissionsView, \
     SpecificPermissionView
 from auslib.admin.views.releases import SingleLocaleView, \
     SingleReleaseView, ReleaseHistoryView, \
-    ReleasesAPIView
+    ReleasesAPIView, ReleaseReadOnlyView
 from auslib.admin.views.rules import RulesAPIView, \
     SingleRuleView, RuleHistoryAPIView
 from auslib.admin.views.history import DiffView, FieldView
@@ -55,6 +55,7 @@ app.add_url_rule("/rules/<id_or_alias>", view_func=SingleRuleView.as_view("rule"
 app.add_url_rule("/rules/<int:rule_id>/revisions", view_func=RuleHistoryAPIView.as_view("rules_revisions"))
 app.add_url_rule("/releases", view_func=ReleasesAPIView.as_view("releases"))
 app.add_url_rule("/releases/<release>", view_func=SingleReleaseView.as_view("single_release"))
+app.add_url_rule("/releases/<release>/read_only", view_func=ReleaseReadOnlyView.as_view("read_only"))
 app.add_url_rule("/releases/<release>/builds/<platform>/<locale>", view_func=SingleLocaleView.as_view("single_locale"))
 app.add_url_rule("/releases/<release>/revisions", view_func=ReleaseHistoryView.as_view("release_revisions"))
 app.add_url_rule("/history/diff/<type_>/<change_id>/<field>", view_func=DiffView.as_view("diff"))

--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -1,7 +1,7 @@
 import simplejson as json
 
 from flask_wtf import Form
-from wtforms import StringField, IntegerField, SelectField
+from wtforms import StringField, IntegerField, SelectField, BooleanField
 from wtforms.widgets import TextInput, FileInput, HiddenInput
 from wtforms.validators import Required, Optional, NumberRange, Length, Regexp
 
@@ -147,4 +147,11 @@ class CompleteReleaseForm(Form):
     name = StringField('Name', validators=[Required()])
     product = StringField('Product', validators=[Required()])
     blob = JSONStringField('Data', validators=[Required()], widget=FileInput())
+    data_version = IntegerField('data_version', widget=HiddenInput())
+
+
+class ReadOnlyForm(Form):
+    name = StringField('Name', validators=[Required()])
+    product = StringField('Product', validators=[Required()])
+    read_only = BooleanField('Read Only', validators=[Required()])
     data_version = IntegerField('data_version', widget=HiddenInput())

--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -153,5 +153,5 @@ class CompleteReleaseForm(Form):
 class ReadOnlyForm(Form):
     name = StringField('Name', validators=[Required()])
     product = StringField('Product', validators=[Required()])
-    read_only = BooleanField('Read Only', validators=[Required()])
+    read_only = BooleanField('read_only')
     data_version = IntegerField('data_version', widget=HiddenInput())

--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -152,6 +152,5 @@ class CompleteReleaseForm(Form):
 
 class ReadOnlyForm(Form):
     name = StringField('Name', validators=[Required()])
-    product = StringField('Product', validators=[Required()])
     read_only = BooleanField('read_only')
     data_version = IntegerField('data_version', widget=HiddenInput())

--- a/auslib/admin/views/releases.py
+++ b/auslib/admin/views/releases.py
@@ -6,13 +6,13 @@ from flask import Response, jsonify, make_response, request
 
 from auslib.global_state import dbo
 from auslib.blobs.base import createBlob, BlobValidationError
-from auslib.db import OutdatedDataError
+from auslib.db import OutdatedDataError, ReadOnlyError
 from auslib.log import cef_event, CEF_WARN, CEF_ALERT
 from auslib.admin.views.base import (
     requirelogin, requirepermission, AdminView, HistoryAdminView
 )
 from auslib.admin.views.csrf import get_csrf_headers
-from auslib.admin.views.forms import PartialReleaseForm, CompleteReleaseForm, DbEditableForm
+from auslib.admin.views.forms import PartialReleaseForm, CompleteReleaseForm, DbEditableForm, ReadOnlyForm
 
 __all__ = ["SingleReleaseView", "SingleLocaleView"]
 
@@ -152,6 +152,10 @@ def changeRelease(release, changed_by, transaction, existsCallback, commitCallba
             msg = "Couldn't update release: %s" % e
             cef_event("Bad input", CEF_WARN, errors=msg, release=rel)
             return Response(status=400, response=json.dumps({"data": e.errors}))
+        except ReadOnlyError as e:
+            msg = "Couldn't update release: %s" % e
+            cef_event("Bad input", CEF_WARN, errors=msg, release=rel)
+            return Response(status=403, response=json.dumps({"data": e.args}))
         except (ValueError, OutdatedDataError) as e:
             msg = "Couldn't update release: %s" % e
             cef_event("Bad input", CEF_WARN, errors=msg, release=rel)
@@ -237,6 +241,10 @@ class SingleReleaseView(AdminView):
                 msg = "Couldn't update release: %s" % e
                 cef_event("Bad input", CEF_WARN, errors=msg)
                 return Response(status=400, response=json.dumps({"data": e.errors}))
+            except ReadOnlyError as e:
+                msg = "Couldn't update release: %s" % e
+                cef_event("Bad input", CEF_WARN, errors=msg)
+                return Response(status=403, response=json.dumps({"data": e.args}))
             except ValueError as e:
                 msg = "Couldn't update release: %s" % e
                 cef_event("Bad input", CEF_WARN, errors=msg)
@@ -297,8 +305,13 @@ class SingleReleaseView(AdminView):
             cef_event("Bad input", CEF_WARN, errors=form.errors)
             return Response(status=400, response=json.dumps(form.errors))
 
-        dbo.releases.deleteRelease(changed_by=changed_by, name=release['name'],
-                                   old_data_version=form.data_version.data, transaction=transaction)
+        try:
+            dbo.releases.deleteRelease(changed_by=changed_by, name=release['name'],
+                                       old_data_version=form.data_version.data, transaction=transaction)
+        except ReadOnlyError as e:
+                msg = "Couldn't update release: %s" % e
+                cef_event("Bad input", CEF_WARN, errors=msg)
+                return Response(status=403, response=json.dumps({"data": e.args}))
 
         return Response(status=200)
 
@@ -307,12 +320,12 @@ class ReleaseReadOnlyView(AdminView):
     """/releases/:release/read_only"""
 
     def get(self, release):
-        releases = dbo.releases.getReleases(name=release, limit=1)
-        is_release_read_only = dbo.releases.isReadOnly(name=release, limit=1)
-        if not releases:
+        try:
+            is_release_read_only = dbo.releases.isReadOnly(name=release, limit=1)
+        except:
             return Response(status=404,
                             response='Requested release does not exist')
-        release = releases[0]
+
         return jsonify({
             'read_only': is_release_read_only
         })
@@ -320,19 +333,21 @@ class ReleaseReadOnlyView(AdminView):
     @requirelogin
     @requirepermission('/releases/:name/read_only')
     def _put(self, release, changed_by, transaction):
-        req_read_only = request.form.get('read_only')
+        form = ReadOnlyForm()
         is_release_read_only = dbo.releases.isReadOnly(release)
-        old_data_version = request.form.get('data_version')
 
-        if req_read_only and not is_release_read_only:
-            dbo.releases.changeReadOnly(name=release, read_only=True, changed_by=changed_by, old_data_version=old_data_version, transaction=transaction)
-        elif not req_read_only and is_release_read_only:
-            # Only an admin user can unset the read_only field once it's set to True
-            if dbo.permissions.hasUrlPermission(changed_by, 'admin'):
-                dbo.releases.changeReadOnly(name=release, read_only=False, changed_by=changed_by, transaction=transaction)
-            else:
-                msg = "%s is not allowed to set releases as read-write" % changed_by
-                cef_event("Unauthorized attempt to mark release as read-write", CEF_ALERT, msg=msg)
+        if form.read_only:
+            if not is_release_read_only:
+                dbo.releases.updateRelease(release, read_only=True, changed_by=changed_by, old_data_version=form.data_version, transaction=transaction)
+        else:
+            if is_release_read_only:
+                # Only an admin user can unset the read_only field once it's set to True
+                if dbo.permissions.hasUrlPermission(changed_by, 'admin'):
+                    dbo.releases.updateRelease(release, read_only=False, changed_by=changed_by, old_data_version=form.data_version, transaction=transaction)
+                else:
+                    msg = "%s is not allowed to set releases as read-write" % changed_by
+                    cef_event("Unauthorized attempt to mark release as read-write", CEF_ALERT, msg=msg)
+                    return Response(status=403, response=msg)
         return Response(status=201, response='read_only changed')
 
 
@@ -442,6 +457,7 @@ class ReleasesAPIView(AdminView):
                 'name': 'name',
                 'product': 'product',
                 'data_version': 'data_version',
+                'read_only': 'read_only'
             }
             for release in releases:
                 _releases.append(dict(

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -7,7 +7,7 @@ import sys
 import time
 
 from sqlalchemy import Table, Column, Integer, Text, String, MetaData, \
-    create_engine, select, BigInteger
+    create_engine, select, BigInteger, Boolean
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql.expression import null
 
@@ -58,6 +58,10 @@ class OutdatedDataError(SQLAlchemyError):
 
 class WrongNumberOfRowsError(SQLAlchemyError):
     """Raised when an update or delete fails because the clause matches more than one row."""
+
+
+class ReadOnlyError(SQLAlchemyError):
+    """Raised when a release marked as read-only is attempted to be changed."""
 
 
 class AUSTransaction(object):
@@ -863,6 +867,7 @@ class Releases(AUSTable):
         self.table = Table('releases', metadata,
                            Column('name', String(100), primary_key=True),
                            Column('product', String(15), nullable=False),
+                           Column('read_only', Boolean, default=False),
                            )
         if dialect == 'mysql':
             from sqlalchemy.dialects.mysql import LONGTEXT
@@ -1013,6 +1018,7 @@ class Releases(AUSTable):
         return ret.inserted_primary_key[0]
 
     def updateRelease(self, name, changed_by, old_data_version, product=None, blob=None, transaction=None):
+        self._proceedIfNotReadOnly(name, transaction=transaction)
         what = {}
         if product:
             what['product'] = product
@@ -1037,6 +1043,7 @@ class Releases(AUSTable):
            validated before commiting it, and a ValueError is raised if it is
            invalid.
         """
+        self._proceedIfNotReadOnly(name, transaction=transaction)
         releaseBlob = self.getReleaseBlob(name, transaction=transaction)
         if 'platforms' not in releaseBlob:
             releaseBlob['platforms'] = {}
@@ -1087,10 +1094,26 @@ class Releases(AUSTable):
             return False
 
     def deleteRelease(self, changed_by, name, old_data_version, transaction=None):
+        self._proceedIfNotReadOnly(name, transaction=transaction)
         where = [self.name == name]
         self.delete(changed_by=changed_by, where=where, old_data_version=old_data_version, transaction=transaction)
         cache.invalidate("blob", name)
         cache.invalidate("blob_version", name)
+
+    def isReadOnly(self, name, limit=None, transaction=None):
+        where = [self.name == name]
+        column = [self.read_only]
+        row = self.select(where=where, columns=column, limit=limit, transaction=transaction)[0]
+        return row['read_only']
+
+    def _proceedIfNotReadOnly(self, name, limit=None, transaction=None):
+        if self.isReadOnly(name, limit, transaction):
+            raise ReadOnlyError("Release '%s' is read only" % name)
+
+    def changeReadOnly(self, name, read_only, changed_by, old_data_version=None, transaction=None):
+        where = [self.name == name]
+        what = dict(read_only=read_only)
+        self.update(where=where, what=what, changed_by=changed_by, old_data_version=old_data_version, transaction=transaction)
 
 
 class Permissions(AUSTable):
@@ -1108,6 +1131,7 @@ class Permissions(AUSTable):
         '/releases/:name': ['method', 'product'],
         '/releases/:name/revisions': ['product'],
         '/releases/:name/builds/:platform/:locale': ['method', 'product'],
+        '/releases/:name/read_only': ['product'],
         '/rules': ['method', 'product'],
         '/rules/:id': ['method', 'product'],
         '/rules/:id/revisions': ['product'],

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1021,9 +1021,8 @@ class Releases(AUSTable):
         if product or blob:
             self._proceedIfNotReadOnly(name, transaction=transaction)
         what = {}
-        if read_only:
+        if read_only is not None:
             what['read_only'] = read_only
-            import pdb; pdb.set_trace()
         if product:
             what['product'] = product
         if blob:

--- a/auslib/migrate/versions/011_add_read_only_releases.py
+++ b/auslib/migrate/versions/011_add_read_only_releases.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, Boolean, MetaData, Table
+
+
+def upgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+
+    releases = Table('releases', metadata, autoload=True)
+    releases_history = Table('releases_history', metadata, autoload=True)
+
+    read_only = Column('read_only', Boolean)
+    read_only.create(releases)
+
+    history_read_only = Column('read_only', Boolean)
+    history_read_only.create(releases_history)
+
+
+def downgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+
+    releases = Table('releases', metadata, autoload=True)
+    releases_history = Table('releases', metadata, autoload=True)
+
+    releases.c.read_only.drop()
+    releases_history.c.read_only.drop()

--- a/auslib/migrate/versions/011_add_read_only_releases.py
+++ b/auslib/migrate/versions/011_add_read_only_releases.py
@@ -8,10 +8,10 @@ def upgrade(migrate_engine):
     releases_history = Table('releases_history', metadata, autoload=True)
 
     read_only = Column('read_only', Boolean)
-    read_only.create(releases)
+    read_only.create(releases, default=False)
 
     history_read_only = Column('read_only', Boolean)
-    history_read_only.create(releases_history)
+    history_read_only.create(releases_history, default=False)
 
 
 def downgrade(migrate_engine):

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -27,6 +27,7 @@ class ViewTest(unittest.TestCase):
         dbo.permissions.t.insert().execute(permission='admin', username='bill', data_version=1)
         dbo.permissions.t.insert().execute(permission='/users/:id/permissions/:permission', username='bob', data_version=1)
         dbo.permissions.t.insert().execute(permission='/releases/:name', username='bob', options=json.dumps(dict(product=['fake'])), data_version=1)
+        dbo.permissions.t.insert().execute(permission='/releases/:name/read_only', username='bob', options=json.dumps(dict(method='PUT')), data_version=1)
         dbo.permissions.t.insert().execute(permission='/rules/:id', username='bob', options=json.dumps(dict(product=['fake'])), data_version=1)
         dbo.releases.t.insert().execute(
             name='a', product='a', data=json.dumps(dict(name='a', hashFunction="sha512", schema_version=1)), data_version=1)

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -966,16 +966,16 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
 
     def testGetReleaseInfoAll(self):
         releases = self.releases.getReleaseInfo()
-        expected = [dict(name='a', product='a', data_version=1),
-                    dict(name='ab', product='a', data_version=1),
-                    dict(name='b', product='b', data_version=1),
-                    dict(name='c', product='c', data_version=1)]
+        expected = [dict(name='a', product='a', data_version=1, read_only=False),
+                    dict(name='ab', product='a', data_version=1, read_only=False),
+                    dict(name='b', product='b', data_version=1, read_only=False),
+                    dict(name='c', product='c', data_version=1, read_only=False)]
         self.assertEquals(releases, expected)
 
     def testGetReleaseInfoProduct(self):
         releases = self.releases.getReleaseInfo(product='a')
-        expected = [dict(name='a', product='a', data_version=1),
-                    dict(name='ab', product='a', data_version=1)]
+        expected = [dict(name='a', product='a', data_version=1, read_only=False),
+                    dict(name='ab', product='a', data_version=1, read_only=False)]
         self.assertEquals(releases, expected)
 
     def testGetReleaseInfoNoMatch(self):
@@ -985,8 +985,8 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
 
     def testGetReleaseInfoNamePrefix(self):
         releases = self.releases.getReleaseInfo(name_prefix='a')
-        expected = [dict(name='a', product='a', data_version=1),
-                    dict(name='ab', product='a', data_version=1)]
+        expected = [dict(name='a', product='a', data_version=1, read_only=False),
+                    dict(name='ab', product='a', data_version=1, read_only=False)]
         self.assertEquals(releases, expected)
 
     def testGetReleaseInfoNamePrefixNameOnly(self):
@@ -1023,7 +1023,7 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.assertEquals(release, [])
 
     def testDeleteReleaseWhenReadOnly(self):
-        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+        self.releases.updateRelease('a', read_only=True, changed_by='me', old_data_version=1)
         self.assertRaises(ReadOnlyError, self.releases.deleteRelease, changed_by='me', name='a', old_data_version=2)
 
     def testAddReleaseWithNameMismatch(self):
@@ -1034,16 +1034,16 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         newBlob = ReleaseBlobV1(name="c", schema_version=1, hashFunction="sha512")
         self.assertRaises(ValueError, self.releases.updateRelease, "a", "bill", 1, blob=newBlob)
 
-    def testChangeReadOnly(self):
-        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+    def testUpdateReleaseChangeReadOnly(self):
+        self.releases.updateRelease('a', read_only=True, changed_by='me', old_data_version=1)
         self.assertEqual(select([self.releases.read_only]).where(self.releases.name == 'a').execute().fetchone()[0], True)
 
     def testIsReadOnly(self):
-        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+        self.releases.updateRelease('a', read_only=True, changed_by='me', old_data_version=1)
         self.assertEqual(self.releases.isReadOnly('a'), True)
 
     def testProceedIfNotReadOnly(self):
-        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+        self.releases.updateRelease('a', read_only=True, changed_by='me', old_data_version=1)
         self.assertRaises(ReadOnlyError, self.releases._proceedIfNotReadOnly, 'a')
 
 
@@ -1315,7 +1315,7 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
     def testUpdateReleaseWhenReadOnly(self):
         blob = ReleaseBlobV1(name='a', hashFunction="sha512")
         # set release 'a' to read-only
-        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+        self.releases.updateRelease('a', read_only=True, changed_by='me', old_data_version=1)
         self.assertRaises(ReadOnlyError, self.releases.updateRelease, name='a', product='z', blob=blob, changed_by='me', old_data_version=2)
 
     def testUpdateReleaseWithBlob(self):
@@ -1635,7 +1635,7 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                 "hashValue": "abc",
             }
         }
-        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+        self.releases.updateRelease('a', read_only=True, changed_by='me', old_data_version=1)
         self.assertRaises(ReadOnlyError, self.releases.addLocaleToRelease, name='a', platform='p', locale='c', data=data, old_data_version=1, changed_by='bill')
 
 

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -14,7 +14,7 @@ import migrate.versioning.api
 
 from auslib.global_state import cache
 from auslib.db import AUSDatabase, AUSTable, AlreadySetupError, \
-    AUSTransaction, TransactionError, OutdatedDataError
+    AUSTransaction, TransactionError, OutdatedDataError, ReadOnlyError
 from auslib.blobs.base import BlobValidationError
 from auslib.blobs.apprelease import ReleaseBlobV1
 
@@ -1022,6 +1022,10 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         release = self.releases.t.select().where(self.releases.name == 'a').execute().fetchall()
         self.assertEquals(release, [])
 
+    def testDeleteReleaseWhenReadOnly(self):
+        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+        self.assertRaises(ReadOnlyError, self.releases.deleteRelease, changed_by='me', name='a', old_data_version=2)
+
     def testAddReleaseWithNameMismatch(self):
         blob = ReleaseBlobV1(name="f", schema_version=1, hashFunction="sha512")
         self.assertRaises(ValueError, self.releases.addRelease, "g", "g", blob, "bill")
@@ -1029,6 +1033,18 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
     def testUpdateReleaseWithNameMismatch(self):
         newBlob = ReleaseBlobV1(name="c", schema_version=1, hashFunction="sha512")
         self.assertRaises(ValueError, self.releases.updateRelease, "a", "bill", 1, blob=newBlob)
+
+    def testChangeReadOnly(self):
+        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+        self.assertEqual(select([self.releases.read_only]).where(self.releases.name == 'a').execute().fetchone()[0], True)
+
+    def testIsReadOnly(self):
+        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+        self.assertEqual(self.releases.isReadOnly('a'), True)
+
+    def testProceedIfNotReadOnly(self):
+        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+        self.assertRaises(ReadOnlyError, self.releases._proceedIfNotReadOnly, 'a')
 
 
 class TestBlobCaching(unittest.TestCase, MemoryDatabaseMixin):
@@ -1283,7 +1299,7 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
     def testAddRelease(self):
         blob = ReleaseBlobV1(name="d", hashFunction="sha512")
         self.releases.addRelease(name='d', product='d', blob=blob, changed_by='bill')
-        expected = [('d', 'd', json.dumps(dict(name="d", schema_version=1, hashFunction="sha512")), 1)]
+        expected = [('d', 'd', False, json.dumps(dict(name="d", schema_version=1, hashFunction="sha512")), 1)]
         self.assertEquals(self.releases.t.select().where(self.releases.name == 'd').execute().fetchall(), expected)
 
     def testAddReleaseAlreadyExists(self):
@@ -1293,13 +1309,19 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
     def testUpdateRelease(self):
         blob = ReleaseBlobV1(name='a', hashFunction="sha512")
         self.releases.updateRelease(name='a', product='z', blob=blob, changed_by='bill', old_data_version=1)
-        expected = [('a', 'z', json.dumps(dict(name='a', schema_version=1, hashFunction="sha512")), 2)]
+        expected = [('a', 'z', False, json.dumps(dict(name='a', schema_version=1, hashFunction="sha512")), 2)]
         self.assertEquals(self.releases.t.select().where(self.releases.name == 'a').execute().fetchall(), expected)
+
+    def testUpdateReleaseWhenReadOnly(self):
+        blob = ReleaseBlobV1(name='a', hashFunction="sha512")
+        # set release 'a' to read-only
+        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+        self.assertRaises(ReadOnlyError, self.releases.updateRelease, name='a', product='z', blob=blob, changed_by='me', old_data_version=2)
 
     def testUpdateReleaseWithBlob(self):
         blob = ReleaseBlobV1(name='b', schema_version=1, hashFunction="sha512")
         self.releases.updateRelease(name='b', product='z', changed_by='bill', blob=blob, old_data_version=1)
-        expected = [('b', 'z', json.dumps(dict(name='b', schema_version=1, hashFunction="sha512")), 2)]
+        expected = [('b', 'z', False, json.dumps(dict(name='b', schema_version=1, hashFunction="sha512")), 2)]
         self.assertEquals(self.releases.t.select().where(self.releases.name == 'b').execute().fetchall(), expected)
 
     def testUpdateReleaseInvalidBlob(self):
@@ -1604,6 +1626,17 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
 }
 """)
         self.assertEqual(ret, expected)
+
+    def testAddLocaleWhenReadOnly(self):
+        data = {
+            "complete": {
+                "filesize": 1,
+                "from": "*",
+                "hashValue": "abc",
+            }
+        }
+        self.releases.changeReadOnly('a', True, changed_by='me', old_data_version=1)
+        self.assertRaises(ReadOnlyError, self.releases.addLocaleToRelease, name='a', platform='p', locale='c', data=data, old_data_version=1, changed_by='bill')
 
 
 class TestPermissions(unittest.TestCase, MemoryDatabaseMixin):


### PR DESCRIPTION
Defined a new endpoint and permission `/releases/:name/read_only`, and added column `read_only` to the releases table.

Releases can be marked as read only by anyone with the `/releases/:name/read_only` permission, but can be set to read write again only by an admin account.