### PR TITLE
Bug 1134190 - balrog throws ISE 500 instead of 400 when data_version is wrong

### DIFF
--- a/auslib/admin/views/base.py
+++ b/auslib/admin/views/base.py
@@ -58,7 +58,6 @@ class AdminView(MethodView):
 
     def put(self, *args, **kwargs):
         self.log.debug("processing PUT request to %s" % request.path)
-        
         try:
             with dbo.begin() as trans:
                 return self._put(*args, transaction=trans, **kwargs)
@@ -66,7 +65,7 @@ class AdminView(MethodView):
             msg = "Couldn't Update. Outdated Data Version: %s" % e
             cef_event("Bad input", CEF_WARN, errors=msg)
             return Response(status=400, response=json.dumps({"data": e.args}))
-            
+
     def delete(self, *args, **kwargs):
         self.log.debug("processing DELETE request to %s" % request.path)
         with dbo.begin() as trans:

--- a/auslib/admin/views/base.py
+++ b/auslib/admin/views/base.py
@@ -6,7 +6,8 @@ from flask.views import MethodView
 from auslib.global_state import dbo
 from auslib.log import cef_event, CEF_ALERT, CEF_WARN
 from auslib.util.timesince import timesince
-
+from auslib.db import OutdatedDataError
+import json
 import logging
 
 
@@ -57,9 +58,15 @@ class AdminView(MethodView):
 
     def put(self, *args, **kwargs):
         self.log.debug("processing PUT request to %s" % request.path)
-        with dbo.begin() as trans:
-            return self._put(*args, transaction=trans, **kwargs)
-
+        
+        try:
+            with dbo.begin() as trans:
+                return self._put(*args, transaction=trans, **kwargs)
+        except OutdatedDataError as e:
+            msg = "Couldn't Update. Outdated Data Version: %s" % e
+            cef_event("Bad input", CEF_WARN, errors=msg)
+            return Response(status=400, response=json.dumps({"data": e.args}))
+            
     def delete(self, *args, **kwargs):
         self.log.debug("processing DELETE request to %s" % request.path)
         with dbo.begin() as trans:

--- a/auslib/admin/views/base.py
+++ b/auslib/admin/views/base.py
@@ -45,7 +45,7 @@ def requirepermission(url, options=['product']):
     return wrap
 
 
-def catchOutDataError(messages):
+def catchOutdatedDataError(messages):
     def wrap(f):
         def decorated(*args, **kwargs):
             try:
@@ -64,19 +64,19 @@ class AdminView(MethodView):
         self.log = logging.getLogger(self.__class__.__name__)
         MethodView.__init__(self, *args, **kwargs)
 
-    @catchOutDataError("POST")
+    @catchOutdatedDataError("POST")
     def post(self, *args, **kwargs):
         self.log.debug("processing POST request to %s" % request.path)
         with dbo.begin() as trans:
             return self._post(*args, transaction=trans, **kwargs)
 
-    @catchOutDataError("Update")
+    @catchOutdatedDataError("PUT")
     def put(self, *args, **kwargs):
         self.log.debug("processing PUT request to %s" % request.path)
         with dbo.begin() as trans:
             return self._put(*args, transaction=trans, **kwargs)
 
-    @catchOutDataError("Delete")
+    @catchOutdatedDataError("DELETE")
     def delete(self, *args, **kwargs):
         self.log.debug("processing DELETE request to %s" % request.path)
         with dbo.begin() as trans:

--- a/auslib/admin/views/base.py
+++ b/auslib/admin/views/base.py
@@ -51,7 +51,7 @@ def catchOutDataError(messages):
             try:
                 return f(*args, **kwargs)
             except OutdatedDataError as e:
-                msg = "Couldn't preform the request %s. Outdated Data Version. old_data_version doesn't match current data_version: %s" % (messages, e)
+                msg = "Couldn't perform the request %s. Outdated Data Version. old_data_version doesn't match current data_version: %s" % (messages, e)
                 cef_event("Bad input", CEF_WARN, errors=msg)
                 return Response(status=400, response=json.dumps({"data": e.args}))
         return decorated

--- a/auslib/admin/views/releases.py
+++ b/auslib/admin/views/releases.py
@@ -241,8 +241,12 @@ class SingleReleaseView(AdminView):
                 msg = "Couldn't update release: %s" % e
                 cef_event("Bad input", CEF_WARN, errors=msg)
                 return Response(status=400, response=json.dumps({"data": e.args}))
