### PR TITLE
Don't allow changes in the past to be scheduled

### DIFF
--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -1,4 +1,3 @@
-import time
 import simplejson as json
 
 from flask_wtf import Form
@@ -6,6 +5,7 @@ from wtforms import StringField, IntegerField, SelectField, BooleanField
 from wtforms.widgets import TextInput, FileInput, HiddenInput
 from wtforms.validators import Required, Optional, NumberRange, Length, Regexp, ValidationError
 from auslib.util.comparison import get_op
+from auslib.util.timestamp import getMillisecondTimestamp
 from auslib.util.versions import MozillaVersion
 
 import logging
@@ -129,7 +129,7 @@ def not_in_the_past():
         if field.data is None:
             return
 
-        if (field.data / 1000) < time.time():
+        if field.data < getMillisecondTimestamp():
             raise ValidationError("Changes may not be scheduled in the past")
 
     return _validator

--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -134,6 +134,7 @@ def not_in_the_past():
 
     return _validator
 
+
 class DbEditableForm(Form):
     data_version = IntegerField('data_version', validators=[Required()], widget=HiddenInput())
 

--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -1,3 +1,4 @@
+import time
 import simplejson as json
 
 from flask_wtf import Form
@@ -119,6 +120,16 @@ def version_validator():
     return _validator
 
 
+def not_in_the_past():
+    def _validator(form, field):
+        if field.data is None:
+            return
+
+        if (field.data / 1000) < time.time():
+            raise ValidationError("Changes may not be scheduled in the past")
+
+    return _validator
+
 class DbEditableForm(Form):
     data_version = IntegerField('data_version', validators=[Required()], widget=HiddenInput())
 
@@ -127,7 +138,7 @@ class ScheduledChangeForm(Form):
     telemetry_product = NullableStringField("Telemetry Product")
     telemetry_channel = NullableStringField("Telemetry Channel")
     telemetry_uptake = NullableStringField("Telemetry Uptake")
-    when = IntegerField("When", validators=[Optional()])
+    when = IntegerField("When", validators=[Optional(), not_in_the_past()])
 
 
 class NewPermissionForm(Form):

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -932,6 +932,10 @@ class ScheduledChangeTable(AUSTable):
         # updated unnecessarily when the base table's update method calls
         # mergeUpdate. If the base table update fails, this will get reverted
         # when the transaction is rolled back.
