### PR TITLE
Add displayVersion to DesupportBlob.

### DIFF
--- a/auslib/blobs/apprelease.py
+++ b/auslib/blobs/apprelease.py
@@ -694,8 +694,7 @@ class DesupportBlob(Blob):
 
     def getInnerXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
         xml = []
-        xml.append('    <update type="%s" unsupported="true" detailsURL="%s">' % (update_type,
-                                                                                  self['detailsUrl']))
+        xml.append('    <update type="%s" unsupported="true" detailsURL="%s" displayVersion="%s">' % (update_type, self['detailsUrl'], self["displayVersion"]))
         return xml
 
     def getFooterXML(self):

--- a/auslib/blobs/schemas/desupport.yml
+++ b/auslib/blobs/schemas/desupport.yml
@@ -5,6 +5,7 @@
     - name
     - schema_version
     - detailsUrl
+    - displayVersion
   additionalProperties: false
   properties:
     name:
@@ -21,3 +22,6 @@
       type: string
       description: URL that shows more information about why users getting this release are desupported
       format: uri
+    displayVersion:
+      type: string
+      description: The displayVersion to return with the update. Generally, the client will show this in the UI. For desupport responses, this is generally set to the last supported version.

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -1612,7 +1612,8 @@ class TestDesupportBlob(unittest.TestCase):
 {
     "name": "d1",
     "schema_version": 50,
-    "detailsUrl": "http://moo.com/cow"
+    "detailsUrl": "http://moo.com/cow",
+    "displayVersion": "50.0"
 }
 """)
 
@@ -1624,7 +1625,7 @@ class TestDesupportBlob(unittest.TestCase):
         returned = [x.strip() for x in returned]
         expected_header = ""
         expected = ["""
-<update type="minor" unsupported="true" detailsURL="http://moo.com/cow">
+<update type="minor" unsupported="true" detailsURL="http://moo.com/cow" displayVersion="50.0">
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"


### PR DESCRIPTION
According to Robert, we want to use the last supported version in displayVersion, so we'll need per-channel versions of the existing desupport blobs (like the OS X and GTK deprecation ones). This shouldn't be a big deal.