### PR TITLE
Fix detailsUrl property in desupport schema.

### DIFF
--- a/auslib/blobs/schemas/desupport.yml
+++ b/auslib/blobs/schemas/desupport.yml
@@ -17,7 +17,7 @@
       description: Blob identifier number
       enum:
         - 50
-    settings:
+    detailsUrl:
       type: string
       description: URL that shows more information about why users getting this release are desupported
       format: uri


### PR DESCRIPTION
I tried to add a new desupport blob today and discovered this silly error....