### PR TITLE
Compressed history tables

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -462,6 +462,7 @@ class History(AUSTable):
         self.table = Table('%s_history' % baseTable.t.name, metadata,
                            Column('change_id', Integer, primary_key=True, autoincrement=True),
                            Column('changed_by', String(100), nullable=False),
+                           mysql_row_format='COMPRESSED',
                            )
         # Timestamps are stored as an integer, but actually contain
         # precision down to the millisecond, achieved through

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -167,9 +167,12 @@ class AUSTable(object):
     """
 
     def __init__(self, db, dialect, history=True, versioned=True, onInsert=None,
-                 onUpdate=None, onDelete=None):
+                 onUpdate=None, onDelete=None, compressHistory=False):
         self.db = db
-        self.t = self.table
+        if hasattr(self, 'table'):
+            self.t = self.table
+        else:
+            raise NotImplementedError
         # Enable versioning, if required
         if versioned:
             self.t.append_column(Column('data_version', Integer, nullable=False))
@@ -185,7 +188,8 @@ class AUSTable(object):
                 self.primary_key.append(col)
         # Set-up a history table to do logging in, if required
         if history:
-            self.history = History(db, dialect, self.t.metadata, self)
+            self.history = History(db, dialect, self.t.metadata, self,
+                                   compress=compressHistory)
         else:
             self.history = None
         self.log = logging.getLogger(self.__class__.__name__)
@@ -457,12 +461,13 @@ class History(AUSTable):
        inputs, and are documented below. History tables are never versioned,
        and cannot have history of their own."""
 
-    def __init__(self, db, dialect, metadata, baseTable):
+    def __init__(self, db, dialect, metadata, baseTable, compress=False):
         self.baseTable = baseTable
+        row_format = 'COMPRESSED' if compress else 'DEFAULT'
         self.table = Table('%s_history' % baseTable.t.name, metadata,
                            Column('change_id', Integer, primary_key=True, autoincrement=True),
                            Column('changed_by', String(100), nullable=False),
-                           mysql_row_format='COMPRESSED',
+                           mysql_row_format=row_format,
                            )
         # Timestamps are stored as an integer, but actually contain
         # precision down to the millisecond, achieved through
@@ -946,7 +951,7 @@ class Releases(AUSTable):
         else:
             dataType = Text
         self.table.append_column(Column('data', dataType, nullable=False))
-        AUSTable.__init__(self, db, dialect)
+        AUSTable.__init__(self, db, dialect, compressHistory=True)
 
     def setDomainWhitelist(self, domainWhitelist):
         self.domainWhitelist = domainWhitelist

--- a/auslib/migrate/versions/013_compress_history.py
+++ b/auslib/migrate/versions/013_compress_history.py
@@ -1,0 +1,18 @@
+
+
+def upgrade(migrate_engine):
+    con = migrate_engine.connect()
+
+    if migrate_engine.name == 'mysql':
+        con.execute('ALTER TABLE releases_history ROW_FORMAT=COMPRESSED')
+        con.execute('ALTER TABLE permissions_history ROW_FORMAT=COMPRESSED')
+        con.execute('ALTER TABLE rules_history ROW_FORMAT=COMPRESSED')
+
+
+def downgrade(migrate_engine):
+    con = migrate_engine.connect()
+
+    if migrate_engine.name == 'mysql':
+        con.execute('ALTER TABLE releases_history ROW_FORMAT=DEFAULT')
+        con.execute('ALTER TABLE permissions_history ROW_FORMAT=DEFAULT')
+        con.execute('ALTER TABLE rules_history ROW_FORMAT=DEFAULT')

--- a/auslib/migrate/versions/013_compress_history.py
+++ b/auslib/migrate/versions/013_compress_history.py
@@ -2,17 +2,11 @@
 
 def upgrade(migrate_engine):
     con = migrate_engine.connect()
-
     if migrate_engine.name == 'mysql':
         con.execute('ALTER TABLE releases_history ROW_FORMAT=COMPRESSED')
-        con.execute('ALTER TABLE permissions_history ROW_FORMAT=COMPRESSED')
-        con.execute('ALTER TABLE rules_history ROW_FORMAT=COMPRESSED')
 
 
 def downgrade(migrate_engine):
     con = migrate_engine.connect()
-
     if migrate_engine.name == 'mysql':
         con.execute('ALTER TABLE releases_history ROW_FORMAT=DEFAULT')
-        con.execute('ALTER TABLE permissions_history ROW_FORMAT=DEFAULT')
-        con.execute('ALTER TABLE rules_history ROW_FORMAT=DEFAULT')

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -302,24 +302,24 @@ class TestAUSTable(unittest.TestCase, TestTableMixin, MemoryDatabaseMixin):
 
         class TestTable(AUSTable):
 
-            def __init__(self, metadata):
+            def __init__(self, db, metadata):
                 self.table = Table('test_two', metadata, Column('id', Integer, primary_key=True))
-                AUSTable.__init__(self, 'sqlite')
+                AUSTable.__init__(self, db, 'sqlite')
 
         class TestCompressedHistoryTable(AUSTable):
 
-            def __init__(self, metadata):
+            def __init__(self, db, metadata):
                 self.table = Table('test_three', metadata, Column('id', Integer, primary_key=True))
-                AUSTable.__init__(self, 'sqlite', compressHistory=True)
+                AUSTable.__init__(self, db, 'sqlite', compressHistory=True)
 
         # Patching Table so that we can check if setting the flag results in
         # the correct arguments being set during its instantiation.
         with mock.patch('sqlalchemy.Table.__init__') as mock_history_table:
             mock_history_table.return_value = None
-            TestTable(self.metadata)
+            TestTable("fake", self.metadata)
             _, kwargs = mock_history_table.call_args
             self.assertEquals(kwargs['mysql_row_format'], 'DEFAULT')
-            TestCompressedHistoryTable(self.metadata)
+            TestCompressedHistoryTable("fake", self.metadata)
             _, kwargs = mock_history_table.call_args
             self.assertEquals(kwargs['mysql_row_format'], 'COMPRESSED')
 


### PR DESCRIPTION
Used raw SQL queries since sqlalchemy-migrate does not expose an interface for changing ROW_FORMAT.