### PR TITLE
bug 1266392: Add link to Taskcluster build in version.json; create artifact with sha256 of created image

### DIFF
--- a/scripts/push-dockerimage.sh
+++ b/scripts/push-dockerimage.sh
@@ -3,6 +3,8 @@
 set -e
 
 password_url="taskcluster/secrets/v1/secret/repo:github.com/mozilla/balrog:dockerhub"
+artifact_url="taskcluster/queue/v1/task/${TASK_ID}/runs/${RUN_ID}/artifacts/public/docker-image-shasum256.txt"
+artifact_expiry=$(date -d "+1 year" -u +%FT%TZ)
 dockerhub_email=release+balrog@mozilla.com
 dockerhub_username=mozillabalrog
 dockerhub_password=$(curl ${password_url} | python -c 'import json, sys; a = json.load(sys.stdin); print a["secret"]["dockerhub_password"]')
@@ -20,7 +22,8 @@ date=$(date --utc +%Y-%m-%d-%H-%M)
 echo "{
     \"commit\": \"${commit}\",
     \"version\": \"${version}\",
-    \"source\": \"https://github.com/mozilla/balrog\"
+    \"source\": \"https://github.com/mozilla/balrog\",
+    \"build\": \"https://tools.taskcluster.net/task-inspector/#${TASK_ID}\"
 }" > version.json
 
 branch_tag="${branch}"
@@ -28,6 +31,7 @@ if [ "$branch" == "master" ]; then
     branch_tag="latest"
 fi
 date_tag="${branch}-${date}"
+
 echo "Building Docker image"
 docker build -t mozilla/balrog:${branch_tag} .
 echo "Tagging Docker image with date tag"
@@ -37,3 +41,9 @@ docker login -e $dockerhub_email -u $dockerhub_username -p $dockerhub_password
 echo "Pushing Docker image"
 docker push mozilla/balrog:${branch_tag}
 docker push mozilla/balrog:${date_tag}
+
+sha256=$(docker images --no-trunc mozilla/balrog | grep "${date_tag}" | awk '/^mozilla/ {print $3}')
+echo "SHA256 is ${sha256}, creating artifact for it"
+put_url=$(curl --retry 5 --retry-delay 5 --data "{\"storageType\": \"s3\", \"contentType\": \"text/plain\", \"expires\": \"${artifact_expiry}\"}" ${artifact_url} | python -c 'import json; import sys; print json.load(sys.stdin)["putUrl"]')
+curl --retry 5 --retry-delay 5 -X PUT -H "Content-Type: text/plain" --data "${sha256}" "${put_url}"
+echo 'Artifact created, all done!'

--- a/version.json
+++ b/version.json
@@ -1,5 +1,6 @@
 {
     "commit": "stub",
     "version": "stub",
-    "source": "https://github.com/mozilla/balrog"
+    "source": "https://github.com/mozilla/balrog",
+    "build": "https://tools.taskcluster.net/task-inspector/#XXXXXXXXXXXXXXXXXX"
 }


### PR DESCRIPTION
@mostlygeek asked for both of these the other day. Combined, these let CloudOps do sha256 verification of the images that are pulled from Dockerhub.

@rail - can you look at this? I think you're probably the best person since you know Balrog+Taskcluster fairly well.