### PR TITLE
First pass at rule caching.

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -787,32 +787,42 @@ class Rules(AUSTable):
         """Returns all of the rules that match the given update query.
            For cases where a particular updateQuery channel has no
            fallback, fallbackChannel should match the channel from the query."""
-        where = [
-            ((self.product == updateQuery['product']) | (self.product == null())) &
-            ((self.buildTarget == updateQuery['buildTarget']) | (self.buildTarget == null())) &
-            ((self.headerArchitecture == updateQuery['headerArchitecture']) | (self.headerArchitecture == null()))
-        ]
-        # Query version 2 doesn't have distribution information, and to keep
-        # us maximally flexible, we won't match any rules that have
-        # distribution update set.
-        if updateQuery['queryVersion'] == 2:
-            where.extend([(self.distribution == null()) & (self.distVersion == null())])
-        # Only query versions 3 and 4 have distribution information, so we
-        # need to consider it.
-        if updateQuery['queryVersion'] in (3, 4):
-            where.extend([
-                ((self.distribution == updateQuery['distribution']) | (self.distribution == null())) &
-                ((self.distVersion == updateQuery['distVersion']) | (self.distVersion == null()))
-            ])
-        if not updateQuery['force']:
-            where.append(self.backgroundRate > 0)
-        rules = self.select(where=where, transaction=transaction)
-        self.log.debug("where: %s" % where)
+
+        def getRawMatches():
+            where = [
+                ((self.product == updateQuery['product']) | (self.product == null())) &
+                ((self.buildTarget == updateQuery['buildTarget']) | (self.buildTarget == null())) &
+                ((self.headerArchitecture == updateQuery['headerArchitecture']) | (self.headerArchitecture == null()))
+            ]
+            # Query version 2 doesn't have distribution information, and to keep
+            # us maximally flexible, we won't match any rules that have
+            # distribution update set.
+            if updateQuery['queryVersion'] == 2:
+                where.extend([(self.distribution == null()) & (self.distVersion == null())])
+            # Only query versions 3 and 4 have distribution information, so we
+            # need to consider it.
+            if updateQuery['queryVersion'] in (3, 4):
+                where.extend([
+                    ((self.distribution == updateQuery['distribution']) | (self.distribution == null())) &
+                    ((self.distVersion == updateQuery['distVersion']) | (self.distVersion == null()))
+                ])
+            if not updateQuery['force']:
+                where.append(self.backgroundRate > 0)
+
+            self.log.debug("where: %s" % where)
+            return self.select(where=where, transaction=transaction)
+
+        cache_key = "%s-%s-%s-%s-%s-%s" % \
+            (updateQuery["product"], updateQuery["buildTarget"], updateQuery["headerArchitecture"],
+             updateQuery.get("distribution"), updateQuery.get("distVersion"), updateQuery["force"])
+        rules = cache.get("rules", cache_key, getRawMatches)
+
         self.log.debug("Raw matches:")
 
         matchingRules = []
         for rule in rules:
             self.log.debug(rule)
+
             # Resolve special means for channel, version, and buildID - dropping
             # rules that don't match after resolution.
             if not self._channelMatchesRule(rule['channel'], updateQuery['channel'], fallbackChannel):

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -812,6 +812,11 @@ class Rules(AUSTable):
             self.log.debug("where: %s" % where)
             return self.select(where=where, transaction=transaction)
 
+        # This cache key is constructed from all parts of the updateQuery that
+        # are used in the select() to get the "raw" rule matches. For the most
+        # part, product and buildTarget will be the only applicable ones which
+        # means we should get very high cache hit rates, as there's not a ton
+        # of variability of possible combinations for those.
         cache_key = "%s:%s:%s:%s:%s:%s" % \
             (updateQuery["product"], updateQuery["buildTarget"], updateQuery["headerArchitecture"],
              updateQuery.get("distribution"), updateQuery.get("distVersion"), updateQuery["force"])

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -812,7 +812,7 @@ class Rules(AUSTable):
             self.log.debug("where: %s" % where)
             return self.select(where=where, transaction=transaction)
 
-        cache_key = "%s-%s-%s-%s-%s-%s" % \
+        cache_key = "%s:%s:%s:%s:%s:%s" % \
             (updateQuery["product"], updateQuery["buildTarget"], updateQuery["headerArchitecture"],
              updateQuery.get("distribution"), updateQuery.get("distVersion"), updateQuery["force"])
         rules = cache.get("rules", cache_key, getRawMatches)

--- a/auslib/util/cache.py
+++ b/auslib/util/cache.py
@@ -54,7 +54,10 @@ class MaybeCacher(object):
                 return None
 
         value = self.caches[name].get(key)
-        if not value and callable(value_getter):
+        # "if value is None" is important here (instead of "if not value")
+        # because it allows us to cache results of potentially expensive
+        # calls that may end up returning nothing.
+        if value is None and callable(value_getter):
             value = value_getter()
             self.put(name, key, value)
 

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -37,7 +37,9 @@ cache.make_cache("blob", 500, 3600)
 cache.make_cache("blob_schema", 50, 24 * 60 * 60)
 cache.make_cache("blob_version", 500, 60)
 
-cache.make_cache("rules", 20, 30)
+# 500 is probably a bit oversized for the rules cache, but the items are so
+# small there sholudn't be any negative effect.
+cache.make_cache("rules", 500, 30)
 
 dbo.setDb(os.environ["DBURI"])
 dbo.setDomainWhitelist(DOMAIN_WHITELIST)

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -37,6 +37,8 @@ cache.make_cache("blob", 500, 3600)
 cache.make_cache("blob_schema", 50, 24 * 60 * 60)
 cache.make_cache("blob_version", 500, 60)
 
+cache.make_cache("rules", 20, 30)
+
 dbo.setDb(os.environ["DBURI"])
 dbo.setDomainWhitelist(DOMAIN_WHITELIST)
 application.config["WHITELISTED_DOMAINS"] = DOMAIN_WHITELIST


### PR DESCRIPTION
This is a first crack at doing full-table caching of rules (the second option listed at https://bugzilla.mozilla.org/show_bug.cgi?id=1111032#c0). There's no invalidation necessary here because this code only runs on the public nodes, and they cannot modify rules.

This patch introduces an extra delay of up to 30 seconds between making a rule change, and having it take effect. This is on top of the existing 60 second cache at zeus (webops) or nginx (cloudops).

I haven't done a lot of self review or testing yet, I wanted to get this up for quick feedback anyways though.