### PR TITLE
Copy in requirements files early again

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -22,9 +22,6 @@ WORKDIR /app
 # The general app requirements and packages required to run Tox are installed into the system.
 # We copy them in early to avoid re-installing them unless absolutely necessary.
 COPY requirements.txt requirements-tox.txt /app/
-# install the requirements into the container first
-# these rarely change and is more cache friendly
-# ... really speeds up building new containers
 RUN pip install -r requirements.txt
 RUN pip install -r requirements-tox.txt
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,15 +19,21 @@ RUN apt-get -q update \
 
 WORKDIR /app
 
-# The general app requirements and packages required to run Tox are installed into the system,
-# so we need to include them as part of the Docker build.
-# TODO: edit this comment
-COPY ./ /app/
+# The general app requirements and packages required to run Tox are installed into the system.
+# We copy them in early to avoid re-installing them unless absolutely necessary.
+COPY requirements.txt requirements-tox.txt /app/
 # install the requirements into the container first
 # these rarely change and is more cache friendly
 # ... really speeds up building new containers
 RUN pip install -r requirements.txt
 RUN pip install -r requirements-tox.txt
+
+COPY aus-data-snapshots/ /app/aus-data-snapshots/
+COPY auslib/ /app/auslib/
+COPY ui/ /app/ui/
+COPY scripts/ /app/scripts/
+COPY uwsgi/ /app/uwsgi/
+COPY MANIFEST.in requirements-test.txt setup.py tox.ini version.json version.txt /app/
 
 # Using /bin/bash as the entrypoint works around some volume mount issues on Windows
 # where volume-mounted files do not have execute bits set.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,6 +3,6 @@
 # TODO: When we can run docker-compose in Taskcluster, we should use
 # docker-compose-test.yml instead of running docker directly.
 docker build  -t balrogtest -f Dockerfile.dev .
-# Using a volume mount here ensures that the tox cache dir ends up on the host,
-# which avoids re-installing test dependencies every single time.
+# We can't use a volume mount here because this script is used for local
+# tests as well as CI, and Taskcluster doesn't support volume mounts.
 docker run --rm balrogtest test $@


### PR DESCRIPTION
@JohanLorenzo - I seem to recall that we added the COPY ./ /app/ because we couldn't volume mount in run-tests.sh. However, I noticed that we end up reinstalling dependencies a lot by not doing the requirements files first. This should have the same pratcial effect of of the COPY ./, except be more cache friendly.