### PR TITLE
Look for HTTP_REMOTE_USER if REMOTE_USER isn't present.

### DIFF
--- a/auslib/admin/views/base.py
+++ b/auslib/admin/views/base.py
@@ -12,7 +12,7 @@ import logging
 
 def requirelogin(f):
     def decorated(*args, **kwargs):
-        username = request.environ.get('REMOTE_USER')
+        username = request.environ.get('REMOTE_USER', request.environ.get("HTTP_REMOTE_USER"))
         if not username:
             logging.warning("Login Required")
             return Response(status=401)

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -80,11 +80,17 @@ class ViewTest(unittest.TestCase):
     def _getBadAuth(self):
         return {'REMOTE_USER': 'NotAuth!'}
 
+    def _getHttpRemoteUserAuth(self, username):
+        return {"HTTP_REMOTE_USER": username}
+
     def _getAuth(self, username):
         return {'REMOTE_USER': username}
 
     def _post(self, url, data={}, username='bill', **kwargs):
         return self.client.post(url, data=data, environ_base=self._getAuth(username), **kwargs)
+
+    def _httpRemoteUserPost(self, url, username="bill", data={}):
+        return self.client.post(url, data=data, environ_base=self._getHttpRemoteUserAuth(username))
 
     def _badAuthPost(self, url, data={}):
         return self.client.post(url, data=data, environ_base=self._getBadAuth())

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -328,6 +328,26 @@ class TestSingleRuleView_JSON(ViewTest, JSONTestMixin):
         self.assertEquals(ret.status_code, 401, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
         self.assertTrue("not allowed to alter" in ret.data, msg=ret.data)
 
+    def testHttpRemoteUserAuth(self):
+        # Make some changes to a rule
+        ret = self._httpRemoteUserPost('/rules/1', data=dict(backgroundRate=71, mapping='d', priority=73, data_version=1,
+                                                             product='Firefox', channel='nightly'))
+        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+        load = json.loads(ret.data)
+        self.assertEquals(load['new_data_version'], 2)
+
+        # Assure the changes made it into the database
+        r = dbo.rules.t.select().where(dbo.rules.rule_id == 1).execute().fetchall()
+        self.assertEquals(len(r), 1)
+        self.assertEquals(r[0]['mapping'], 'd')
+        self.assertEquals(r[0]['backgroundRate'], 71)
+        self.assertEquals(r[0]['priority'], 73)
+        self.assertEquals(r[0]['data_version'], 2)
+        # And that we didn't modify other fields
+        self.assertEquals(r[0]['update_type'], 'minor')
+        self.assertEquals(r[0]['version'], '3.5')
+        self.assertEquals(r[0]['buildTarget'], 'd')
+
     def testNoPermissionToAlterExistingProduct(self):
         ret = self._post('/rules/1', data=dict(backgroundRate=71, data_version=1), username='bob')
         self.assertEquals(ret.status_code, 401)


### PR DESCRIPTION
We discovered yesterday that the CloudOps nginx+uwsgi deployment doesn't quite work because REMOTE_USER isn't set. According to @mostlygeek, we should check for this instead.

@rail - r?