### PR TITLE
Unquote necessary url parts during routing

### DIFF
--- a/auslib/admin/base.py
+++ b/auslib/admin/base.py
@@ -3,8 +3,6 @@ import urllib
 from flask import Flask, request
 from flask_compress import Compress
 
-from werkzeug.routing import BaseConverter, PathConverter
-
 import logging
 log = logging.getLogger(__name__)
 
@@ -22,6 +20,21 @@ from auslib.admin.views.history import DiffView, FieldView
 from auslib.dockerflow import create_dockerflow_endpoints
 
 create_dockerflow_endpoints(app)
+
+
+# When running under uwsgi, paths will not get decoded before hitting the app.
+# We need to handle this ourselves in certain fields, and adding converters
+# for them is the best way to do this.
+class UnquotingMiddleware(object):
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        environ["PATH_INFO"] = urllib.unquote(environ["PATH_INFO"])
+        return self.app(environ, start_response)
+
+
+app.wsgi_app = UnquotingMiddleware(app.wsgi_app)
 
 
 @app.errorhandler(500)
@@ -42,30 +55,6 @@ def add_security_headers(response):
 Compress(app)
 
 
-# When running under uwsgi, paths will not get decoded before hitting the app.
-# We need to handle this ourselves in certain fields, and adding converters
-# for them is the best way to do this.
-class UrlquotingConverter(BaseConverter):
-    def to_python(self, value):
-        return urllib.unquote(value)
-
-    def to_url(self, value):
-        return urllib.quote(value)
-
-
-class UrlquotingPathConverter(PathConverter):
-    def to_python(self, value):
-        value = super(UrlquotingPathConverter, self).to_python(value)
-        return urllib.unquote(value)
-
-    def to_url(self, value):
-        value = super(UrlquotingPathConverter, self).to_url(value)
-        return urllib.quote(value)
-
-
-app.url_map.converters["urlquote"] = UrlquotingConverter
-app.url_map.converters["urlquotepath"] = UrlquotingPathConverter
-
 # Endpoints required for the Balrog 2.0 UI.
 # In the Mozilla deployments of Balrog, both the the admin API (these endpoints)
 # and the static admin UI are hosted on the same domain. This API wsgi app is
@@ -73,10 +62,10 @@ app.url_map.converters["urlquotepath"] = UrlquotingPathConverter
 # these requests.
 app.add_url_rule("/csrf_token", view_func=CSRFView.as_view("csrf"))
 app.add_url_rule("/users", view_func=UsersView.as_view("users"))
-app.add_url_rule("/users/<urlquote:username>/permissions", view_func=PermissionsView.as_view("user_permissions"))
-app.add_url_rule("/users/<urlquote:username>/permissions/<urlquotepath:permission>", view_func=SpecificPermissionView.as_view("specific_permission"))
+app.add_url_rule("/users/<username>/permissions", view_func=PermissionsView.as_view("user_permissions"))
+app.add_url_rule("/users/<username>/permissions/<path:permission>", view_func=SpecificPermissionView.as_view("specific_permission"))
 # Some permissions may start with a slash, and the <path> converter won"t match them, so we need an extra rule to cope.
-app.add_url_rule("/users/<urlquote:username>/permissions//<urlquotepath:permission>", view_func=SpecificPermissionView.as_view("specific_permission2"))
+app.add_url_rule("/users/<username>/permissions//<path:permission>", view_func=SpecificPermissionView.as_view("specific_permission2"))
 app.add_url_rule("/rules", view_func=RulesAPIView.as_view("rules"))
 # Normal operations (get/update/delete) on rules can be done by id or alias...
 app.add_url_rule("/rules/<id_or_alias>", view_func=SingleRuleView.as_view("rule"))


### PR DESCRIPTION
I did some digging and AFAICT there's no way to make uwsgi unquote the path before handing them off to the app. This is different than Apache which seems to do that by default.

I was considering doing manual conversation of @, /, and : in the uwsgi config, but I thought this would be a more flexible approach.

The path unquoting should go away when #80 lands and removes URL-style permissions.