### PR TITLE
Separate out the changed values when rules are updated

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1813,13 +1813,19 @@ def make_change_notifier(relayhost, port, username, password, to_addr, from_addr
         if type_ == "UPDATE":
             body.append("Row(s) to be updated as follows:")
             where = [c for c in query._whereclause.get_children()]
+            changed = {}
+            unchanged = {}
             for row in table.select(where=where):
                 for k in row:
                     if query.parameters[k] != row[k]:
-                        row[k] = UnquotedStr("%s ---> %s" % (repr(row[k]), repr(query.parameters[k])))
+                        changed[k] = UnquotedStr("%s ---> %s" % (repr(row[k]), repr(query.parameters[k])))
                     else:
-                        row[k] = UnquotedStr("%s (unchanged)" % repr(row[k]))
-                body.append(UTF8PrettyPrinter().pformat(row))
+                        unchanged[k] = UnquotedStr("%s" % repr(row[k]))
+                body.append('Changed values:')
+                body.append(UTF8PrettyPrinter().pformat(changed))
+                body.append('\nUnchanged:')
+                body.append(UTF8PrettyPrinter().pformat(unchanged))
+            body.append('\n\n')
         elif type_ == "DELETE":
             body.append("Row(s) to be removed:")
             where = [c for c in query._whereclause.get_children()]

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -2799,11 +2799,11 @@ class TestChangeNotifiers(unittest.TestCase):
         mock_conn.sendmail.assert_any_call("fake@from.com", "fake@to.com", PartialString("UPDATE to rules"))
         mock_conn.sendmail.assert_any_call("fake@from.com", "fake@to.com", PartialString("Row(s) to be updated as follows:"))
         mock_conn.sendmail.assert_any_call("fake@from.com", "fake@to.com", PartialString("'product': None ---> 'blah'"))
-        mock_conn.sendmail.assert_any_call("fake@from.com", "fake@to.com", PartialString("'channel': u'release' (unchanged)"))
+        mock_conn.sendmail.assert_any_call("fake@from.com", "fake@to.com", PartialString("'channel': u'release',"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("UPDATE to rules_scheduled_changes"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("Row(s) to be updated as follows:"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("'base_product': None ---> 'blah'"))
-        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("'base_channel': u'release' (unchanged)"))
+        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("'base_channel': u'release',"))
 
     def testOnDelete(self):
         def doit():
@@ -2831,7 +2831,7 @@ class TestChangeNotifiers(unittest.TestCase):
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("UPDATE"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("Row(s) to be updated as follows:"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("'base_product': None ---> 'blah'"))
-        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("'base_channel': u'release' (unchanged)"))
+        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("'base_channel': u'release',"))
 
     def testOnDeleteRuleSC(self):
         def doit():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ balrogadmin:
     - SMTP_PORT
     - SMTP_USERNAME
     - SMTP_PASSWORD
+    - SMTP_TLS
     - NOTIFY_TO_ADDR
     - NOTIFY_FROM_ADDR
 


### PR DESCRIPTION
Also passes SMTP_TLS into docker, which made it possible for me to use TLS with gmail's smtp server.

Example email with this change:
```
Changed by: balrogadmin
Row(s) to be updated as follows:
Changed values:
{'alias': None ---> u'yeehaw',
 'comment': 'cccc' ---> u'dddd',
 'data_version': 34L ---> 35L,
 'mapping': 'Firefox-mozilla-central-nightly-latest' ---> u'Firefox-mozilla-aurora-nightly-20151223004004',
 'priority': 90L ---> 99,
 'systemCapabilities': 'boopboop' ---> u'woot'}

Unchanged:
{'backgroundRate': 100L,
 'buildID': None,
 'buildTarget': None,
 'channel': 'nightly',
 'distVersion': None,
 'distribution': None,
 'fallbackMapping': None,
 'headerArchitecture': None,
 'locale': None,
 'osVersion': None,
 'product': 'Firefox',
 'rule_id': 3L,
 'update_type': 'minor',
 'version': None,
 'whitelist': None}
```