+        # We explicitly avoid using ScheduledChangeTable's update() method here
+        # because we don't want to trigger its validation of conditions. Doing so
+        # would raise any exception for any timestamp based changes, because
+        # they are already in the past when we're ready to enact them.
         super(ScheduledChangeTable, self).update(
             where=[self.sc_id == sc_id], what={"complete": True}, changed_by=sc["scheduled_by"], old_data_version=sc["data_version"],
             transaction=transaction

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -823,6 +823,9 @@ class ScheduledChangeTable(AUSTable):
             except:
                 raise ValueError("Cannot parse 'when' as a unix timestamp.")
 
+            if conditions["when"] < time.time():
+                raise ValueError("Cannot schedule changes in the past")
+
     def insert(self, changed_by, transaction=None, dryrun=False, **columns):
         base_table_where = []
         for pk in self.base_primary_key:

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -819,11 +819,11 @@ class ScheduledChangeTable(AUSTable):
 
         if "when" in conditions:
             try:
-                time.gmtime(conditions["when"])
+                time.gmtime(conditions["when"] / 1000)
             except:
                 raise ValueError("Cannot parse 'when' as a unix timestamp.")
 
-            if conditions["when"] < time.time():
+            if (conditions["when"] / 1000) < time.time():
                 raise ValueError("Cannot schedule changes in the past")
 
     def insert(self, changed_by, transaction=None, dryrun=False, **columns):

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -24,6 +24,7 @@ from auslib.global_state import cache, dbo
 from auslib.AUS import isForbiddenUrl
 from auslib.blobs.base import createBlob
 from auslib.util.comparison import string_compare, version_compare
+from auslib.util.timestamp import getMillisecondTimestamp
 
 import logging
 
@@ -544,10 +545,6 @@ class History(AUSTable):
             self.table.append_column(newcol)
         AUSTable.__init__(self, db, dialect, history=False, versioned=False)
 
-    def getTimestamp(self):
-        t = int(time.time() * 1000)
-        return t
-
     def forInsert(self, insertedKeys, columns, changed_by):
         """Inserts cause two rows in the History table to be created. The first
            one records the primary key data and NULLs for other row data. This
@@ -563,7 +560,7 @@ class History(AUSTable):
             # Make sure the primary keys are included in the second row as well
             columns[name] = insertedKeys[i]
 
-        ts = self.getTimestamp()
+        ts = getMillisecondTimestamp()
         queries.append(self._insertStatement(changed_by=changed_by, timestamp=ts - 1, **primary_key_data))
         queries.append(self._insertStatement(changed_by=changed_by, timestamp=ts, **columns))
         return queries
@@ -576,7 +573,7 @@ class History(AUSTable):
             row[str(k)] = rowData[k]
         # Tack on history table information to the row
         row['changed_by'] = changed_by
-        row['timestamp'] = self.getTimestamp()
+        row['timestamp'] = getMillisecondTimestamp()
         return self._insertStatement(**row)
 
     def forUpdate(self, rowData, changed_by):
@@ -586,7 +583,7 @@ class History(AUSTable):
         for k in rowData:
             row[str(k)] = rowData[k]
         row['changed_by'] = changed_by
-        row['timestamp'] = self.getTimestamp()
+        row['timestamp'] = getMillisecondTimestamp()
         return self._insertStatement(**row)
 
     def getChange(self, change_id=None, column_values=None, data_version=None, transaction=None):
@@ -823,7 +820,7 @@ class ScheduledChangeTable(AUSTable):
             except:
                 raise ValueError("Cannot parse 'when' as a unix timestamp.")
 
-            if (conditions["when"] / 1000) < time.time():
+            if conditions["when"] < getMillisecondTimestamp():
                 raise ValueError("Cannot schedule changes in the past")
 
     def insert(self, changed_by, transaction=None, dryrun=False, **columns):

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -935,8 +935,10 @@ class ScheduledChangeTable(AUSTable):
         # updated unnecessarily when the base table's update method calls
         # mergeUpdate. If the base table update fails, this will get reverted
         # when the transaction is rolled back.
-        self.update(where=[self.sc_id == sc_id], what={"complete": True}, changed_by=sc["scheduled_by"], old_data_version=sc["data_version"],
-                    transaction=transaction)
+        super(ScheduledChangeTable, self).update(
+            where=[self.sc_id == sc_id], what={"complete": True}, changed_by=sc["scheduled_by"], old_data_version=sc["data_version"],
+            transaction=transaction
+        )
 
         # If the scheduled change had a data version, it means the row already
         # exists, and we need to use update() to enact it.

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -796,9 +796,8 @@ class TestRuleScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-    @mock.patch("time.time")
-    def testAddScheduledChangeNewRule(self, time):
-        time.return_value = 300
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testAddScheduledChangeNewRule(self):
         data = {
             "when": 1234567, "priority": 120, "backgroundRate": 100, "product": "blah", "channel": "blah",
             "update_type": "minor", "mapping": "a",
@@ -819,9 +818,8 @@ class TestRuleScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-    @mock.patch("time.time")
-    def testAddScheduledChangeInThePast(self, time):
-        time.return_value = 300
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testAddScheduledChangeInThePast(self):
         data = {
             "when": 67, "priority": 120, "backgroundRate": 100, "product": "blah", "channel": "blah",
             "update_type": "minor", "mapping": "a",
@@ -829,9 +827,8 @@ class TestRuleScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 400, ret.data)
 
-    @mock.patch("time.time")
-    def testAddScheduledChangeNoPermissionsToSchedule(self, time):
-        time.return_value = 300
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testAddScheduledChangeNoPermissionsToSchedule(self):
         data = {
             "when": 1234567, "priority": 120, "backgroundRate": 100, "product": "blah", "channel": "blah",
             "update_type": "minor", "mapping": "a",
@@ -839,9 +836,8 @@ class TestRuleScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/rules", data=data, username="bob")
         self.assertEquals(ret.status_code, 403, ret.data)
 
-    @mock.patch("time.time")
-    def testAddScheduledChangeNoPermissionsToMakeChange(self, time):
-        time.return_value = 300
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testAddScheduledChangeNoPermissionsToMakeChange(self):
         data = {
             "when": 1234567, "priority": 120, "backgroundRate": 100, "product": "foo", "channel": "blah",
             "update_type": "minor", "mapping": "a",
@@ -849,9 +845,8 @@ class TestRuleScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/rules", data=data, username="mary")
         self.assertEquals(ret.status_code, 403, ret.data)
 
-    @mock.patch("time.time")
-    def testAddScheduledChangeMultipleConditions(self, time):
-        time.return_value = 300
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testAddScheduledChangeMultipleConditions(self):
         data = {
             "when": 23893254, "telemetry_product": "foo", "telemetry_channel": "foo", "telemetry_uptake": 5,
             "priority": 120, "backgroundRate": 100, "update_type": "minor",
@@ -866,9 +861,8 @@ class TestRuleScheduledChanges(ViewTest):
         ret = self._post("scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 400)
 
-    @mock.patch("time.time")
-    def testUpdateScheduledChange(self, time):
-        time.return_value = 300
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testUpdateScheduledChange(self):
         data = {
             "when": 2000000, "data_version": 1, "rule_id": 1, "priority": 100, "version": "3.5", "buildTarget": "d",
             "backgroundRate": 100, "mapping": "c", "update_type": "minor", "sc_data_version": 1
@@ -888,16 +882,13 @@ class TestRuleScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-    @mock.patch("time.time")
-    def testUpdateScheduledChangeCantRemoveProductWithoutPermission(self, time):
-        time.return_value = 300
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testUpdateScheduledChangeCantRemoveProductWithoutPermission(self):
         data = {"data_version": 1, "product": None, "sc_data_version": 1}
         ret = self._post("/scheduled_changes/rules/2", username="bob", data=data)
         self.assertEquals(ret.status_code, 403, ret.data)
 
-    @mock.patch("time.time")
-    def testUpdateRuleWithMergeError(self, time):
-        time.return_value = 300
+    def testUpdateRuleWithMergeError(self):
         data = {"mapping": "a", "data_version": 1}
         ret = self._post("/rules/1", data=data)
         self.assertEquals(ret.status_code, 400, ret.data)
@@ -987,9 +978,8 @@ class TestRuleScheduledChanges(ViewTest):
         }
         self.assertEquals(json.loads(ret.data), expected)
 
-    @mock.patch("time.time")
-    def testRevertScheduledChange(self, time):
-        time.return_value = 300
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testRevertScheduledChange(self):
         ret = self._post("/scheduled_changes/rules/3/revisions", data={"change_id": 2})
         self.assertEquals(ret.status_code, 200, ret.data)
 

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -660,48 +660,48 @@ class TestRuleScheduledChanges(ViewTest):
     def setUp(self):
         super(TestRuleScheduledChanges, self).setUp()
         dbo.rules.scheduled_changes.t.insert().execute(
-            sc_id=1, when=1000, scheduled_by="bill", data_version=1, base_rule_id=1, base_priority=100, base_version="3.5", base_buildTarget="d",
+            sc_id=1, when=1000000, scheduled_by="bill", data_version=1, base_rule_id=1, base_priority=100, base_version="3.5", base_buildTarget="d",
             base_backgroundRate=100, base_mapping="b", base_update_type="minor", base_data_version=1,
         )
         dbo.rules.scheduled_changes.t.insert().execute(
-            sc_id=2, when=1500, scheduled_by="bill", data_version=1, base_priority=50, base_backgroundRate=100, base_product="baz",
+            sc_id=2, when=1500000, scheduled_by="bill", data_version=1, base_priority=50, base_backgroundRate=100, base_product="baz",
             base_mapping="ab", base_update_type="minor",
         )
         dbo.rules.scheduled_changes.t.insert().execute(
-            sc_id=3, when=2000, scheduled_by="bill", data_version=2, base_priority=150, base_backgroundRate=100, base_product="ff",
+            sc_id=3, when=2000000, scheduled_by="bill", data_version=2, base_priority=150, base_backgroundRate=100, base_product="ff",
             base_mapping="ghi", base_update_type="minor",
         )
         dbo.rules.scheduled_changes.t.insert().execute(
-            sc_id=4, when=500, scheduled_by="bill", data_version=2, complete=True, base_rule_id=5, base_priority=80, base_version="3.3",
+            sc_id=4, when=500000, scheduled_by="bill", data_version=2, complete=True, base_rule_id=5, base_priority=80, base_version="3.3",
             base_buildTarget="d", base_backgroundRate=0, base_mapping="c", base_update_type="minor", base_data_version=1,
         )
         dbo.rules.scheduled_changes.history.t.insert().execute(
             change_id=1, changed_by="bill", timestamp=5, sc_id=3
         )
         dbo.rules.scheduled_changes.history.t.insert().execute(
-            change_id=2, changed_by="bill", timestamp=6, sc_id=3, scheduled_by="bill", when=2000, data_version=1, base_priority=150,
+            change_id=2, changed_by="bill", timestamp=6, sc_id=3, scheduled_by="bill", when=2000000, data_version=1, base_priority=150,
             base_backgroundRate=100, base_product="ff", base_mapping="def", base_update_type="minor",
         )
         dbo.rules.scheduled_changes.history.t.insert().execute(
-            change_id=3, changed_by="bill", timestamp=10, sc_id=3, scheduled_by="bill", when=2000, data_version=2, base_priority=150,
+            change_id=3, changed_by="bill", timestamp=10, sc_id=3, scheduled_by="bill", when=2000000, data_version=2, base_priority=150,
             base_backgroundRate=100, base_product="ff", base_mapping="ghi", base_update_type="minor",
         )
         dbo.rules.scheduled_changes.history.t.insert().execute(
             change_id=4, changed_by="bill", timestamp=15, sc_id=2
         )
         dbo.rules.scheduled_changes.history.t.insert().execute(
-            change_id=5, changed_by="bill", timestamp=16, sc_id=2, when=1500, scheduled_by="bill", data_version=1, base_priority=50,
+            change_id=5, changed_by="bill", timestamp=16, sc_id=2, when=1500000, scheduled_by="bill", data_version=1, base_priority=50,
             base_backgroundRate=100, base_product="baz", base_mapping="ab", base_update_type="minor"
         )
         dbo.rules.scheduled_changes.history.t.insert().execute(
             change_id=6, changed_by="bill", timestamp=5, sc_id=4
         )
         dbo.rules.scheduled_changes.history.t.insert().execute(
-            change_id=7, changed_by="bill", timestamp=6, sc_id=4, scheduled_by="bill", when=500, data_version=1, base_priority=80,
+            change_id=7, changed_by="bill", timestamp=6, sc_id=4, scheduled_by="bill", when=500000, data_version=1, base_priority=80,
             base_version="3.3", base_buildTarget="d", base_backgroundRate=0, base_mapping="c", base_update_type="minor", base_data_version=1
         )
         dbo.rules.scheduled_changes.history.t.insert().execute(
-            change_id=8, changed_by="bill", timestamp=7, sc_id=4, scheduled_by="bill", when=500, data_version=2, complete=True, base_rule_id=5,
+            change_id=8, changed_by="bill", timestamp=7, sc_id=4, scheduled_by="bill", when=500000, data_version=2, complete=True, base_rule_id=5,
             base_priority=80, base_version="3.3", base_buildTarget="d", base_backgroundRate=0, base_mapping="c", base_update_type="minor", base_data_version=1
         )
 
@@ -711,21 +711,21 @@ class TestRuleScheduledChanges(ViewTest):
             "count": 3,
             "scheduled_changes": [
                 {
-                    "sc_id": 1, "when": 1000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 1, "priority": 100,
+                    "sc_id": 1, "when": 1000000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 1, "priority": 100,
                     "version": "3.5", "buildTarget": "d", "backgroundRate": 100, "mapping": "b", "update_type": "minor",
                     "data_version": 1, "alias": None, "product": None, "channel": None, "buildID": None, "locale": None,
                     "osVersion": None, "distribution": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "whitelist": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                 },
                 {
-                    "sc_id": 2, "when": 1500, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
+                    "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
                     "backgroundRate": 100, "product": "baz", "mapping": "ab", "update_type": "minor", "version": None,
                     "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None,
                     "distribution": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
                     "data_version": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                 },
                 {
-                    "sc_id": 3, "when": 2000, "scheduled_by": "bill", "complete": False, "sc_data_version": 2, "rule_id": None, "priority": 150,
+                    "sc_id": 3, "when": 2000000, "scheduled_by": "bill", "complete": False, "sc_data_version": 2, "rule_id": None, "priority": 150,
                     "backgroundRate": 100, "product": "ff", "mapping": "ghi", "update_type": "minor", "version": None,
                     "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None,
                     "distribution": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
@@ -741,28 +741,28 @@ class TestRuleScheduledChanges(ViewTest):
             "count": 4,
             "scheduled_changes": [
                 {
-                    "sc_id": 1, "when": 1000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 1, "priority": 100,
+                    "sc_id": 1, "when": 1000000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 1, "priority": 100,
                     "version": "3.5", "buildTarget": "d", "backgroundRate": 100, "mapping": "b", "update_type": "minor",
                     "data_version": 1, "alias": None, "product": None, "channel": None, "buildID": None, "locale": None,
                     "osVersion": None, "distribution": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "whitelist": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                 },
                 {
-                    "sc_id": 2, "when": 1500, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
+                    "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
                     "backgroundRate": 100, "product": "baz", "mapping": "ab", "update_type": "minor", "version": None,
                     "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None,
                     "distribution": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
                     "data_version": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                 },
                 {
-                    "sc_id": 3, "when": 2000, "scheduled_by": "bill", "complete": False, "sc_data_version": 2, "rule_id": None, "priority": 150,
+                    "sc_id": 3, "when": 2000000, "scheduled_by": "bill", "complete": False, "sc_data_version": 2, "rule_id": None, "priority": 150,
                     "backgroundRate": 100, "product": "ff", "mapping": "ghi", "update_type": "minor", "version": None,
                     "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None,
                     "distribution": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
                     "data_version": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                 },
                 {
-                    "sc_id": 4, "when": 500, "scheduled_by": "bill", "complete": True, "sc_data_version": 2, "rule_id": 5, "priority": 80,
+                    "sc_id": 4, "when": 500000, "scheduled_by": "bill", "complete": True, "sc_data_version": 2, "rule_id": 5, "priority": 80,
                     "version": "3.3", "buildTarget": "d", "backgroundRate": 0, "mapping": "c", "update_type": "minor",
                     "data_version": 1, "alias": None, "product": None, "channel": None, "buildID": None, "locale": None,
                     "osVersion": None, "distribution": None, "distVersion": None, "headerArchitecture": None, "comment": None,
@@ -818,6 +818,16 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(db_data, expected)
 
     @mock.patch("time.time")
+    def testAddScheduledChangeInThePast(self, time):
+        time.return_value = 300
+        data = {
+            "when": 67, "priority": 120, "backgroundRate": 100, "product": "blah", "channel": "blah",
+            "update_type": "minor", "mapping": "a",
+        }
+        ret = self._post("/scheduled_changes/rules", data=data)
+        self.assertEquals(ret.status_code, 400, ret.data)
+
+    @mock.patch("time.time")
     def testAddScheduledChangeNoPermissionsToSchedule(self, time):
         time.return_value = 300
         data = {
@@ -858,7 +868,7 @@ class TestRuleScheduledChanges(ViewTest):
     def testUpdateScheduledChange(self, time):
         time.return_value = 300
         data = {
-            "when": 2000, "data_version": 1, "rule_id": 1, "priority": 100, "version": "3.5", "buildTarget": "d",
+            "when": 2000000, "data_version": 1, "rule_id": 1, "priority": 100, "version": "3.5", "buildTarget": "d",
             "backgroundRate": 100, "mapping": "c", "update_type": "minor", "sc_data_version": 1
         }
         ret = self._post("/scheduled_changes/rules/1", data=data)
@@ -868,7 +878,7 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
-            "sc_id": 1, "when": 2000, "scheduled_by": "bill", "data_version": 2, "complete": False, "base_rule_id": 1, "base_priority": 100,
+            "sc_id": 1, "when": 2000000, "scheduled_by": "bill", "data_version": 2, "complete": False, "base_rule_id": 1, "base_priority": 100,
             "base_version": "3.5", "base_buildTarget": "d", "base_backgroundRate": 100, "base_mapping": "c", "base_update_type": "minor",
             "base_data_version": 1, "base_alias": None, "base_product": None, "base_channel": None, "base_buildID": None, "base_locale": None,
             "base_osVersion": None, "base_distribution": None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None,
@@ -956,7 +966,7 @@ class TestRuleScheduledChanges(ViewTest):
             "count": 2,
             "revisions": [
                 {
-                    "change_id": 2, "changed_by": "bill", "timestamp": 6, "sc_id": 3, "scheduled_by": "bill", "when": 2000, "sc_data_version": 1,
+                    "change_id": 2, "changed_by": "bill", "timestamp": 6, "sc_id": 3, "scheduled_by": "bill", "when": 2000000, "sc_data_version": 1,
                     "priority": 150, "backgroundRate": 100, "product": "ff", "mapping": "def", "update_type": "minor",
                     "complete": False, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "rule_id": None,
                     "version": None, "channel": None, "buildTarget": None, "buildID": None, "locale": None,
@@ -964,7 +974,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "headerArchitecture": None, "comment": None, "whitelist": None, "alias": None, "data_version": None,
                 },
                 {
-                    "change_id": 3, "changed_by": "bill", "timestamp": 10, "sc_id": 3, "scheduled_by": "bill", "when": 2000, "sc_data_version": 2,
+                    "change_id": 3, "changed_by": "bill", "timestamp": 10, "sc_id": 3, "scheduled_by": "bill", "when": 2000000, "sc_data_version": 2,
                     "priority": 150, "backgroundRate": 100, "product": "ff", "mapping": "ghi", "update_type": "minor",
                     "complete": False, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "rule_id": None,
                     "version": None, "channel": None, "buildTarget": None, "buildID": None, "locale": None,
@@ -984,7 +994,7 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(dbo.rules.scheduled_changes.history.t.count().execute().first()[0], 9)
         got = dbo.rules.scheduled_changes.select({"sc_id": 3})[0]
         expected = {
-            "sc_id": 3, "when": 2000, "scheduled_by": "bill", "complete": False, "data_version": 3, "base_rule_id": None, "base_priority": 150,
+            "sc_id": 3, "when": 2000000, "scheduled_by": "bill", "complete": False, "data_version": 3, "base_rule_id": None, "base_priority": 150,
             "base_backgroundRate": 100, "base_product": "ff", "base_mapping": "def", "base_update_type": "minor", "base_version": None,
             "base_buildTarget": None, "base_alias": None, "base_channel": None, "base_buildID": None, "base_locale": None, "base_osVersion": None,
             "base_distribution": None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None, "base_whitelist": None,

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1,4 +1,5 @@
 import json
+import mock
 
 from auslib.global_state import dbo
 from auslib.test.admin.views.base import ViewTest
@@ -793,7 +794,9 @@ class TestRuleScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-    def testAddScheduledChangeNewRule(self):
+    @mock.patch("time.time")
+    def testAddScheduledChangeNewRule(self, time):
+        time.return_value = 300
         data = {
             "when": 1234567, "priority": 120, "backgroundRate": 100, "product": "blah", "channel": "blah",
             "update_type": "minor", "mapping": "a",
@@ -814,7 +817,9 @@ class TestRuleScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-    def testAddScheduledChangeNoPermissionsToSchedule(self):
+    @mock.patch("time.time")
+    def testAddScheduledChangeNoPermissionsToSchedule(self, time):
+        time.return_value = 300
         data = {
             "when": 1234567, "priority": 120, "backgroundRate": 100, "product": "blah", "channel": "blah",
             "update_type": "minor", "mapping": "a",
@@ -822,7 +827,9 @@ class TestRuleScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/rules", data=data, username="bob")
         self.assertEquals(ret.status_code, 403, ret.data)
 
-    def testAddScheduledChangeNoPermissionsToMakeChange(self):
+    @mock.patch("time.time")
+    def testAddScheduledChangeNoPermissionsToMakeChange(self, time):
+        time.return_value = 300
         data = {
             "when": 1234567, "priority": 120, "backgroundRate": 100, "product": "foo", "channel": "blah",
             "update_type": "minor", "mapping": "a",
@@ -830,7 +837,9 @@ class TestRuleScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/rules", data=data, username="mary")
         self.assertEquals(ret.status_code, 403, ret.data)
 
-    def testAddScheduledChangeMultipleConditions(self):
+    @mock.patch("time.time")
+    def testAddScheduledChangeMultipleConditions(self, time):
+        time.return_value = 300
         data = {
             "when": 23893254, "telemetry_product": "foo", "telemetry_channel": "foo", "telemetry_uptake": 5,
             "priority": 120, "backgroundRate": 100, "update_type": "minor",
@@ -845,7 +854,9 @@ class TestRuleScheduledChanges(ViewTest):
         ret = self._post("scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 400)
 
-    def testUpdateScheduledChange(self):
+    @mock.patch("time.time")
+    def testUpdateScheduledChange(self, time):
+        time.return_value = 300
         data = {
             "when": 2000, "data_version": 1, "rule_id": 1, "priority": 100, "version": "3.5", "buildTarget": "d",
             "backgroundRate": 100, "mapping": "c", "update_type": "minor", "sc_data_version": 1
@@ -865,12 +876,16 @@ class TestRuleScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-    def testUpdateScheduledChangeCantRemoveProductWithoutPermission(self):
+    @mock.patch("time.time")
+    def testUpdateScheduledChangeCantRemoveProductWithoutPermission(self, time):
+        time.return_value = 300
         data = {"data_version": 1, "product": None, "sc_data_version": 1}
         ret = self._post("/scheduled_changes/rules/2", username="bob", data=data)
         self.assertEquals(ret.status_code, 403, ret.data)
 
-    def testUpdateRuleWithMergeError(self):
+    @mock.patch("time.time")
+    def testUpdateRuleWithMergeError(self, time):
+        time.return_value = 300
         data = {"mapping": "a", "data_version": 1}
         ret = self._post("/rules/1", data=data)
         self.assertEquals(ret.status_code, 400, ret.data)
@@ -960,7 +975,9 @@ class TestRuleScheduledChanges(ViewTest):
         }
         self.assertEquals(json.loads(ret.data), expected)
 
-    def testRevertScheduledChange(self):
+    @mock.patch("time.time")
+    def testRevertScheduledChange(self, time):
+        time.return_value = 300
         ret = self._post("/scheduled_changes/rules/3/revisions", data={"change_id": 2})
         self.assertEquals(ret.status_code, 200, ret.data)
 

--- a/auslib/util/timestamp.py
+++ b/auslib/util/timestamp.py
@@ -1,0 +1,6 @@
+import time
+
+
+def getMillisecondTimestamp():
+    t = int(time.time() * 1000)
+    return t


### PR DESCRIPTION
This turned out to be pretty simple, just a couple of notable things:
* I had to adjust most of the new tests to simulate millisecond-precision timestamps instead of second-precision ones. This is annoying, but makes sense because all "when" timestamps we receive (either coming out of the database, or from the API) are assumed to be to-the-millisecond.
* I changed enactChange to call AUSTable.update directly instead of using ScheduledChangeTable.update. The latter has two value-adds: base table column renaming, and condition validation - but neither of them are relevant to marking changes as complete.

If you want to test this with the UI you can apply that PR and comment out the if block here: https://github.com/mozilla/balrog-ui/pull/30/files#diff-65e9079076aadc61faf96f00687e1364R36