### PR TITLE
Add test that ensures JsonLogFormatter is used when appropriate.

### DIFF
--- a/auslib/log.py
+++ b/auslib/log.py
@@ -138,7 +138,7 @@ def safer_format_traceback(exc_typ, exc_val, exc_tb):
 def configure_logging(stream=sys.stdout, formatter=JsonLogFormatter, format_=log_format, level=logging.DEBUG):
     logging.setLoggerClass(BalrogLogger)
     handler = logging.StreamHandler(stream)
-    formatter = JsonLogFormatter(fmt=format_)
+    formatter = formatter(fmt=format_)
     handler.setFormatter(formatter)
     logging.root.addHandler(handler)
     logging.root.setLevel(level)

--- a/auslib/log.py
+++ b/auslib/log.py
@@ -74,9 +74,9 @@ class JsonLogFormatter(logging.Formatter):
     ))
 
     def __init__(self, fmt=None, datefmt=None, logger_name='Balrog'):
-        super(JsonLogFormatter, self).__init__(fmt, datefmt)
         self.logger_name = logger_name
         self.hostname = socket.gethostname()
+        logging.Formatter.__init__(self, fmt, datefmt)
 
     def format(self, record):
         """
@@ -138,7 +138,7 @@ def safer_format_traceback(exc_typ, exc_val, exc_tb):
 def configure_logging(stream=sys.stdout, formatter=JsonLogFormatter, format_=log_format, level=logging.DEBUG):
     logging.setLoggerClass(BalrogLogger)
     handler = logging.StreamHandler(stream)
-    formatter = formatter(fmt=format_)
+    formatter = JsonLogFormatter(fmt=format_)
     handler.setFormatter(formatter)
     logging.root.addHandler(handler)
     logging.root.setLevel(level)

--- a/auslib/test/admin/views/test_base.py
+++ b/auslib/test/admin/views/test_base.py
@@ -1,3 +1,6 @@
+import logging
+
+from auslib.log import configure_logging, JsonLogFormatter
 from auslib.test.admin.views.base import ViewTest
 
 
@@ -10,3 +13,20 @@ class TestRequirepermission(ViewTest):
     def testGranular(self):
         ret = self._put('/users/foo/permissions/admin', username='bob')
         self.assertStatusCode(ret, 201)
+
+
+class TestJsonLogFormatter(ViewTest):
+
+    def setUp(self):
+        self.logger = logging.getLogger()
+        self.orig_handlers = self.logger.handlers
+        self.logger.handlers = []
+        self.level = self.logger.level
+
+    def tearDown(self):
+        self.logger.handlers = self.orig_handlers
+        self.logger.level = self.level
+
+    def testConfigureLogging(self):
+        configure_logging()
+        self.assertTrue(isinstance(self.logger.handlers[0].formatter, JsonLogFormatter))

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
 
 commands=
     flake8 auslib scripts balrog.wsgi admin.wsgi uwsgi
-    py.test --cov=. --doctest-modules auslib
+    py.test --cov=. --doctest-modules {posargs:auslib}
     coverage run -a scripts/test-rules.py
 
 [testenv:py26]


### PR DESCRIPTION
Since I've taken this code from elsewhere I think it's safe to assume that format() works fine, so I'm just testing configure_logging(). Incidentally, this discovered that JsonLogFormatter would've busted production because calling super(JsonLogFormatter, self) doesn't work in Python 2.6 (because logging.Formatter is still an old-style class).