### PR TITLE
Add batch delete for releases and releases_history tables

### DIFF
--- a/scripts/run-batch-deletes.sh
+++ b/scripts/run-batch-deletes.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# deletes are required to be done in small batches since they take
+# too long to do as one large DB transaction
+
+cd $(dirname $0)
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 DBURI MAX_AGE <length in seconds>"
+    echo "Example: $0 <dburi> <maxage> 21600 -- runs for 6 hours"
+    echo " -- this script runs batch deletes in a loop for the time specified"
+    exit 1
+fi
+
+DBURI=$1
+MAX_AGE=$2
+
+START=$(date '+%s')
+TIL=$(expr $START + $3)
+
+TOTAL=0
+while true; do
+    NOW=$(date '+%s')
+    if [ $NOW -gt $TIL ]; then
+        break
+    fi
+
+    printf "Deleting..."
+    # DBURI and MAX_AGE should be in the environment
+    DELETED=$(python ./manage-db.py -d "$DBURI" cleanup "$MAX_AGE" 2>/dev/null | awk '/Total/ {print $3}')
+    TOTAL=$(expr $TOTAL + $DELETED)
+    NOW=$(date '+%s')
+    printf "%d rows removed >>> %d seconds remaining. %d deleted.\n" $DELETED $(expr $TIL - $NOW) $TOTAL
+
+    if [ $DELETED -eq 0 ]; then
+        echo "Nothing left to do"
+        exit 0
+    fi
+done

--- a/uwsgi/run.sh
+++ b/uwsgi/run.sh
@@ -21,17 +21,12 @@ elif [ $1 == "cleanup-db" ]; then
         echo "\${MAX_AGE} must be set!"
         exit 1
     fi
-    exec python scripts/manage-db.py -d ${DBURI} cleanup ${MAX_AGE}
-elif [ $1 == "cleanup-db-dryrun" ]; then
-    if [ -z "${DBURI}" ]; then
-        echo "\${DBURI} must be set!"
+    if [ -z "${DELETE_RUN_TIME}" ]; then
+        echo "\${DELETE_RUN_TIME} must be set!"
         exit 1
     fi
-    if [ -z "${MAX_AGE}" ]; then
-        echo "\${MAX_AGE} must be set!"
-        exit 1
-    fi
-    exec python scripts/manage-db.py -d ${DBURI} cleanup-dryrun ${MAX_AGE}
+
+    exec scripts/run-batch-deletes.sh $DBURI $MAX_AGE $DELETE_RUN_TIME
 else
    echo "unknown mode: $1"
    exit 1


### PR DESCRIPTION
- The `cleanup-db` will now run a shell script which batch deletes for a
  defined length of time
- The delete logic was rewritten to allow for batch deletes of records
