### PR TITLE
Fix db creation when sample data doesn't match current schema version.

### DIFF
--- a/scripts/initdb_and_run.sh
+++ b/scripts/initdb_and_run.sh
@@ -13,8 +13,11 @@ if [ ! -e /app/.cache/mysql/db.done ]; then
 else
     # We also should sleep for existing databases, but we don't need for nearly as long.
     sleep 10
-    python scripts/manage-db.py -d mysql://balrogadmin:balrogadmin@balrogdb/balrog upgrade
 fi
+
+# We need to try upgrading even if the database was freshly created, because it
+# may use sample data from an older version.
+python scripts/manage-db.py -d mysql://balrogadmin:balrogadmin@balrogdb/balrog upgrade
 
 # run the command passed from docker
 /app/scripts/run.sh $@


### PR DESCRIPTION
I discovered this small bug after recreating my database today. The current sample data is from version 14, but version 16 of the schema landed last week. This means that my database ends up on version 14, but with code that requires version 16. "upgrade" is a no-op if the database is on the latest version, so this is safe to run even if the sample data is at version 16.

@rail - can you sanity check this?