### PR TITLE
Enable http keepalive for the admin interface

### DIFF
--- a/uwsgi/admin.ini
+++ b/uwsgi/admin.ini
@@ -6,6 +6,9 @@ mount = /=/app/uwsgi/admin.wsgi
 # Rewrite PATH_INFO & SCRIPT_NAME to match mountpoint (so the app sees paths like /foo instead of /api/foo)
 manage-script-name = 1
 
+# Enable keepalive so that clients can maintain sessions
+http-keepalive = 1
+
 # Check /app/ui/dist for static file
 check-static = /app/ui/dist
 # Serve index.html when / is requested


### PR DESCRIPTION
I discovered this was needed at least for dev while doing some local testing. I suspect we'll need it for prod as well, otherwise uwsgi will close sockets very quickly. What do you think, @mostlygeek?