### PR TITLE
Add UserRoles table + apis

### DIFF
--- a/auslib/admin/base.py
+++ b/auslib/admin/base.py
@@ -13,7 +13,7 @@ sentry = Sentry()
 
 from auslib.admin.views.csrf import CSRFView
 from auslib.admin.views.permissions import UsersView, PermissionsView, \
-    SpecificPermissionView
+    SpecificPermissionView, UserRolesView, UserRoleView
 from auslib.admin.views.releases import SingleLocaleView, \
     SingleReleaseView, ReleaseHistoryView, \
     ReleasesAPIView, SingleReleaseColumnView, ReleaseReadOnlyView
@@ -70,6 +70,8 @@ app.add_url_rule("/csrf_token", view_func=CSRFView.as_view("csrf"))
 app.add_url_rule("/users", view_func=UsersView.as_view("users"))
 app.add_url_rule("/users/<username>/permissions", view_func=PermissionsView.as_view("user_permissions"))
 app.add_url_rule("/users/<username>/permissions/<permission>", view_func=SpecificPermissionView.as_view("specific_permission"))
+app.add_url_rule("/users/<username>/roles", view_func=UserRolesView.as_view("user_roles"))
+app.add_url_rule("/users/<username>/roles/<role>", view_func=UserRoleView.as_view("user_role"))
 app.add_url_rule("/rules", view_func=RulesAPIView.as_view("rules"))
 # Normal operations (get/update/delete) on rules can be done by id or alias...
 app.add_url_rule("/rules/<id_or_alias>", view_func=SingleRuleView.as_view("rule"))

--- a/auslib/admin/views/permissions.py
+++ b/auslib/admin/views/permissions.py
@@ -113,6 +113,9 @@ class UserRoleView(AdminView):
 
     @requirelogin
     def _put(self, username, role, changed_by, transaction):
+        # These requests are idempotent - if the user already has the desired role,
+        # no change needs to be made. Because of this there's also no reason to
+        # return an error.
         r = dbo.permissions.user_roles.select({"username": username, "role": role}, transaction=transaction)
         if r:
             return Response(status=200, response=json.dumps({"new_data_version": r[0]["data_version"]}))

--- a/auslib/admin/views/permissions.py
+++ b/auslib/admin/views/permissions.py
@@ -4,7 +4,7 @@ from flask import request, Response, jsonify
 
 from auslib.global_state import dbo
 from auslib.admin.views.base import requirelogin, AdminView
-from auslib.admin.views.forms import NewPermissionForm, ExistingPermissionForm
+from auslib.admin.views.forms import NewPermissionForm, ExistingPermissionForm, DbEditableForm
 
 __all__ = ["UsersView", "PermissionsView", "SpecificPermissionView"]
 
@@ -95,3 +95,41 @@ class SpecificPermissionView(AdminView):
         except ValueError as e:
             self.log.warning("Bad input: %s", e.args)
             return Response(status=400, response=e.args)
+
+
+class UserRolesView(AdminView):
+    """/users/:username/roles"""
+
+    def get(self, username):
+        roles = dbo.permissions.user_roles.getRoles(username)
+        if roles:
+            return jsonify({"roles": roles})
+        else:
+            return Response(status=404, response="No roles found for user")
+
+
+class UserRoleView(AdminView):
+    """/users/:username/roles/:role"""
+
+    @requirelogin
+    def _put(self, username, role, changed_by, transaction):
+        r = dbo.permissions.user_roles.select({"username": username, "role": role}, transaction=transaction)
+        if r:
+            return Response(status=200, response=json.dumps({"new_data_version": r[0]["data_version"]}))
+
+        dbo.permissions.user_roles.insert(changed_by, transaction, username=username, role=role)
+        return Response(status=201, response=json.dumps({"new_data_version": 1}))
+
+    @requirelogin
+    def _delete(self, username, role, changed_by, transaction):
+        if role not in dbo.permissions.user_roles.getRoles(username):
+            return Response(status=404)
+
+        form = DbEditableForm(request.args)
+        if not form.validate():
+            self.log.warning("Bad input: %s", form.errors)
+            return Response(status=400, response=json.dumps(form.errors))
+
+        dbo.permissions.user_roles.delete(where={"username": username, "role": role}, changed_by=changed_by,
+                                          old_data_version=form.data_version.data, transaction=transaction)
+        return Response(status=200)

