### PR TITLE
Bug 1303057 - docker-compose up should build ui

### DIFF
--- a/uwsgi/run.sh
+++ b/uwsgi/run.sh
@@ -2,6 +2,7 @@
 
 build_front_end() {
     cd /app/ui
+    npm install
     npm run build
     cd -
 }


### PR DESCRIPTION
The ownership is still not fixed yet by this PR. I'm not too familiar with the user namespace model of Docker. I tried to add `user: $UID` in `docker-compose.yml` [1]. It should pass --user to docker-run[2]. But I didn't manage to make it work. 

[1] https://docs.docker.com/compose/compose-file/#/cpu-shares-cpu-quota-cpuset-domainname-hostname-ipc-mac-address-mem-limit-memswap-limit-privileged-read-only-restart-shm-size-stdin-open-tty-user-working-dir and docker/compose#1532
[2] https://docs.docker.com/engine/reference/run/#/user