### PR TITLE
Use different default value for permission options.

### DIFF
--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -31,6 +31,10 @@ class DisableableTextInput(TextInput):
 class JSONStringField(StringField):
     """StringField that parses incoming data as JSON."""
 
+    def __init__(self, default_value, *args, **kwargs):
+        self.default_value = default_value
+        super(JSONStringField, self).__init__(*args, **kwargs)
+
     def process_formdata(self, valuelist):
         if valuelist and valuelist[0]:
             try:
@@ -47,7 +51,7 @@ class JSONStringField(StringField):
             self._set_default()
 
     def _set_default(self):
-        self.data = {}
+        self.data = self.default_value
 
     def _value(self):
         return json.dumps(self.data) if self.data is not None else u''
@@ -131,11 +135,11 @@ class ScheduledChangeForm(Form):
 
 
 class NewPermissionForm(Form):
-    options = JSONStringField('Options')
+    options = JSONStringField(None, 'Options')
 
 
 class ExistingPermissionForm(DbEditableForm):
-    options = JSONStringField('Options')
+    options = JSONStringField(None, 'Options')
 
 
 class PartialReleaseForm(Form):
@@ -145,10 +149,10 @@ class PartialReleaseForm(Form):
     data_version = IntegerField('data_version', widget=HiddenInput())
     product = StringField('Product', validators=[Required()])
     hashFunction = StringField('Hash Function')
-    data = JSONStringField('Data', validators=[Required()])
+    data = JSONStringField({}, 'Data', validators=[Required()])
     schema_version = IntegerField('Schema Version')
-    copyTo = JSONStringField('Copy To', default=list)
-    alias = JSONStringField('Alias', default=list)
+    copyTo = JSONStringField({}, 'Copy To', default=list)
+    alias = JSONStringField({}, 'Alias', default=list)
 
 
 class RuleForm(Form):
@@ -219,7 +223,7 @@ class EditScheduledChangeExistingRuleForm(ScheduledChangeForm, EditRuleForm):
 class CompleteReleaseForm(Form):
     name = StringField('Name', validators=[Required()])
     product = StringField('Product', validators=[Required()])
-    blob = JSONStringField('Data', validators=[Required()], widget=FileInput())
+    blob = JSONStringField({}, 'Data', validators=[Required()], widget=FileInput())
     data_version = IntegerField('data_version', widget=HiddenInput())
 
 

--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -36,6 +36,15 @@ class TestPermissionsAPI_JSON(ViewTest):
         query = query.where(dbo.permissions.permission == 'admin')
         self.assertEqual(query.execute().fetchone(), ('admin', 'bob', None, 1))
 
+    def testPermissionPutWithEmptyOptions(self):
+        ret = self._put('/users/bob/permissions/admin', data=dict(options=""))
+        self.assertStatusCode(ret, 201)
+        self.assertEqual(ret.data, json.dumps(dict(new_data_version=1)), "Data: %s" % ret.data)
+        query = dbo.permissions.t.select()
+        query = query.where(dbo.permissions.username == 'bob')
+        query = query.where(dbo.permissions.permission == 'admin')
+        self.assertEqual(query.execute().fetchone(), ('admin', 'bob', None, 1))
+
     def testPermissionPutWithEmail(self):
         ret = self._put('/users/bob@bobsworld.com/permissions/admin')
         self.assertStatusCode(ret, 201)


### PR DESCRIPTION
This is for https://bugzilla.mozilla.org/show_bug.cgi?id=1297765, where it was discovered that I broke creating permissions without options. The problem comes down to the fact that "options" now comes in as a kwarg in https://github.com/mozilla/balrog/blob/a09fd8ebd1f9df402966682a634eb3c729a3c72a/auslib/db.py#L1641, and if it's present in there, we try to insert it. The old code checked "if options", which meant that even passing {} as options would not get into that block.

I _think_ the new behaviour of trying to insert it if present makes sense, so I've adjusted the web layer to be a better consumer of the new db layer.