+            except OutdatedDataError as e:
+                msg = "Couldn't update release: %s" % e
+                cef_event("Bad input", CEF_WARN, errors=msg)
+                return Response(status=400, response=json.dumps({"data": e.args}))
             data_version += 1
-            return Response(json.dumps(dict(new_data_version=data_version)), status=200)
+            return Response(json.dumps(dict(new_data_version=data_version)), status=200)            
         else:
             try:
                 dbo.releases.addRelease(name=release, product=form.product.data,

--- a/auslib/admin/views/releases.py
+++ b/auslib/admin/views/releases.py
@@ -241,12 +241,8 @@ class SingleReleaseView(AdminView):
                 msg = "Couldn't update release: %s" % e
                 cef_event("Bad input", CEF_WARN, errors=msg)
                 return Response(status=400, response=json.dumps({"data": e.args}))
-            except OutdatedDataError as e:
-                msg = "Couldn't update release: %s" % e
-                cef_event("Bad input", CEF_WARN, errors=msg)
-                return Response(status=400, response=json.dumps({"data": e.args}))
             data_version += 1
-            return Response(json.dumps(dict(new_data_version=data_version)), status=200)            
+            return Response(json.dumps(dict(new_data_version=data_version)), status=200)
         else:
             try:
                 dbo.releases.addRelease(name=release, product=form.product.data,

--- a/auslib/admin/views/rules.py
+++ b/auslib/admin/views/rules.py
@@ -11,7 +11,6 @@ from auslib.admin.views.base import (
 from auslib.admin.views.csrf import get_csrf_headers
 from auslib.admin.views.forms import EditRuleForm, RuleForm, DbEditableForm
 from auslib.log import cef_event, CEF_WARN, CEF_ALERT
-from auslib.db import OutdatedDataError
 
 
 class RulesAPIView(AdminView):
@@ -132,13 +131,8 @@ class SingleRuleView(AdminView):
             if (request.json and k in request.json) or k in request.form:
                 what[k] = v
 
-        try:
-            dbo.rules.updateRule(changed_by=changed_by, id_or_alias=id_or_alias, what=what,
+        dbo.rules.updateRule(changed_by=changed_by, id_or_alias=id_or_alias, what=what,
                              old_data_version=form.data_version.data, transaction=transaction)
-        except OutdatedDataError as e:
-            msg = "Couldn't Update Rule: %s" % e
-            cef_event("Bad input", CEF_WARN, errors=msg)
-            return Response(status=400, response=json.dumps({"data": e.args}))
 
         # find out what the next data version is
         rule = dbo.rules.getRule(id_or_alias, transaction=transaction)

--- a/auslib/admin/views/rules.py
+++ b/auslib/admin/views/rules.py
@@ -11,6 +11,7 @@ from auslib.admin.views.base import (
 from auslib.admin.views.csrf import get_csrf_headers
 from auslib.admin.views.forms import EditRuleForm, RuleForm, DbEditableForm
 from auslib.log import cef_event, CEF_WARN, CEF_ALERT
+from auslib.db import OutdatedDataError
 
 
 class RulesAPIView(AdminView):
@@ -131,8 +132,14 @@ class SingleRuleView(AdminView):
             if (request.json and k in request.json) or k in request.form:
                 what[k] = v
 
-        dbo.rules.updateRule(changed_by=changed_by, id_or_alias=id_or_alias, what=what,
+        try:
+            dbo.rules.updateRule(changed_by=changed_by, id_or_alias=id_or_alias, what=what,
                              old_data_version=form.data_version.data, transaction=transaction)
+        except OutdatedDataError as e:
+            msg = "Couldn't Update Rule: %s" % e
+            cef_event("Bad input", CEF_WARN, errors=msg)
+            return Response(status=400, response=json.dumps({"data": e.args}))
+
         # find out what the next data version is
         rule = dbo.rules.getRule(id_or_alias, transaction=transaction)
         new_data_version = rule['data_version']

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -75,7 +75,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
             }
         }"""
         # Testing Put request to add new release
-        ret = self._put('/releases/dd', data=dict(data=data, name='dd', blob=blob , product='dd', data_version=1))
+        ret = self._put('/releases/dd', data=dict(data=data, name='dd', blob=blob, product='dd', data_version=1))
         self.assertStatusCode(ret, 201)
 
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'dd').execute().fetchone()[0]
@@ -83,14 +83,14 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 
         # Updating same release
         data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1))
-        ret = self._put('/releases/dd', data=dict(data=data, name='dd' , product='dd', blob=blob , data_version=1))
+        ret = self._put('/releases/dd', data=dict(data=data, name='dd', product='dd', blob=blob, data_version=1))
         self.assertStatusCode(ret, 200)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
 
         # Outdated Data Error on same release
         data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1))
-        ret = self._put('/releases/dd', data=dict(data=data, name='dd' , product='dd', blob=blob , data_version=1))
-        self.assertStatusCode(ret,400)
+        ret = self._put('/releases/dd', data=dict(data=data, name='dd', product='dd', blob=blob, data_version=1))
+        self.assertStatusCode(ret, 400)
 
     def testReleasePostMismatchedName(self):
         data = json.dumps(dict(name="eee", schema_version=1))

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -51,7 +51,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
 }
 """))
 
-    def testReleasePutUpdateDataError(self):
+    def testReleasePutUpdateOutdatedData(self):
         data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1))
         blob = """
         {
@@ -92,7 +92,7 @@ class TestReleasesAPI_JSON(ViewTest, JSONTestMixin):
         ret = self._put('/releases/dd', data=dict(data=data, name='dd', product='dd', blob=blob, data_version=1))
         self.assertStatusCode(ret, 400)
 
-    def testReleasePostUpdateDataError(self):
+    def testReleasePostUpdateOutdatedData(self):
         data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1))
         blob = """
         {

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -123,7 +123,7 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
         self.assertEquals(r[0]['version'], '3.5')
         self.assertEquals(r[0]['buildTarget'], 'd')
 
-    def testPutOutdatedError(self):
+    def testPutRuleOutdatedData(self):
         # Make changes to a rule
         ret = self._put('/rules/1', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1, product='Firefox', channel='nightly'))
         self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
