### PR TITLE
[client_view] Non-substituted url variables return empty response

### DIFF
--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -865,6 +865,24 @@ class ClientTest(ClientTestBase):
         ret = self.client.get('/update/3/product_that_should_not_be_updated/1.0/1/p/l/a/a/a/a/update.xml')
         self.assertUpdatesAreEmpty(ret)
 
+    def testNonSubstitutedUrlVariablesReturn404(self):
+        request1 = '/update/1/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/update.xml'
+        request2 = '/update/2/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/update.xml'
+        request3 = '/update/3/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/' \
+            'update.xml'
+        request4 = '/update/4/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/' \
+            '%MOZ_VERSION%/update.xml'
+        request5 = '/update/5/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/' \
+            '%IMEI%/update.xml'
+        request6 = '/update/6/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%SYSTEM_CAPABILITIES%/%DISTRIBUTION%/' \
+            '%DISTRIBUTION_VERSION%/update.xml'
+
+        with mock.patch('auslib.web.views.client.ClientRequestView') as mock_cr_view:
+            for request in [request1, request2, request3, request4, request5, request6]:
+                ret = self.client.get(request)
+                self.assertEqual(ret.status_code, 404)
+                self.assertFalse(mock_cr_view.called)
+
 
 class ClientTestWithErrorHandlers(ClientTestCommon):
     """Most of the tests are run without the error handler because it gives more
@@ -916,3 +934,21 @@ class ClientTestWithErrorHandlers(ClientTestCommon):
             with mock.patch("auslib.web.base.sentry") as sentry:
                 self.client.get("/update/4/b/1.0/1/p/l/a/a/a/a/1/update.xml")
                 self.assertTrue(sentry.captureException.called)
+
+    def testNonSubstitutedUrlVariablesReturnEmptyUpdate(self):
+        request1 = '/update/1/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/update.xml'
+        request2 = '/update/2/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/update.xml'
+        request3 = '/update/3/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/' \
+            'update.xml'
+        request4 = '/update/4/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/' \
+            '%MOZ_VERSION%/update.xml'
+        request5 = '/update/5/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/' \
+            '%IMEI%/update.xml'
+        request6 = '/update/6/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%SYSTEM_CAPABILITIES%/%DISTRIBUTION%/' \
+            '%DISTRIBUTION_VERSION%/update.xml'
+
+        with mock.patch('auslib.web.views.client.ClientRequestView') as mock_cr_view:
+            for request in [request1, request2, request3, request4, request5, request6]:
+                ret = self.client.get(request)
+                self.assertUpdatesAreEmpty(ret)
+                self.assertFalse(mock_cr_view.called)

--- a/auslib/web/base.py
+++ b/auslib/web/base.py
@@ -1,7 +1,7 @@
 import logging
 log = logging.getLogger(__name__)
 
-from flask import Flask, make_response, send_from_directory, request
+from flask import Flask, make_response, send_from_directory, request, abort
 
 from raven.contrib.flask import Sentry
 
@@ -61,6 +61,19 @@ def generic(error):
 @app.route('/robots.txt')
 def robots():
     return send_from_directory(app.static_folder, "robots.txt")
+
+
+@app.route('/update/1/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/update.xml')
+@app.route('/update/2/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/update.xml')
+@app.route('/update/3/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/update.xml')
+@app.route('/update/4/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/%MOZ_VERSION%'
+           '/update.xml')
+@app.route('/update/5/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/%IMEI%/update.xml')
+@app.route('/update/6/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%SYSTEM_CAPABILITIES%/%DISTRIBUTION%'
+           '/%DISTRIBUTION_VERSION%/update.xml')
+def unsubstituted_url_variables():
+    abort(404)
+
 
 # The "main" routes. 99% of requests will come in through these.
 app.add_url_rule(

--- a/auslib/web/views/client.py
+++ b/auslib/web/views/client.py
@@ -54,6 +54,7 @@ class ClientRequestView(MethodView):
         query = self.getQueryFromURL(url)
         self.log.debug("Got query: %s", query)
         release, update_type = AUS.evaluateRules(query)
+
         # passing {},None returns empty xml
         if release:
             response_products = release.getResponseProducts()


### PR DESCRIPTION
We get tens of thousands of requests per day that don't substitute
the URL variables. A route has been added that quickly returns an
empty response for these. There's no reason query the rules table,
 we'll never find anything useful in there.

Fixes bug #1282569