### PR TITLE
Bug 1074362 - balrog serves partial when it shouldn't when fromRelease doesn't exist

### DIFF
--- a/auslib/blobs/apprelease.py
+++ b/auslib/blobs/apprelease.py
@@ -85,7 +85,11 @@ class ReleaseBlobBase(Blob):
 
     def _getSpecificPatchXML(self, patchKey, patchType, patch, updateQuery, whitelistedDomains, specialForceHosts):
         fromRelease = self._getFromRelease(patch)
+        # don't return an update if we don't match the from restriction
         if fromRelease and not fromRelease.matchesUpdateQuery(updateQuery):
+            return None
+        # don't return an update if an older release isn't in the DB for some reason
+        if patch['from'] != '*' and fromRelease is None:
             return None
 
         url = self._getUrl(updateQuery, patchKey, patch, specialForceHosts)

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -1049,7 +1049,8 @@ class TestSchema4Blob(unittest.TestCase):
     "fileUrls": {
         "c1": {
             "partials": {
-                "h1": "http://a.com/h1-partial.mar"
+                "h1": "http://a.com/h1-partial.mar",
+                "h2": "http://a.com/h2-partial.mar"
             },
             "completes": {
                 "*": "http://a.com/complete.mar"
@@ -1057,7 +1058,8 @@ class TestSchema4Blob(unittest.TestCase):
         },
         "c2": {
             "partials": {
-                "h1": "http://a.com/h1-%LOCALE%-partial"
+                "h1": "http://a.com/h1-%LOCALE%-partial",
+                "h2": "http://a.com/h2-%LOCALE%-partial"
             },
             "completes": {
                 "*": "http://a.com/%LOCALE%-complete"
@@ -1065,7 +1067,8 @@ class TestSchema4Blob(unittest.TestCase):
         },
         "*": {
             "partials": {
-                "h1": "http://a.com/h1-partial-catchall"
+                "h1": "http://a.com/h1-partial-catchall",
+                "h2": "http://a.com/h2-partial-catchall"
             },
             "completes": {
                 "*": "http://a.com/complete-catchall"
@@ -1080,6 +1083,11 @@ class TestSchema4Blob(unittest.TestCase):
             "locales": {
                 "l": {
                     "partials": [
+                        {
+                            "filesize": 6,
+                            "from": "h2",
+                            "hashValue": "7"
+                        },
                         {
                             "filesize": 8,
                             "from": "h1",


### PR DESCRIPTION
Turns out _getFromRelease() can return None in two situations, and we're not handling the 'release missing from DB' case. The test is a little dirty, we could add something to the TestReleaseBlobBase class if you prefer.