@@ -137,7 +137,7 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
         ret2 = self._put('/rules/1', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1, product='Firefox', channel='nightly'))
         self.assertEquals(ret2.status_code, 400, "Status Code: %d, Data: %s" % (ret2.status_code, ret2.data))
 
-    def testPostOutdatedError(self):
+    def testPostRuleOutdatedData(self):
         # Make changes to a rule
         ret = self._post('/rules/1', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1, product='Firefox', channel='nightly'))
         self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
@@ -306,7 +306,7 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
         ret = self._delete('/rules/1', qs=dict(data_version=1))
         self.assertEquals(ret.status_code, 200, msg=ret.data)
 
-    def testDeleteRuleOutdatedError(self):
+    def testDeleteRuleOutdatedData(self):
         ret = self._get('/rules/1')
         self.assertEquals(ret.status_code, 200, msg=ret.data)
         ret = self._delete('/rules/1', qs=dict(data_version=7))

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -123,6 +123,22 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
         self.assertEquals(r[0]['version'], '3.5')
         self.assertEquals(r[0]['buildTarget'], 'd')
 
+    def testPutOutdatedError400(self):
+        # Make changes to a rule
+        ret = self._put('/rules/1', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1,
+                                               product='Firefox', channel='nightly'))
+        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+        load = json.loads(ret.data)
+        self.assertEquals(load['new_data_version'], 2)
+        # Assure the changes made it into the database
+        r = dbo.rules.t.select().where(dbo.rules.rule_id == 1).execute().fetchall()
+        self.assertEquals(r[0]['data_version'], 2)
+
+        # OutdatedDataVersion Request
+        ret2 = self._put('/rules/1', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1,
+                                               product='Firefox', channel='nightly'))
+        self.assertEquals(ret2.status_code, 400, "Status Code: %d, Data: %s" % (ret2.status_code, ret2.data))
+
     def testPostByAlias(self):
         # Make some changes to a rule
         ret = self._post('/rules/frodo', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1,

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -125,8 +125,7 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
 
     def testPutOutdatedError400(self):
         # Make changes to a rule
-        ret = self._put('/rules/1', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1,
-                                               product='Firefox', channel='nightly'))
+        ret = self._put('/rules/1', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1, product='Firefox', channel='nightly'))
         self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
         load = json.loads(ret.data)
         self.assertEquals(load['new_data_version'], 2)
@@ -135,8 +134,7 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
         self.assertEquals(r[0]['data_version'], 2)
 
         # OutdatedDataVersion Request
-        ret2 = self._put('/rules/1', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1,
-                                               product='Firefox', channel='nightly'))
+        ret2 = self._put('/rules/1', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1, product='Firefox', channel='nightly'))
         self.assertEquals(ret2.status_code, 400, "Status Code: %d, Data: %s" % (ret2.status_code, ret2.data))
 
     def testPostByAlias(self):


### PR DESCRIPTION
Added an exception handler at web layer to catch OutdatedDataError case.