### PR TITLE
bug 1315801: product name filter for /api/rules

### DIFF
--- a/auslib/admin/views/rules.py
+++ b/auslib/admin/views/rules.py
@@ -20,7 +20,14 @@ class RulesAPIView(AdminView):
     """/rules"""
 
     def get(self, **kwargs):
-        rules = dbo.rules.getOrderedRules()
+        # We can't use a form here because it will enforce "csrf_token" needing
+        # to exist, which doesn't make sense for GET requests.
+        where = {}
+        for field in ("product",):
+            if request.args.get(field):
+                where[field] = request.args[field]
+
+        rules = dbo.rules.getOrderedRules(where=where)
         count = 0
         _rules = []
         for rule in rules:

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1108,9 +1108,9 @@ class Rules(AUSTable):
             ret = super(Rules, self).insert(changed_by=changed_by, transaction=transaction, **columns)
             return ret.inserted_primary_key[0]
 
-    def getOrderedRules(self, transaction=None):
+    def getOrderedRules(self, where=None, transaction=None):
         """Returns all of the rules, sorted in ascending order"""
-        return self.select(order_by=(self.priority, self.version, self.mapping), transaction=transaction)
+        return self.select(where=where, order_by=(self.priority, self.version, self.mapping), transaction=transaction)
 
     def countRules(self, transaction=None):
         """Returns a number of the count of rules"""

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -14,6 +14,17 @@ class TestRulesAPI_JSON(ViewTest):
         got = json.loads(ret.data)
         self.assertEquals(got["count"], 5)
 
+    def testGetRulesWithProductFilter(self):
+        ret = self._get("/rules", qs={"product": "fake"})
+        got = json.loads(ret.data)
+        expected = {
+            "rule_id": 4, "product": "fake", "priority": 80, "buildTarget": "d", "backgroundRate": 100, "mapping": "a",
+            "update_type": "minor", "data_version": 1
+        }
+        self.assertEquals(got["count"], 1)
+        for k, v in expected.iteritems():
+            self.assertEquals(got["rules"][0][k], v)
+
     def testNewRulePost(self):
         ret = self._post('/rules', data=dict(backgroundRate=31, mapping='c', priority=33,
                                              product='Firefox', update_type='minor', channel='nightly'))

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1087,6 +1087,18 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         ]
         self.assertEquals(rules, expected)
 
+    def testGetOrderedRulesWithCondition(self):
+        rules = self._stripNullColumns(self.paths.getOrderedRules(where=[self.paths.buildTarget == "d"]))
+        expected = [
+            dict(rule_id=4, alias="gandalf", priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z', data_version=1),
+            dict(rule_id=5, priority=80, backgroundRate=0, version='3.3', buildTarget='d', mapping='c', update_type='z', data_version=1),
+            dict(rule_id=6, priority=100, buildTarget='d', mapping='a', backgroundRate=100, osVersion='foo 1', update_type='z', data_version=1),
+            dict(rule_id=7, priority=100, buildTarget='d', mapping='a', backgroundRate=100, osVersion='foo 2,blah 6', update_type='z', data_version=1),
+            dict(rule_id=2, priority=100, backgroundRate=100, version='3.3', buildTarget='d', mapping='b', update_type='z', data_version=1),
+            dict(rule_id=1, priority=100, backgroundRate=100, version='3.5', buildTarget='d', mapping='c', update_type='z', data_version=1),
+        ]
+        self.assertEquals(rules, expected)
+
     def testGetRulesMatchingQuery(self):
         rules = self.paths.getRulesMatchingQuery(
             dict(product='', version='3.5', channel='',


### PR DESCRIPTION
I looked at using a Form to do the arg parsing here, but Forms really don't seem to be designed to work with GET requests (they don't look in request.args, and they end up looking for csrf_token, which is silly in this context).

I didn't add any additional filters for now, but this is structured in such a way where it would easy to add more later.