### PR TITLE
[rule_history_api] Changed mapping keys for id and rate

### DIFF
--- a/auslib/admin/views/rules.py
+++ b/auslib/admin/views/rules.py
@@ -182,13 +182,13 @@ class RuleHistoryAPIView(HistoryAdminView):
         _rules = []
         _mapping = {
             # return : db name
-            'id': 'rule_id',
+            'rule_id': 'rule_id',
             'mapping': 'mapping',
             'priority': 'priority',
             'alias': 'alias',
             'product': 'product',
             'version': 'version',
-            'background_rate': 'backgroundRate',
+            'backgroundRate': 'backgroundRate',
             'buildID': 'buildID',
             'channel': 'channel',
             'locale': 'locale',

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -479,6 +479,8 @@ class TestRuleHistoryView(ViewTest):
         got = json.loads(ret.data)
         self.assertEquals(ret.status_code, 200, msg=ret.data)
         self.assertEquals(got["count"], 2)
+        self.assertTrue(u"rule_id" in got["rules"][0])
+        self.assertTrue(u"backgroundRate" in got["rules"][0])
 
     def testPostRevisionRollback(self):
         # Make some changes to a rule


### PR DESCRIPTION
Rate changes and rule ids were not being shown on rule
history because the fields were named differently i.e.
'id' and 'background_rate' instead of what the ui uses
i.e. 'rule_id' and 'backgroundRate'