### PR TITLE
Use volume mount when running tests in local dev, but not in Taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -10,6 +10,8 @@ tasks:
     payload:
       maxRunTime: 1200
       image: "rail/python-test-runner"
+      env:
+        NO_VOLUME_MOUNT: 1
       command:
         - "/bin/bash"
         - "-c"
@@ -33,6 +35,8 @@ tasks:
     payload:
       maxRunTime: 1200
       image: "rail/python-test-runner"
+      env:
+        NO_VOLUME_MOUNT: 1
       command:
         - "/bin/bash"
         - "-c"
@@ -84,6 +88,8 @@ tasks:
     payload:
       maxRunTime: 1200
       image: "rail/python-test-runner"
+      env:
+        NO_VOLUME_MOUNT: 1
       command:
         - "/bin/bash"
         - "-c"

--- a/agent/run-tests.sh
+++ b/agent/run-tests.sh
@@ -3,4 +3,13 @@
 # TODO: When we can run docker-compose in Taskcluster, we should use
 # docker-compose-test.yml instead of running docker directly.
 docker build --pull -t balrogagenttest .
-docker run --entrypoint /app/scripts/test-entrypoint.sh balrogagenttest
+# We can't use a volume mount in Taskcluster, but we do want to use it
+# by default for local development, because it greatly speeds up repeated
+# test runs.
+if [ -n "${NO_VOLUME_MOUNT}" ]; then
+    echo "Running tests without volume mount"
+    docker run --entrypoint /app/scripts/test-entrypoint.sh --rm balrogagenttest
+else
+    echo "Running tests with volume mount"
+    docker run --entrypoint /app/scripts/test-entrypoint.sh --rm -v `pwd`:/app balrogagenttest
+fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,6 +3,13 @@
 # TODO: When we can run docker-compose in Taskcluster, we should use
 # docker-compose-test.yml instead of running docker directly.
 docker build  -t balrogtest -f Dockerfile.dev .
-# We can't use a volume mount here because this script is used for local
-# tests as well as CI, and Taskcluster doesn't support volume mounts.
-docker run --rm balrogtest test $@
+# We can't use a volume mount in Taskcluster, but we do want to use it
+# by default for local development, because it greatly speeds up repeated
+# test runs.
+if [ -n "${NO_VOLUME_MOUNT}" ]; then
+    echo "Running tests without volume mount"
+    docker run --rm balrogtest test $@
+else
+    echo "Running tests with volume mount"
+    docker run --rm -v `pwd`:/app balrogtest test $@
+fi


### PR DESCRIPTION
We tried to enable a volume mount for local tests in #131, but got foiled by Taskcluster not supporting it. I realized today that we can still do this as long as we have a way to disable it for Taskcluster.