### PR TITLE
Set cache control header for public app

### DIFF
--- a/auslib/dockerflow.py
+++ b/auslib/dockerflow.py
@@ -14,7 +14,7 @@ def create_dockerflow_endpoints(app):
         if version_file and path.exists(version_file):
             with open(app.config["VERSION_FILE"]) as f:
                 version_json = f.read()
-            return Response(version_json, mimetype="application/json")
+            return Response(version_json, mimetype="application/json", headers={"Cache-Control": "no-cache"})
         else:
             return jsonify({
                 "source": "https://github.com/mozilla/balrog",
@@ -30,11 +30,11 @@ def create_dockerflow_endpoints(app):
         # Counting the rules should be a trivial enough operation that it won't
         # cause notable load, but will verify that the database works.
         dbo.rules.countRules()
-        return Response("OK!", headers={"Cache-Control": "max-age: 20"})
+        return Response("OK!", headers={"Cache-Control": "no-cache"})
 
     @app.route("/__lbheartbeat__")
     def lbheartbeat():
         """Per the Dockerflow spec:
         Respond to /__lbheartbeat__ with an HTTP 200. This is for load balancer
         checks and should not check any dependent services."""
-        return "OK!"
+        return Response("OK!", headers={"Cache-Control": "no-cache"})

--- a/auslib/test/admin/views/test_dockerflow.py
+++ b/auslib/test/admin/views/test_dockerflow.py
@@ -20,7 +20,7 @@ class TestDockerflowEndpoints(ViewTest):
             ret = self.client.get("/__heartbeat__")
             self.assertEqual(ret.status_code, 200)
             self.assertEqual(cr.call_count, 1)
-            self.assertTrue("Cache-Control" in ret.headers)
+            self.assertEqual(ret.headers["Cache-Control"], "no-cache")
 
     def testHeartbeatWithException(self):
         with mock.patch("auslib.global_state.dbo.rules.countRules") as cr:
@@ -33,3 +33,4 @@ class TestDockerflowEndpoints(ViewTest):
     def testLbHeartbeat(self):
         ret = self.client.get("/__lbheartbeat__")
         self.assertEqual(ret.status_code, 200)
+        self.assertEqual(ret.headers["Cache-Control"], "no-cache")

--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -656,6 +656,20 @@ class ClientTestWithErrorHandlers(unittest.TestCase):
         self.client = app.test_client()
         self.view = ClientRequestView()
 
+    def testCacheControlIsSet(self):
+        ret = self.client.get('/update/3/c/15.0/1/p/l/a/a/default/a/update.xml')
+        self.assertEqual(ret.headers.get("Cache-Control"), "public,max-age=60")
+
+    def testCacheControlIsNotSetFor404(self):
+        ret = self.client.get('/whizzybang')
+        self.assertEqual(ret.headers.get("Cache-Control"), None)
+
+    def testCacheControlIsNotSetFor500(self):
+        with mock.patch('auslib.web.views.client.ClientRequestView.get') as m:
+            m.side_effect = Exception('I break!')
+            ret = self.client.get('/update/4/b/1.0/1/p/l/a/a/a/a/1/update.xml')
+            self.assertEqual(ret.headers.get("Cache-Control"), None)
+
     def testEmptySnippetOn404(self):
         ret = self.client.get('/whizzybang')
         self.assertEqual(ret.status_code, 200)

--- a/auslib/test/web/test_dockerflow.py
+++ b/auslib/test/web/test_dockerflow.py
@@ -20,7 +20,7 @@ class TestDockerflowEndpoints(ClientTestBase):
             ret = self.client.get("/__heartbeat__")
             self.assertEqual(ret.status_code, 200)
             self.assertEqual(cr.call_count, 1)
-            self.assertTrue("Cache-Control" in ret.headers)
+            self.assertEqual(ret.headers["Cache-Control"], "no-cache")
 
     def testHeartbeatWithException(self):
         with mock.patch("auslib.global_state.dbo.rules.countRules") as cr:
@@ -33,3 +33,4 @@ class TestDockerflowEndpoints(ClientTestBase):
     def testLbHeartbeat(self):
         ret = self.client.get("/__lbheartbeat__")
         self.assertEqual(ret.status_code, 200)
+        self.assertEqual(ret.headers["Cache-Control"], "no-cache")

--- a/auslib/web/views/client.py
+++ b/auslib/web/views/client.py
@@ -10,11 +10,10 @@ import logging
 
 
 class ClientRequestView(MethodView):
-    responseHeaders = {
-        "Cache-Control": "public,max-age=60",
-    }
-
     def __init__(self, *args, **kwargs):
+        # By default, we want a cache that can be shared across requests from different users ("public")
+        # and a maximum age of 60 seconds, to keep our TTL low.
+        self.cacheControl = app.config.get("CACHE_CONTROL", "public,max-age=60")
         self.log = logging.getLogger(self.__class__.__name__)
         MethodView.__init__(self, *args, **kwargs)
 
@@ -104,6 +103,6 @@ class ClientRequestView(MethodView):
             xml = "\n".join(xml)
         self.log.debug("Sending XML: %s", xml)
         response = make_response(xml)
-        response.headers = self.responseHeaders
+        response.headers["Cache-Control"] = self.cacheControl
         response.mimetype = "text/xml"
         return response

--- a/auslib/web/views/client.py
+++ b/auslib/web/views/client.py
@@ -10,6 +10,9 @@ import logging
 
 
 class ClientRequestView(MethodView):
+    responseHeaders = {
+        "Cache-Control": "public,max-age=60",
+    }
 
     def __init__(self, *args, **kwargs):
         self.log = logging.getLogger(self.__class__.__name__)
@@ -101,5 +104,6 @@ class ClientRequestView(MethodView):
             xml = "\n".join(xml)
         self.log.debug("Sending XML: %s", xml)
         response = make_response(xml)
+        response.headers = self.responseHeaders
         response.mimetype = "text/xml"
         return response

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -49,3 +49,6 @@ application.config["SPECIAL_FORCE_HOSTS"] = SPECIAL_FORCE_HOSTS
 # about the current code (version number, commit hash), but doesn't exist in
 # the repo itself
 application.config["VERSION_FILE"] = "/app/version.json"
+
+if os.environ.get("CACHE_CONTROL"):
+    application.config["CACHE_CONTROL"] = os.environ["CACHE_CONTROL"]


### PR DESCRIPTION
Not much to say about this one - it should enable a 60s cache that can be shared by requests from different users. We explicitly don't want to cache 500s, to minimize the TTL of transient errors, and I suspect there's no benefit to caching 404s either. I read over the other Cache-Control options as well, and I don't think any of them are of benefit to us (eg: we don't want a lengthier cache for proxies by setting s-max-age).