### PR TITLE
Remove whitelist checks from desupport blobs.

### DIFF
--- a/auslib/blobs/apprelease.py
+++ b/auslib/blobs/apprelease.py
@@ -769,6 +769,6 @@ class DesupportBlob(Blob):
         return '</update>'
 
     def containsForbiddenDomain(self, product, whitelistedDomains):
-        if isForbiddenUrl(self.get('detailsUrl', None), product, whitelistedDomains):
-            return True
+        # Although DesupportBlob contains a domain (detailsUrl), that attribute
+        # is not used to deliver binaries, so it is exempt from whitelist checks.
         return False

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -1853,29 +1853,3 @@ class TestDesupportBlob(unittest.TestCase):
         blob = DesupportBlob(name="d2", schema_version=50, foo="bar")
         self.assertRaises(BlobValidationError, blob.validate, 'd',
                           self.whitelistedDomains)
-
-    def testDesupportDoesntContainForbiddenDomain(self):
-        blob = DesupportBlob()
-        blob.loadJSON("""
-{
-    "name": "d1",
-    "schema_version": 50,
-    "detailsUrl": "http://moo.com/%LOCALE%/cow/%VERSION%/",
-    "displayVersion": "50.0"
-}
-""")
-        self.assertFalse(blob.containsForbiddenDomain('d',
-                                                      self.whitelistedDomains))
-
-    def testDesupportContainsForbiddenDomain(self):
-        blob = DesupportBlob()
-        blob.loadJSON("""
-{
-    "name": "d1",
-    "schema_version": 50,
-    "detailsUrl": "http://boo.com/%LOCALE%/cow/%VERSION%/",
-    "displayVersion": "50.0"
-}
-""")
-        self.assertTrue(blob.containsForbiddenDomain('d',
-                                                     self.whitelistedDomains))


### PR DESCRIPTION
While testing https://bugzilla.mozilla.org/show_bug.cgi?id=1270827 I realized that we're requiring the detailsUrl of DesupportBlob to be in the domain whitelist. This is probably not desired, as detailsUrl doesn't deliver binaries, and adding domains like support.mozilla.org to it would mean adding them to "Firefox"'s whitelist, which could open up an attack vector.

This is my bad, I failed to catch this while reviewing https://bugzilla.mozilla.org/show_bug.cgi?id=1041584. I'll try to get a fix in today's push, as the current state of things means that we're not delivering any responses to desupported users at the moment.

@nurav - can you sanity check this?