### PR TITLE
Add extract command to run.sh

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -45,6 +45,12 @@ elif [ $1 == "cleanup-db" ]; then
     fi
 
     exec scripts/run-batch-deletes.sh $DBURI $MAX_AGE $DELETE_RUN_TIME
+elif [ $1 == "extract-active-data" ]; then
+    if [ -z "${DBURI}" ]; then
+        echo "\${DBURI} must be set!"
+        exit 1
+    fi
+    exec python scripts/manage-db.py -d ${DBURI} extract ${OUTPUT_FILE}
 elif [ $1 == "test" ]; then
     shift
     if [[ $1 == "backend" ]]; then


### PR DESCRIPTION
This command was added to manage-db.py in #139, but in order to run it in production we need to make it accessible through the default entrypoint (run.sh). I tested this with and without OUTPUT_FILE set, and it correctly uses the default (dump.sql) when it is unset.

@JohanLorenzo - can you have a look?