### PR TITLE
Implement Mozlog and remove CEF logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,11 @@ RUN pip install -r requirements.txt
 # copy in sources after
 # Copying Balrog to /app instead of installing it means that production can run
 # it, and we can bind mount to override it for local development.
-COPY auslib setup.py ui uwsgi version.json /app/
+COPY auslib/ /app/auslib/
+COPY ui/ /app/ui/
+COPY uwsgi/ /app/uwsgi/
+COPY scripts/ /app/scripts/
+COPY setup.py version.json /app/
 
 ENTRYPOINT ["/app/uwsgi/run.sh"]
 CMD ["public"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,7 +20,11 @@ RUN pip install -r requirements.txt
 # copy in sources after
 # Copying Balrog to /app instead of installing it means that production can run
 # it, and we can bind mount to override it for local development.
-COPY auslib setup.py ui uwsgi version.json /app/
+COPY auslib/ /app/auslib/
+COPY ui/ /app/ui/
+COPY uwsgi/ /app/uwsgi/
+COPY scripts/ /app/scripts/
+COPY setup.py version.json /app/
 
 ENTRYPOINT ["/app/uwsgi/run.sh"]
 CMD ["public"]

--- a/admin.wsgi
+++ b/admin.wsgi
@@ -32,7 +32,6 @@ cache.make_copies = True
 for cache_name, cache_cfg in cfg.getCaches().iteritems():
     cache.make_cache(cache_name, *cache_cfg)
 
-auslib.log.cef_config = auslib.log.get_cef_config(cfg.getCefLogfile())
 dbo.setDb(cfg.getDburi())
 dbo.setupChangeMonitors(cfg.getSystemAccounts())
 dbo.setDomainWhitelist(cfg.getDomainWhitelist())

--- a/auslib/AUS.py
+++ b/auslib/AUS.py
@@ -4,7 +4,6 @@ from urlparse import urlparse
 import logging
 
 from auslib.global_state import dbo
-from auslib.log import cef_event, CEF_ALERT
 
 
 def isSpecialURL(url, specialForceHosts):
@@ -19,7 +18,7 @@ def isSpecialURL(url, specialForceHosts):
 def isForbiddenUrl(url, whitelistedDomains):
     domain = urlparse(url)[1]
     if domain not in whitelistedDomains:
-        cef_event("Forbidden domain", CEF_ALERT, domain=domain)
+        logging.warning("Forbidden domain: %s", domain)
         return True
     return False
 

--- a/auslib/admin/views/history.py
+++ b/auslib/admin/views/history.py
@@ -7,7 +7,6 @@ from flask import Response
 
 from auslib.global_state import dbo
 from auslib.admin.views.base import AdminView
-from auslib.log import cef_event, CEF_WARN
 
 
 class FieldView(AdminView):
@@ -46,7 +45,7 @@ class FieldView(AdminView):
         try:
             value = self.get_value(type_, change_id, field)
         except KeyError as msg:
-            cef_event("Bad input", CEF_WARN, errors=str(msg), field=field)
+            self.log.warning("Bad input: %s", field)
             return Response(status=400, response=str(msg))
         except ValueError as msg:
             return Response(status=404, response=str(msg))

--- a/auslib/admin/views/rules.py
+++ b/auslib/admin/views/rules.py
@@ -10,7 +10,6 @@ from auslib.admin.views.base import (
 )
 from auslib.admin.views.csrf import get_csrf_headers
 from auslib.admin.views.forms import EditRuleForm, RuleForm, DbEditableForm
-from auslib.log import cef_event, CEF_WARN, CEF_ALERT
 
 
 class RulesAPIView(AdminView):
@@ -43,7 +42,7 @@ class RulesAPIView(AdminView):
         form.mapping.choices.insert(0, ('', 'NULL'))
 
         if not form.validate():
-            cef_event("Bad input", CEF_WARN, errors=form.errors)
+            self.log.warning("Bad input: %s", form.errors)
             return Response(status=400, response=json.dumps(form.errors))
 
         what = dict(backgroundRate=form.backgroundRate.data,
@@ -99,7 +98,7 @@ class SingleRuleView(AdminView):
         for product in toCheck:
             if not dbo.permissions.hasUrlPermission(changed_by, '/rules/:id', 'POST', urlOptions={'product': product}):
                 msg = "%s is not allowed to alter rules that affect %s" % (changed_by, product)
-                cef_event('Unauthorized access attempt', CEF_ALERT, msg=msg)
+                self.log.warning("Unauthorized access attempt: %s", msg)
                 return Response(status=401, response=msg)
         releaseNames = dbo.releases.getReleaseNames()
 
@@ -107,7 +106,7 @@ class SingleRuleView(AdminView):
         form.mapping.choices.insert(0, ('', 'NULL'))
 
         if not form.validate():
-            cef_event("Bad input", CEF_WARN, errors=form.errors)
+            self.log.warning("Bad input: %s", form.errors)
             return Response(status=400, response=json.dumps(form.errors))
 
         what = dict()
@@ -159,7 +158,7 @@ class SingleRuleView(AdminView):
 
         if not dbo.permissions.hasUrlPermission(changed_by, '/rules/:id', 'DELETE', urlOptions={'product': rule['product']}):
             msg = "%s is not allowed to alter rules that affect %s" % (changed_by, rule['product'])
-            cef_event('Unauthorized access attempt', CEF_ALERT, msg=msg)
+            self.log.warning("Unauthorized access_attempt: %s", msg)
             return Response(status=401, response=msg)
 
         dbo.rules.deleteRule(changed_by=changed_by, id_or_alias=id_or_alias,
@@ -184,7 +183,7 @@ class RuleHistoryAPIView(HistoryAdminView):
             limit = int(request.args.get('limit', 100))
             assert page >= 1
         except (ValueError, AssertionError) as msg:
-            cef_event("Bad input", CEF_WARN, errors=msg)
+            self.log.warning("Bad input: %s", msg)
             return Response(status=400, response=str(msg))
         offset = limit * (page - 1)
         total_count = table.t.count()\
@@ -245,7 +244,7 @@ class RuleHistoryAPIView(HistoryAdminView):
         if request.json:
             change_id = request.json.get('change_id')
         if not change_id:
-            cef_event("Bad input", CEF_WARN, errors="no change_id")
+            self.log.warning("Bad input: %s", "no change_id")
             return Response(status=400, response='no change_id')
         change = dbo.rules.history.getChange(change_id=change_id)
         if change is None:
@@ -259,7 +258,7 @@ class RuleHistoryAPIView(HistoryAdminView):
         for product in (rule['product'], change['product']):
             if not dbo.permissions.hasUrlPermission(changed_by, '/rules/:id', 'POST', urlOptions={'product': product}):
                 msg = "%s is not allowed to alter rules that affect %s" % (changed_by, product)
-                cef_event('Unauthorized access attempt', CEF_ALERT, msg=msg)
+                self.log.warning("Unauthorized access attempt: %s", msg)
                 return Response(status=401, response=msg)
         old_data_version = rule['data_version']
 

--- a/auslib/config.py
+++ b/auslib/config.py
@@ -46,12 +46,6 @@ class AUSConfig(object):
     def getDburi(self):
         return self.cfg.get('database', 'dburi')
 
-    def getCefLogfile(self):
-        if self.cfg.has_option('logging', 'cef_logfile'):
-            return self.cfg.get('logging', 'cef_logfile')
-        else:
-            return "cef.log"
-
     def getDomainWhitelist(self):
         try:
             return tuple(a.strip() for a in self.cfg.get('site-specific', 'domain_whitelist').split(','))

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -17,7 +17,6 @@ import migrate.versioning.api
 from auslib.global_state import cache, dbo
 from auslib.AUS import isForbiddenUrl
 from auslib.blobs.base import createBlob
-from auslib.log import cef_event, CEF_ALERT
 from auslib.util.comparison import string_compare, version_compare
 
 import logging
@@ -1253,20 +1252,22 @@ class Permissions(AUSTable):
         return True
 
 
+# TODO: replace these with e-mails about rules/permissions changes?
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1251338
 def getHumanModificationMonitors(systemAccounts):
     # Long lines from "what" get truncated to avoid printing out massive
     # release blobs ty the logs.
     def onInsert(table, who, what):
         if who not in systemAccounts:
-            cef_event('Human modification', CEF_ALERT, user=who, what=what, table=table.name, type='insert')
+            pass
 
     def onDelete(table, who, where):
         if who not in systemAccounts:
-            cef_event('Human modification', CEF_ALERT, user=who, where=where, table=table.name, type='delete')
+            pass
 
     def onUpdate(table, who, where, what):
         if who not in systemAccounts:
-            cef_event('Human modification', CEF_ALERT, user=who, what=what, where=where, table=table.name, type='update')
+            pass
     return onInsert, onDelete, onUpdate
 
 

--- a/auslib/log.py
+++ b/auslib/log.py
@@ -1,16 +1,17 @@
-from logging import Logger
+import logging
+
+import json
+import socket
+import sys
+import traceback
 
 from flask import request
 
-import cef
 
 log_format = "%(asctime)s - %(levelname)s - PID: %(process)s - Request: %(requestid)s - %(name)s.%(funcName)s#%(lineno)s: %(message)s"
 
-# Needs to be set by entry points.
-cef_config = {}
 
-
-class BalrogLogger(Logger):
+class BalrogLogger(logging.Logger):
 
     def makeRecord(self, name, level, fn, lno, msg, args, exc_info, func=None, extra=None):
         if extra is None:
@@ -26,42 +27,118 @@ class BalrogLogger(Logger):
                 # Request object, whose id is actually what we want.
                 # Without this we end up with the id of the proxy object, which
                 # is static for the life of the application.
+                # TODO: this doesn't seem to be 100% unique.
+                # Sometimes requests that happen around the same time will
+                # end up with the same value here. Possibly only when the
+                # query strings are the same, or srcip?
                 requestid = id(request._get_current_object())
             # RuntimeError will be raised if there's no active request.
             except RuntimeError:
                 pass
             extra['requestid'] = requestid
-        return Logger.makeRecord(self, name, level, fn, lno, msg, args, exc_info, func, extra)
+        return logging.Logger.makeRecord(self, name, level, fn, lno, msg, args, exc_info, func, extra)
 
 
-# Standard CEF levels at Mozilla. More details here:
-# https://mana.mozilla.org/wiki/display/SECURITY/CEF+Guidelines+for+Application+Development+at+Mozilla#CEFGuidelinesforApplicationDevelopmentatMozilla-apxaAppendixA-%C2%A0Severity%C2%A0IntegersSuggestions
-CEF_INFO = 4
-CEF_WARN = 6
-CEF_ALERT = 8
-CEF_EMERG = 10
+class JsonLogFormatter(logging.Formatter):
+    """Log formatter that outputs machine-readable json.
 
+    This log formatter outputs JSON format messages that are compatible with
+    Mozilla's standard heka-based log aggregation infrastructure.
 
-def cef_event(name, severity, **custom_exts):
-    # Extra values need to be in the format csNLabel=xxx, csN=yyy
-    extra_exts = {}
-    n = 2
-    for k, v in custom_exts.iteritems():
-        valueKey = 'cs%d' % n
-        labelKey = '%sLabel' % valueKey
-        extra_exts[labelKey] = k
-        extra_exts[valueKey] = v
-        n += 1
+    See also:
+    https://mana.mozilla.org/wiki/display/CLOUDSERVICES/Logging+Standard
+    https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=42895640
 
-    username = request.environ.get('REMOTE_USER', 'Unknown User')
-    cef.log_cef(name, severity, request.environ, cef_config, username=username, **extra_exts)
+    Adapted from:
+    https://github.com/mozilla-services/mozservices/blob/master/mozsvc/util.py#L106
+    """
+    LOGGING_FORMAT_VERSION = "2.0"
 
-
-def get_cef_config(logfile):
-    return {
-        'cef.file': logfile,
-        'cef.version': 0,  # This is the CEF format version
-        'cef.product': 'Balrog',
-        'cef.vendor': 'Mozilla',
-        'cef.device_version': '1.0',
+    # Map from Python logging to Syslog severity levels
+    SYSLOG_LEVEL_MAP = {
+        50: 2,  # CRITICAL
+        40: 3,  # ERROR
+        30: 4,  # WARNING
+        20: 6,  # INFO
+        10: 7,  # DEBUG
     }
+
+    # Syslog level to use when/if python level isn't found in map
+    DEFAULT_SYSLOG_LEVEL = 7
+
+    EXCLUDED_LOGRECORD_ATTRS = set((
+        'args', 'asctime', 'created', 'exc_info', 'exc_text', 'filename',
+        'funcName', 'levelname', 'levelno', 'lineno', 'module', 'msecs',
+        'message', 'msg', 'name', 'pathname', 'process', 'processName',
+        'relativeCreated', 'stack_info', 'thread', 'threadName'
+    ))
+
+    def __init__(self, fmt=None, datefmt=None, logger_name='Balrog'):
+        super(JsonLogFormatter, self).__init__(fmt, datefmt)
+        self.logger_name = logger_name
+        self.hostname = socket.gethostname()
+
+    def format(self, record):
+        """
+        Map from Python LogRecord attributes to JSON log format fields
+
+        * from - https://docs.python.org/3/library/logging.html#logrecord-attributes
+        * to - https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=42895640
+        """
+        out = dict(
+            Timestamp=int(record.created * 1e9),
+            Type=record.name,
+            Logger=self.logger_name,
+            Hostname=self.hostname,
+            EnvVersion=self.LOGGING_FORMAT_VERSION,
+            Severity=self.SYSLOG_LEVEL_MAP.get(record.levelno,
+                                               self.DEFAULT_SYSLOG_LEVEL),
+            Pid=record.process,
+        )
+
+        # Include any custom attributes set on the record.
+        # These would usually be collected metrics data.
+        fields = dict()
+        for key, value in record.__dict__.items():
+            if key not in self.EXCLUDED_LOGRECORD_ATTRS:
+                fields[key] = value
+
+        # Only include the 'message' key if it has useful content
+        # and is not already a JSON blob.
+        message = record.getMessage()
+        if message:
+            if not message.startswith("{") and not message.endswith("}"):
+                fields["message"] = message
+
+        # If there is an error, format it for nice output.
+        if record.exc_info is not None:
+            fields["error"] = repr(record.exc_info[1])
+            fields["traceback"] = safer_format_traceback(*record.exc_info)
+
+        out['Fields'] = fields
+
+        return json.dumps(out)
+
+
+def safer_format_traceback(exc_typ, exc_val, exc_tb):
+    """Format an exception traceback into safer string.
+    We don't want to let users write arbitrary data into our logfiles,
+    which could happen if they e.g. managed to trigger a ValueError with
+    a carefully-crafted payload.  This function formats the traceback
+    using "%r" for the actual exception data, which passes it through repr()
+    so that any special chars are safely escaped.
+    """
+    lines = ["Uncaught exception:\n"]
+    lines.extend(traceback.format_tb(exc_tb))
+    lines.append("%r\n" % (exc_typ,))
+    lines.append("%r\n" % (exc_val,))
+    return "".join(lines)
+
+
+def configure_logging(stream=sys.stdout, formatter=JsonLogFormatter, format_=log_format, level=logging.DEBUG):
+    logging.setLoggerClass(BalrogLogger)
+    handler = logging.StreamHandler(stream)
+    formatter = formatter(fmt=format_)
+    handler.setFormatter(formatter)
+    logging.root.addHandler(handler)
+    logging.root.setLevel(level)

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -5,7 +5,6 @@ import unittest
 
 from auslib.global_state import dbo, cache
 from auslib.admin.base import app
-import auslib.log
 
 
 class ViewTest(unittest.TestCase):
@@ -13,7 +12,6 @@ class ViewTest(unittest.TestCase):
        some helper methods."""
 
     def setUp(self):
-        self.cef_fd, self.cef_file = mkstemp()
         self.version_fd, self.version_file = mkstemp()
         cache.reset()
         cache.make_copies = True
@@ -30,7 +28,6 @@ class ViewTest(unittest.TestCase):
   "commit":"abcdef123456"
 }
 """)
-        auslib.log.cef_config = auslib.log.get_cef_config(self.cef_file)
         dbo.setDb('sqlite:///:memory:')
         dbo.setDomainWhitelist(['good.com'])
         dbo.create()
@@ -76,8 +73,6 @@ class ViewTest(unittest.TestCase):
 
     def tearDown(self):
         dbo.reset()
-        os.close(self.cef_fd)
-        os.remove(self.cef_file)
         os.close(self.version_fd)
         os.remove(self.version_file)
 

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -3,7 +3,6 @@ try:
 except ImportError:
     # so you're in python <2.7
     from ordereddict import OrderedDict
-import mock
 import unittest
 from xml.dom import minidom
 
@@ -119,35 +118,23 @@ class TestReleaseBlobV1(unittest.TestCase):
         self.assertEquals(blob.getExtv('f', 'g'), blob.getApplicationVersion('f', 'g'))
 
     def testAllowedDomain(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV1(fileUrls=dict(c="http://a.com/a"))
-            self.assertFalse(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV1(fileUrls=dict(c="http://a.com/a"))
+        self.assertFalse(dbo.releases.containsForbiddenDomain(blob))
 
     def testForbiddenDomainFileUrls(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV1(fileUrls=dict(c="http://evil.com/a"))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV1(fileUrls=dict(c="http://evil.com/a"))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
     def testForbiddenDomainInLocale(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV1(platforms=dict(f=dict(locales=dict(h=dict(partial=dict(fileUrl="http://evil.com/a"))))))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV1(platforms=dict(f=dict(locales=dict(h=dict(partial=dict(fileUrl="http://evil.com/a"))))))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
     def testForbiddenDomainAndAllowedDomain(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            updates = OrderedDict()
-            updates["partial"] = dict(fileUrl="http://a.com/a")
-            updates["complete"] = dict(fileUrl="http://evil.com/a")
-            blob = ReleaseBlobV1(platforms=dict(f=dict(locales=dict(j=updates))))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        updates = OrderedDict()
+        updates["partial"] = dict(fileUrl="http://a.com/a")
+        updates["complete"] = dict(fileUrl="http://evil.com/a")
+        blob = ReleaseBlobV1(platforms=dict(f=dict(locales=dict(j=updates))))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
 
 class TestOldVersionSpecialCases(unittest.TestCase):
@@ -611,18 +598,12 @@ class TestSchema2Blob(unittest.TestCase):
         self.assertEqual(returned.toxml(), expected.toxml())
 
     def testAllowedDomain(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV2(fileUrls=dict(c="http://a.com/a"))
-            self.assertFalse(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV2(fileUrls=dict(c="http://a.com/a"))
+        self.assertFalse(dbo.releases.containsForbiddenDomain(blob))
 
     def testForbiddenDomainFileUrls(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV2(fileUrls=dict(c="http://evil.com/a"))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV2(fileUrls=dict(c="http://evil.com/a"))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
 
 class TestSchema2BlobNightlyStyle(unittest.TestCase):
@@ -724,21 +705,15 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
         self.assertEqual(returned.toxml(), expected.toxml())
 
     def testForbiddenDomainInLocale(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV2(platforms=dict(f=dict(locales=dict(h=dict(partial=dict(fileUrl="http://evil.com/a"))))))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV2(platforms=dict(f=dict(locales=dict(h=dict(partial=dict(fileUrl="http://evil.com/a"))))))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
     def testForbiddenDomainAndAllowedDomain(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            updates = OrderedDict()
-            updates["partial"] = dict(fileUrl="http://a.com/a")
-            updates["complete"] = dict(fileUrl="http://evil.com/a")
-            blob = ReleaseBlobV2(platforms=dict(f=dict(locales=dict(j=updates))))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        updates = OrderedDict()
+        updates["partial"] = dict(fileUrl="http://a.com/a")
+        updates["complete"] = dict(fileUrl="http://evil.com/a")
+        blob = ReleaseBlobV2(platforms=dict(f=dict(locales=dict(j=updates))))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
 
 class TestSchema3Blob(unittest.TestCase):
@@ -1023,33 +998,21 @@ class TestSchema3Blob(unittest.TestCase):
         self.assertEqual(returned.toxml(), expected.toxml())
 
     def testAllowedDomain(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV3(fileUrls=dict(c="http://a.com/a"))
-            self.assertFalse(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV3(fileUrls=dict(c="http://a.com/a"))
+        self.assertFalse(dbo.releases.containsForbiddenDomain(blob))
 
     def testForbiddenDomainFileUrls(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV3(fileUrls=dict(c="http://evil.com/a"))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV3(fileUrls=dict(c="http://evil.com/a"))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
     def testForbiddenDomainInLocale(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV3(platforms=dict(f=dict(locales=dict(h=dict(partials=[dict(fileUrl="http://evil.com/a")])))))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV3(platforms=dict(f=dict(locales=dict(h=dict(partials=[dict(fileUrl="http://evil.com/a")])))))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
     def testForbiddenDomainAndAllowedDomain(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            updates = dict(partials=[dict(fileUrl="http://a.com/a"), dict(fileUrl="http://evil.com/a")])
-            blob = ReleaseBlobV3(platforms=dict(f=dict(locales=dict(j=updates))))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        updates = dict(partials=[dict(fileUrl="http://a.com/a"), dict(fileUrl="http://evil.com/a")])
+        blob = ReleaseBlobV3(platforms=dict(f=dict(locales=dict(j=updates))))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
 
 class TestSchema4Blob(unittest.TestCase):
@@ -1355,33 +1318,21 @@ class TestSchema4Blob(unittest.TestCase):
         self.assertEquals(v4Blob, expected)
 
     def testAllowedDomain(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV4(fileUrls=dict(c=dict(completes=dict(foo="http://a.com/c"))))
-            self.assertFalse(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV4(fileUrls=dict(c=dict(completes=dict(foo="http://a.com/c"))))
+        self.assertFalse(dbo.releases.containsForbiddenDomain(blob))
 
     def testForbiddenDomainFileUrls(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV4(fileUrls=dict(c=dict(completes=dict(foo="http://evil.com/c"))))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV4(fileUrls=dict(c=dict(completes=dict(foo="http://evil.com/c"))))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
     def testForbiddenDomainInLocale(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            blob = ReleaseBlobV4(platforms=dict(f=dict(locales=dict(h=dict(partials=[dict(fileUrl="http://evil.com/a")])))))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        blob = ReleaseBlobV4(platforms=dict(f=dict(locales=dict(h=dict(partials=[dict(fileUrl="http://evil.com/a")])))))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
     def testForbiddenDomainAndAllowedDomain(self):
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            updates = dict(partials=[dict(fileUrl="http://a.com/a"), dict(fileUrl="http://evil.com/a")])
-            blob = ReleaseBlobV3(platforms=dict(f=dict(locales=dict(j=updates))))
-            self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
+        updates = dict(partials=[dict(fileUrl="http://a.com/a"), dict(fileUrl="http://evil.com/a")])
+        blob = ReleaseBlobV3(platforms=dict(f=dict(locales=dict(j=updates))))
+        self.assertTrue(dbo.releases.containsForbiddenDomain(blob))
 
 
 class TestDesupportBlob(unittest.TestCase):

--- a/auslib/test/blobs/test_gmp.py
+++ b/auslib/test/blobs/test_gmp.py
@@ -1,4 +1,3 @@
-import mock
 import unittest
 from xml.dom import minidom
 
@@ -182,9 +181,6 @@ class TestSchema1Blob(unittest.TestCase):
             "osVersion": "a", "distribution": "a", "distVersion": "a",
             "force": 0
         }
-        with mock.patch("auslib.AUS.cef_event") as c:
-            # We don't need to use the mock, but this shuts up pyflakes
-            assert c
-            returned = self.blob.createXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-            returned = minidom.parseString(returned)
-            self.assertEqual(returned.getElementsByTagName('updates')[0].firstChild.nodeValue, '\n')
+        returned = self.blob.createXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned = minidom.parseString(returned)
+        self.assertEqual(returned.getElementsByTagName('updates')[0].firstChild.nodeValue, '\n')

--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -4,7 +4,6 @@ from tempfile import mkstemp
 import unittest
 from xml.dom import minidom
 
-import auslib.log
 from auslib.global_state import dbo
 from auslib.web.base import app
 from auslib.web.views.client import ClientRequestView
@@ -25,7 +24,6 @@ class ClientTestBase(unittest.TestCase):
         app.error_handler_spec = cls.error_spec
 
     def setUp(self):
-        self.cef_fd, self.cef_file = mkstemp()
         self.version_fd, self.version_file = mkstemp()
         app.config['DEBUG'] = True
         app.config['SPECIAL_FORCE_HOSTS'] = ('http://a.com',)
@@ -44,7 +42,6 @@ class ClientTestBase(unittest.TestCase):
         dbo.setDomainWhitelist(('a.com', 'boring.com'))
         self.client = app.test_client()
         self.view = ClientRequestView()
-        auslib.log.cef_config = auslib.log.get_cef_config(self.cef_file)
         dbo.rules.t.insert().execute(backgroundRate=100, mapping='b', update_type='minor', product='b', data_version=1)
         dbo.releases.t.insert().execute(name='b', product='b', data_version=1, data="""
 {
@@ -219,8 +216,6 @@ class ClientTestBase(unittest.TestCase):
 """)
 
     def tearDown(self):
-        os.close(self.cef_fd)
-        os.remove(self.cef_file)
         os.close(self.version_fd)
         os.remove(self.version_file)
 

--- a/balrog.wsgi
+++ b/balrog.wsgi
@@ -43,7 +43,6 @@ from auslib.web.base import app as application
 for cache_name, cache_cfg in cfg.getCaches().iteritems():
     cache.make_cache(cache_name, *cache_cfg)
 
-auslib.log.cef_config = auslib.log.get_cef_config(cfg.getCefLogfile())
 dbo.setDb(cfg.getDburi())
 dbo.setDomainWhitelist(cfg.getDomainWhitelist())
 application.config['WHITELISTED_DOMAINS'] = cfg.getDomainWhitelist()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ balrogadmin:
     - DBURI=mysql://balrogadmin:balrogadmin@balrogdb/balrog
     - SECRET_KEY=blahblah
     - PORT=8080
+    - LOG_FORMAT=plain
+    - LOG_LEVEL=DEBUG
 
 balrogpub:
   build: .
@@ -28,6 +30,8 @@ balrogpub:
     - DBURI=mysql://balrogadmin:balrogadmin@balrogdb/balrog
     - SECRET_KEY=blahblah
     - PORT=9090
+    - LOG_FORMAT=plain
+    - LOG_LEVEL=DEBUG
   links:
     - balrogdb
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 blinker==1.4 \
 #    --hash=sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6
-# no hash for cef because it's going to get removed before we switch to docker in prod
-cef==0.5
 decorator==4.0.6 \
 #    --hash=sha256:1c6254597777fd003da2e8fb503c3dbf3d9e8f8d55f054709c0e65be3467209c --hash=sha256:cc3dcda7835a7eafa887fad9d6a69b2d5fd77c0b1c2a1608f52b48e345e37206
 flask==0.10.1 \

--- a/scripts/admin.py
+++ b/scripts/admin.py
@@ -37,7 +37,6 @@ if __name__ == '__main__':
     parser.add_option("-p", "--port", dest="port", type="int", help="port for server")
     parser.add_option("--host", dest="host", default='127.0.0.1', help="host to listen on. for example, 0.0.0.0 binds on all interfaces.")
     parser.add_option("--whitelist-domain", dest="whitelistedDomains", action="append")
-    parser.add_option("--cef-log", dest="cefLog", default="cef.log")
     parser.add_option("--page-title", dest="pageTitle", default="AUS Management")
     parser.add_option("-v", "--verbose", dest="verbose", action="store_true",
                       help="Verbose output")
@@ -57,7 +56,6 @@ if __name__ == '__main__':
     from auslib.admin.base import app
     from migrate.exceptions import DatabaseAlreadyControlledError
 
-    auslib.log.cef_config = auslib.log.get_cef_config(options.cefLog)
     dbo.setDb(options.db)
     dbo.setDomainWhitelist(options.whitelistedDomains)
     try:

--- a/scripts/balrog-server.py
+++ b/scripts/balrog-server.py
@@ -32,7 +32,6 @@ if __name__ == "__main__":
     parser.add_option("--whitelist-domain", dest="whitelistedDomains", action="append")
     parser.add_option("--special-force-host", dest="specialForceHosts", action="append",
                       help="Hosts to forward force=1 on to, use a protocol prefix like http://")
-    parser.add_option("--cef-log", dest="cefLog", default="cef.log")
     parser.add_option("--profile-dir", dest="profile_dir", default=None,
                       help="Enables profiling and logs to the specified file."),
     parser.add_option("-v", "--verbose", dest="verbose", action="store_true",
@@ -55,7 +54,6 @@ if __name__ == "__main__":
     cache.make_cache("blob", 500, 3600)
     cache.make_cache("blob_version", 500, 60)
 
-    auslib.log.cef_config = auslib.log.get_cef_config(options.cefLog)
     dbo.setDb(options.db)
     dbo.setDomainWhitelist(options.whitelistedDomains)
     try:

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -1,8 +1,7 @@
 import logging
 import os
-import sys
 
-import auslib.log
+from auslib.log import configure_logging
 
 
 SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "b2gbld", "stage-ffxbld", "stage-tbirdbld", "stage-b2gbld"]
@@ -17,14 +16,15 @@ DOMAIN_WHITELIST = [
 
 # Logging needs to be set-up before importing the application to make sure that
 # logging done from other modules uses our Logger.
-logging.setLoggerClass(auslib.log.BalrogLogger)
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG, format=auslib.log.log_format)
+logging_kwargs = {
+    "level": os.environ.get("LOG_LEVEL", logging.INFO)
+}
+if os.environ.get("LOG_FORMAT") == "plain":
+    logging_kwargs["formatter"] = logging.Formatter
+configure_logging(**logging_kwargs)
 
 from auslib.admin.base import app as application
 from auslib.global_state import cache, dbo
-
-# TODO: How to do cef logging in CloudOps? Do we need to?
-auslib.log.cef_config = auslib.log.get_cef_config("syslog")
 
 cache.make_copies = True
 # We explicitly don't want a blob_version cache here because it will cause

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -1,8 +1,7 @@
 import logging
 import os
-import sys
 
-import auslib.log
+from auslib.log import configure_logging
 
 
 SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "b2gbld", "stage-ffxbld", "stage-tbirdbld", "stage-b2gbld"]
@@ -18,14 +17,15 @@ DOMAIN_WHITELIST = [
 
 # Logging needs to be set-up before importing the application to make sure that
 # logging done from other modules uses our Logger.
-logging.setLoggerClass(auslib.log.BalrogLogger)
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG, format=auslib.log.log_format)
+logging_kwargs = {
+    "level": os.environ.get("LOG_LEVEL", logging.INFO)
+}
+if os.environ.get("LOG_FORMAT") == "plain":
+    logging_kwargs["formatter"] = logging.Formatter
+configure_logging(**logging_kwargs)
 
 from auslib.global_state import cache, dbo
 from auslib.web.base import app as application
-
-# TODO: How to do cef logging in CloudOps? Do we need to?
-auslib.log.cef_config = auslib.log.get_cef_config("syslog")
 
 cache.make_cache("blob", 500, 3600)
 # There's probably no no need to ever expire items in the blob schema cache


### PR DESCRIPTION
This branch implements mozlog for Balrog and fully replaces CEF logging with it. The JsonLogFormatter is taken from https://raw.githubusercontent.com/mozilla/testpilot/master/testpilot/base/logging.py. I'm told it's going to be made available independent at some point, so we'll probably switch to that when it is.

Logging configuration has changed a little bit here as well, with Mozlog formatting being the default, but overridable with an environment variable (which we use for the Docker images).

One thing we're losing here is granularity of errors (CEF_* all become a WARNING here) - should I be doing something different here, @jvehent? My assumption is that we're probably going to be running at log level WARNING in production, so I perhaps I should be switching some of these to ERROR or CRITICAL messages?

There's a couple of new TODOs here. One of them is about e-mail notification for rules/permission changes. I'll be doing that in bug 1251338. The other is a note about the requestid that BalrogLogger generates. That's a new bug I found that I don't intend to fix here.