### PR TITLE
fix issues with change notifier in production

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,7 +30,7 @@ COPY auslib/ /app/auslib/
 COPY ui/ /app/ui/
 COPY scripts/ /app/scripts/
 COPY uwsgi/ /app/uwsgi/
-COPY MANIFEST.in requirements-test.txt setup.py tox.ini version.json version.txt /app/
+COPY .coveragerc MANIFEST.in requirements-test.txt setup.py tox.ini version.json version.txt /app/
 
 # Using /bin/bash as the entrypoint works around some volume mount issues on Windows
 # where volume-mounted files do not have execute bits set.

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1848,12 +1848,12 @@ def make_change_notifier_for_read_only(relayhost, port, username, password, to_a
                 data['product'] = UnquotedStr(repr(row['product']))
                 data['read_only'] = UnquotedStr("%s ---> %s" %
                                                 (repr(row['read_only']),
-                                                repr(query.parameters['read_only'])))
+                                                 repr(query.parameters['read_only'])))
                 body.append(UTF8PrettyPrinter().pformat(data))
 
                 subj = "Read only release %s changed to modifiable" % data['name']
                 send_email(relayhost, port, username, password, to_addr, from_addr,
-                        table, subj, body, tls)
+                           table, subj, body, tls)
                 table.log.debug("Sending change notification mail for %s to %s", table.t.name, to_addr)
     return bleet
 

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -43,13 +43,17 @@ cache.make_cache("blob_schema", 50, 24 * 60 * 60)
 
 dbo.setDb(os.environ["DBURI"])
 if os.environ.get("NOTIFY_TO_ADDR"):
+    tls = False
+    if os.environ.get("SMTP_TLS"):
+        tls = True
     dbo.setupChangeMonitors(
         os.environ["SMTP_HOST"],
         os.environ["SMTP_PORT"],
         os.environ.get("SMTP_USERNAME"),
         os.environ.get("SMTP_PASSWORD"),
         os.environ["NOTIFY_TO_ADDR"],
-        os.environ["NOTIFY_FROM_ADDR"]
+        os.environ["NOTIFY_FROM_ADDR"],
+        tls,
     )
 dbo.setDomainWhitelist(DOMAIN_WHITELIST)
 application.config["WHITELISTED_DOMAINS"] = DOMAIN_WHITELIST

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -43,9 +43,9 @@ cache.make_cache("blob_schema", 50, 24 * 60 * 60)
 
 dbo.setDb(os.environ["DBURI"])
 if os.environ.get("NOTIFY_TO_ADDR"):
-    tls = False
+    use_tls = False
     if os.environ.get("SMTP_TLS"):
-        tls = True
+        use_tls = True
     dbo.setupChangeMonitors(
         os.environ["SMTP_HOST"],
         os.environ["SMTP_PORT"],
@@ -53,7 +53,7 @@ if os.environ.get("NOTIFY_TO_ADDR"):
         os.environ.get("SMTP_PASSWORD"),
         os.environ["NOTIFY_TO_ADDR"],
         os.environ["NOTIFY_FROM_ADDR"],
-        tls,
+        use_tls,
     )
 dbo.setDomainWhitelist(DOMAIN_WHITELIST)
 application.config["WHITELISTED_DOMAINS"] = DOMAIN_WHITELIST


### PR DESCRIPTION
This should fix the two issues we found in https://bugzilla.mozilla.org/show_bug.cgi?id=1304082:
1) Production uses a local MTA, so we need to be able to disable tls.
2) We sometimes (or maybe always) get IndexErrors when the read only change notifier fires. I haven't been able to reproduce this, so I just added a guard against it with a comment for now.

I also noticed that the recent Dockerfile changes caused us to start including .tox/ in coverage reports, so I fixed that.