### PR TITLE
Add a horrible hack to greatly reduce CPU usage of balrogui container.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,7 @@ balrogui:
     - WEB_PORT=8080
   entrypoint:
     - /bin/bash
-    - -c
-    - cd /app && /usr/local/bin/npm install && /usr/local/bin/npm build && /usr/local/bin/npm start
+    - /app/docker-entrypoint.sh
 
 balrogdb:
   image: mysql:5.7

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd /app
+/usr/local/bin/npm install
+# The container we run npm/lineman in uses up a lot of CPU by default, and appears to be
+# related to all the polling of files that lineman/grunt does. We haven't been able to
+# fully track it down, but jlorenzo discovered that adjusting this setInterval has made a
+# huge difference without affecting the responsiveness of the UI rebuilding.
+# This really needs a deeper investigation, and a more robust fix.
+sed -i -e 's/200/10000/' /app/node_modules/lineman/node_modules/grunt-watch-nospawn/tasks/watch.js
+/usr/local/bin/npm build
+/usr/local/bin/npm start


### PR DESCRIPTION
I'm pretty sure the root cause of this problem is as described in https://github.com/gruntjs/grunt-contrib-watch/issues/429#issuecomment-216011305 and https://github.com/docker/for-mac/issues/82#issuecomment-247563198 (basically: monitoring a bunch of files for changes inefficiently), but @JohanLorenzo and I couldn't come up with a proper fix.

Please forgive me for this horrible hack.