### PR TITLE
Added support for querying changes with data_version and value via getChange

### DIFF
--- a/auslib/admin/views/history.py
+++ b/auslib/admin/views/history.py
@@ -21,7 +21,7 @@ class FieldView(AdminView):
         if type_ not in tables:
             raise KeyError('Bad table')
         table = tables[type_]
-        revision = table.history.getChange(change_id)
+        revision = table.history.getChange(change_id=change_id)
         if not revision:
             raise ValueError('Bad change_id')
         if field not in revision:

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -533,12 +533,12 @@ class History(AUSTable):
             versioned and their values."""
         if change_id is None:
             where = [self.data_version == data_version]
-            column_names = {col.name: col for col in self.baseTable.primary_key}
-            for col in column_values.keys():
-                if col in column_names.keys():
+            column_names = {col.name: col for col in self.table.columns if col.name in self.base_primary_key}
+            for col in column_names.keys():
+                if col in column_values.keys():
                     where.append(column_names[col] == column_values[col])
                 else:
-                    raise ValueError("Invalid primary key name")
+                    raise ValueError("Entire primary key not present")
             if self.baseTable.versioned:
                 changes = self.select(where=where,
                                       transaction=transaction)
@@ -604,7 +604,7 @@ class History(AUSTable):
         """ Rollback the change given by the change_id,
         Will handle all cases: insert, delete, update """
 
-        change = self.getChange(change_id, transaction)
+        change = self.getChange(change_id=change_id, transaction=transaction)
 
         # Get the values of the primary keys for the given row
         row_primary_keys = [0] * len(self.base_primary_key)

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -490,6 +490,15 @@ class TestHistoryTable(unittest.TestCase, TestTableMixin, MemoryDatabaseMixin):
                                     u'foo': 0, u'timestamp': 1000,
                                     u'change_id': 2, u'id': 4})
 
+    def testHistoryGetChangeWithDataVersionReturnNone(self):
+        with mock.patch('time.time') as t:
+            t.return_value = 1.0
+
+            self.test.insert(changed_by='george', id=4, foo=0)
+            ret = self.test.history.getChange(data_version=1,
+                                              column_values={'id': 5})
+            self.assertEquals(ret, None)
+
     def testHistoryGetChangeWithDataVersionWithNonPrimaryKeyColumn(self):
         with mock.patch('time.time') as t:
             t.return_value = 1.0
@@ -596,6 +605,36 @@ class TestMultiplePrimaryHistoryTable(unittest.TestCase, TestMultiplePrimaryTabl
 
             ret = self.test.t.select().execute().fetchall()
             self.assertEquals(len(ret), 5, msg=ret)
+
+    def testMultiplePrimaryKeyHistoryGetChangeWithDataVersion(self):
+        with mock.patch('time.time') as t:
+            t.return_value = 1.0
+
+            self.test.insert(changed_by='george', id1=4, id2=5, foo=0)
+            ret = self.test.history.getChange(data_version=1,
+                                              column_values={'id1': 4, 'id2': 5})
+            self.assertEquals(ret, {u'data_version': 1,
+                                    u'changed_by': u'george',
+                                    u'foo': 0, u'timestamp': 1000,
+                                    u'change_id': 2, u'id1': 4, u'id2': 5})
+
+    def testMultiplePrimaryKeyHistoryGetChangeWithDataVersionReturnNone(self):
+        with mock.patch('time.time') as t:
+            t.return_value = 1.0
+
+            self.test.insert(changed_by='george', id1=4, id2=5, foo=0)
+            ret = self.test.history.getChange(data_version=1,
+                                              column_values={'id1': 4,
+                                                             'id2': 55})
+            self.assertEquals(ret, None)
+
+    def testHistoryGetChangeWithDataVersionWithNonPrimaryKeyColumn(self):
+        with mock.patch('time.time') as t:
+            t.return_value = 1.0
+
+            self.test.insert(changed_by='george', id1=4, id2=5, foo=0)
+            self.assertRaises(ValueError, self.test.history.getChange, data_version=1,
+                              column_values={'id1': 4, 'foo': 4})
 
 
 class TestSampleData(unittest.TestCase, MemoryDatabaseMixin):

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -467,6 +467,29 @@ class TestHistoryTable(unittest.TestCase, TestTableMixin, MemoryDatabaseMixin):
             ret = self.test.t.select().execute().fetchall()
             self.assertEquals(len(ret), 4, msg=ret)
 
+    def testHistoryGetChangeWithChangeID(self):
+        with mock.patch('time.time') as t:
+            t.return_value = 1.0
+
+            self.test.insert(changed_by='george', id=4, foo=0)
+            ret = self.test.history.getChange(1)
+            self.assertEquals(ret, {u'data_version': None,
+                                    u'changed_by': u'george',
+                                    u'foo': None, u'timestamp': 999,
+                                    u'change_id': 1, u'id': 4})
+
+    def testHistoryGetChangeWithDataVersion(self):
+        with mock.patch('time.time') as t:
+            t.return_value = 1.0
+
+            self.test.insert(changed_by='george', id=4, foo=0)
+            ret = self.test.history.getChange(None, data_version=1,
+                                              key='id', value=4)
+            self.assertEquals(ret, {u'data_version': 1,
+                                    u'changed_by': u'george',
+                                    u'foo': 0, u'timestamp': 1000,
+                                    u'change_id': 2, u'id': 4})
+
 
 class TestMultiplePrimaryHistoryTable(unittest.TestCase, TestMultiplePrimaryTableMixin, MemoryDatabaseMixin):
 

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -472,7 +472,7 @@ class TestHistoryTable(unittest.TestCase, TestTableMixin, MemoryDatabaseMixin):
             t.return_value = 1.0
 
             self.test.insert(changed_by='george', id=4, foo=0)
-            ret = self.test.history.getChange(1)
+            ret = self.test.history.getChange(change_id=1)
             self.assertEquals(ret, {u'data_version': None,
                                     u'changed_by': u'george',
                                     u'foo': None, u'timestamp': 999,
@@ -483,12 +483,20 @@ class TestHistoryTable(unittest.TestCase, TestTableMixin, MemoryDatabaseMixin):
             t.return_value = 1.0
 
             self.test.insert(changed_by='george', id=4, foo=0)
-            ret = self.test.history.getChange(None, data_version=1,
-                                              key='id', value=4)
+            ret = self.test.history.getChange(data_version=1,
+                                              column_values={'id': 4})
             self.assertEquals(ret, {u'data_version': 1,
                                     u'changed_by': u'george',
                                     u'foo': 0, u'timestamp': 1000,
                                     u'change_id': 2, u'id': 4})
+
+    def testHistoryGetChangeWithDataVersionWithNonPrimaryKeyColumn(self):
+        with mock.patch('time.time') as t:
+            t.return_value = 1.0
+
+            self.test.insert(changed_by='george', id=4, foo=0)
+            self.assertRaises(ValueError, self.test.history.getChange, data_version=1,
+                              column_values={'foo': 4})
 
 
 class TestMultiplePrimaryHistoryTable(unittest.TestCase, TestMultiplePrimaryTableMixin, MemoryDatabaseMixin):


### PR DESCRIPTION
This is required for getting historical versions of blobs from the data_version. 