--- a/auslib/migrate/versions/016_add_user_roles.py
+++ b/auslib/migrate/versions/016_add_user_roles.py
@@ -1,0 +1,30 @@
+from sqlalchemy import Table, Column, Integer, String, MetaData, \
+    BigInteger
+
+metadata = MetaData()
+
+user_roles = Table(
+    "user_roles", metadata,
+    Column("username", String(100), primary_key=True),
+    Column("role", String(50), primary_key=True),
+    Column("data_version", Integer),
+)
+
+user_roles_history = Table(
+    "user_roles_history", metadata,
+    Column("change_id", Integer, primary_key=True, autoincrement=True),
+    Column("changed_by", String(100), nullable=False),
+    Column("username", String(100), nullable=False),
+    Column("role", String(50), nullable=False),
+    Column("data_version", Integer),
+)
+
+
+def upgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    if migrate_engine.name == "mysql":
+        bigintType = BigInteger
+    elif migrate_engine.name == "sqlite":
+        bigintType = Integer
+    user_roles_history.append_column(Column("timestamp", bigintType, nullable=False))
+    metadata.create_all()

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -44,7 +44,7 @@ class ViewTest(unittest.TestCase):
         dbo.permissions.t.insert().execute(permission='admin', username='billy',
                                            options=json.dumps(dict(products=['a'])), data_version=1)
         dbo.permissions.user_roles.t.insert().execute(username="bill", role="releng", data_version=1)
-        dbo.permissions.user_roles.t.insert().execute(username="luke", role="relman", data_version=1)
+        dbo.permissions.user_roles.t.insert().execute(username="bob", role="relman", data_version=1)
         dbo.releases.t.insert().execute(
             name='a', product='a', data=json.dumps(dict(name='a', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -43,6 +43,8 @@ class ViewTest(unittest.TestCase):
                                            options=json.dumps(dict(actions=["modify"], products=['a'])), data_version=1)
         dbo.permissions.t.insert().execute(permission='admin', username='billy',
                                            options=json.dumps(dict(products=['a'])), data_version=1)
+        dbo.permissions.user_roles.t.insert().execute(username="bill", role="releng", data_version=1)
+        dbo.permissions.user_roles.t.insert().execute(username="luke", role="relman", data_version=1)
         dbo.releases.t.insert().execute(
             name='a', product='a', data=json.dumps(dict(name='a', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(

--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -11,7 +11,7 @@ class TestUsersAPI_JSON(ViewTest):
         self.assertEqual(ret.status_code, 200)
         data = json.loads(ret.data)
         data['users'] = set(data['users'])
-        self.assertEqual(data, dict(users=set(['bill', 'billy', 'bob', 'ashanti', 'mary', 'luke'])))
+        self.assertEqual(data, dict(users=set(['bill', 'billy', 'bob', 'ashanti', 'mary'])))
 
 
 class TestPermissionsAPI_JSON(ViewTest):
@@ -181,11 +181,11 @@ class TestUserRolesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 404)
 
     def testGrantRole(self):
-        ret = self._put("/users/jackson/roles/dev")
+        ret = self._put("/users/ashanti/roles/dev")
         self.assertStatusCode(ret, 201)
         self.assertEquals(ret.data, json.dumps(dict(new_data_version=1)), ret.data)
-        got = dbo.permissions.user_roles.t.select().where(dbo.permissions.user_roles.username == "jackson").execute().fetchall()
-        self.assertEquals(got, [("jackson", "dev", 1)])
+        got = dbo.permissions.user_roles.t.select().where(dbo.permissions.user_roles.username == "ashanti").execute().fetchall()
+        self.assertEquals(got, [("ashanti", "dev", 1)])
 
     def testGrantExistingRole(self):
         ret = self._put("/users/bill/roles/releng")
@@ -199,15 +199,15 @@ class TestUserRolesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 403)
 
     def testRevokeRole(self):
-        ret = self._delete("/users/luke/roles/relman", qs=dict(data_version=1))
+        ret = self._delete("/users/bob/roles/relman", qs=dict(data_version=1))
         self.assertStatusCode(ret, 200)
-        got = dbo.permissions.user_roles.t.select().where(dbo.permissions.user_roles.username == "luke").execute().fetchall()
+        got = dbo.permissions.user_roles.t.select().where(dbo.permissions.user_roles.username == "bob").execute().fetchall()
         self.assertEquals(got, [])
 
     def testRevokeRoleWithoutPermission(self):
-        ret = self._delete("/users/luke/roles/relman", username="lane", qs=dict(data_version=1))
+        ret = self._delete("/users/bob/roles/relman", username="lane", qs=dict(data_version=1))
         self.assertStatusCode(ret, 403)
 
     def testRevokeRoleBadDataVersion(self):
-        ret = self._delete("/users/luke/roles/relman", qs=dict(data_version=3))
+        ret = self._delete("/users/bob/roles/relman", qs=dict(data_version=3))
         self.assertStatusCode(ret, 400)

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -2682,11 +2682,12 @@ class TestPermissions(unittest.TestCase, MemoryDatabaseMixin):
         self.permissions.revokeRole("bob", "releng", "bill", old_data_version=1)
         got = self.user_roles.t.select().where(self.user_roles.username == "bob").execute().fetchall()
         self.assertEquals(len(got), 1)
+        self.assertEquals(got[0], ("bob", "dev", 1))
 
     def testRevokeRoleWithoutPermission(self):
         self.assertRaises(PermissionDeniedError, self.permissions.revokeRole, username="bob", role="releng", changed_by="kirk", old_data_version=1)
 
-    def testRevokingPermissionAlsoRevokeRolesRole(self):
+    def testRevokingPermissionAlsoRevokeRoles(self):
         self.permissions.delete({"username": "cathy", "permission": "rule"}, changed_by="bill", old_data_version=1)
         got = self.db.permissions.t.select().where(self.db.permissions.username == "cathy").execute().fetchall()
         self.assertEquals(len(got), 0)
@@ -2774,22 +2775,6 @@ class TestPermissions(unittest.TestCase, MemoryDatabaseMixin):
 
     def testUpdateUserRole(self):
         self.assertRaises(AttributeError, self.user_roles.update, {"username": "bob"}, {"role": "relman"}, "bill", 1)
-
-
-class TestUserRolesTable(unittest.TestCase, MemoryDatabaseMixin):
-
-    def setUp(self):
-        MemoryDatabaseMixin.setUp(self)
-        self.db = AUSDatabase(self.dburi)
-        self.db.create()
-        self.user_roles = self.db.permissions.user_roles
-        self.user_roles.t.insert().execute(username="luke", role="releng", data_version=1)
-        self.user_roles.t.insert().execute(username="luke", role="dev", data_version=1)
-        self.user_roles.t.insert().execute(username="jackson", role="releng", data_version=1)
-        self.db.permissions.t.insert().execute(permission="admin", username="lorelai", data_version=1)
-        self.db.permissions.t.insert().execute(permission="rule", username="luke", data_version=1)
-        self.db.permissions.t.insert().execute(permission="rule", username="jackson", data_version=1)
-        self.db.permissions.t.insert().execute(permission="rule", username="emily", data_version=1)
 
 
 class TestDockerflow(unittest.TestCase, MemoryDatabaseMixin):

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -2669,8 +2669,8 @@ class TestPermissions(unittest.TestCase, MemoryDatabaseMixin):
         self.assertIn(("bob", "relman", 1), got)
 
     def testGrantRoleToUserWhoDoesntHaveAPermission(self):
-        self.assertRaisesRegexp(ValueError, "cannot grant role to user without a permission",
-                                self.user_roles.insert, changed_by="bill", username="kirk", role="dev")
+        self.assertRaisesRegexp(ValueError, "Cannot grant a role to a user without any permissions",
+                                self.permissions.grantRole, changed_by="bill", username="kirk", role="dev")
 
     def testRevokePermission(self):
         self.permissions.delete({"username": "bob", "permission": "release"}, changed_by="bill", old_data_version=1)


### PR DESCRIPTION
Not much to say about this one, it's a simple table with a simple CRD API. During the proposal stage of multiple signoffs, a couple of people suggested that we may want to tie Roles and Permissions together directly at some point (ie: grant permissions to Roles, and let users inherit those instead of being granted Permissions). That's out of scope for now, but it's part of the reason I made this table owned by Permissions instead of living beside it.