### PR TITLE
Use custom column types for JSON columns

### DIFF
--- a/auslib/admin/views/base.py
+++ b/auslib/admin/views/base.py
@@ -105,6 +105,11 @@ class HistoryAdminView(AdminView):
                 # prep the value for being shown in revision_row.html
                 if value is None:
                     value = 'NULL'
+                elif isinstance(value, dict):
+                    try:
+                        value = json.dumps(value, indent=2, sort_keys=True)
+                    except ValueError:
+                        pass
                 elif isinstance(value, int):
                     value = unicode(str(value), 'utf8')
                 elif not isinstance(value, basestring):

--- a/auslib/admin/views/history.py
+++ b/auslib/admin/views/history.py
@@ -29,9 +29,8 @@ class FieldView(AdminView):
         return revision[field]
 
     def format_value(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, dict):
             try:
-                value = json.loads(value)
                 value = json.dumps(value, indent=2, sort_keys=True)
             except ValueError:
                 pass

--- a/auslib/admin/views/history.py
+++ b/auslib/admin/views/history.py
@@ -60,7 +60,7 @@ class DiffView(FieldView):
 
     def get_prev_id(self, value, change_id):
 
-        release_name = json.loads(value)['name']
+        release_name = value['name']
 
         table = dbo.releases.history
         old_revision = table.select(
@@ -81,8 +81,8 @@ class DiffView(FieldView):
         prev_id = self.get_prev_id(value, change_id)
         previous = self.get_value(type_, prev_id, field)
 
-        value = self.format_value(value)
-        previous = self.format_value(previous)
+        value = self.format_value(value.getJSON())
+        previous = self.format_value(previous.getJSON())
 
         differ = difflib.Differ()
         result = differ.compare(

--- a/auslib/admin/views/history.py
+++ b/auslib/admin/views/history.py
@@ -76,17 +76,21 @@ class DiffView(FieldView):
 
     def get(self, type_, change_id, field):
         value = self.get_value(type_, change_id, field)
+        data_version = self.get_value(type_, change_id, "data_version")
 
         prev_id = self.get_prev_id(value, change_id)
         previous = self.get_value(type_, prev_id, field)
+        prev_data_version = self.get_value(type_, prev_id, "data_version")
 
-        value = self.format_value(value.getJSON())
-        previous = self.format_value(previous.getJSON())
+        value = self.format_value(value)
+        previous = self.format_value(previous)
 
-        differ = difflib.Differ()
-        result = differ.compare(
+        result = difflib.unified_diff(
             previous.splitlines(),
-            value.splitlines()
+            value.splitlines(),
+            fromfile="Data Version {}".format(prev_data_version),
+            tofile="Data Version {}".format(data_version),
+            lineterm=""
         )
 
         return Response('\n'.join(result), content_type='text/plain')

--- a/auslib/admin/views/releases.py
+++ b/auslib/admin/views/releases.py
@@ -220,7 +220,7 @@ class SingleReleaseView(AdminView):
             indent = 4
         else:
             indent = None
-        return Response(response=json.dumps(release[0]['data'], indent=indent), mimetype='application/json', headers=headers)
+        return Response(response=json.dumps(release[0]['data'], indent=indent, sort_keys=True), mimetype='application/json', headers=headers)
 
     @requirelogin
     def _put(self, release, changed_by, transaction):

--- a/auslib/admin/views/releases.py
+++ b/auslib/admin/views/releases.py
@@ -17,7 +17,7 @@ __all__ = ["SingleReleaseView", "SingleLocaleView"]
 
 
 def createRelease(release, product, changed_by, transaction, releaseData):
-    blob = createBlob(json.dumps(releaseData))
+    blob = createBlob(releaseData)
     dbo.releases.insert(changed_by=changed_by, transaction=transaction, name=release,
                         product=product, data=blob)
     return dbo.releases.getReleases(name=release, transaction=transaction)[0]

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -84,6 +84,10 @@ class ChangeScheduledError(SQLAlchemyError):
 
 
 class JSONColumn(sqlalchemy.types.TypeDecorator):
+    """JSONColumns are used for types that are deserialized JSON (usually
+    dicts) in memory, but need to be serialized to text before storage.
+    JSONColumn handles the conversion both ways, serialized just before
+    storage, and deserialized just after retrieval."""
 
     impl = Text
 
@@ -99,6 +103,11 @@ class JSONColumn(sqlalchemy.types.TypeDecorator):
 
 
 def BlobColumn(impl=Text):
+    """BlobColumns are used to store Release Blobs, which are ultimately dicts.
+    Release Blobs must be serialized before storage, and deserialized upon
+    retrevial. This type handles both conversions. Some database engines
+    (eg: mysql) may require a different underlying type than Text. The
+    desired type may be passed in as an argument."""
     class cls(sqlalchemy.types.TypeDecorator):
 
         def process_bind_param(self, value, dialect):
@@ -1495,7 +1504,7 @@ class Releases(AUSTable):
         def getBlob():
             try:
                 row = self.select(where=[self.name == name], columns=[self.data], limit=1, transaction=transaction)[0]
-                blob = createBlob(row['data'])
+                blob = row['data']
                 return {"data_version": data_version, "blob": blob}
             except IndexError:
                 raise KeyError("Couldn't find release with name '%s'" % name)

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -5,6 +5,7 @@ import unittest
 
 from auslib.global_state import dbo, cache
 from auslib.admin.base import app
+from auslib.blobs.base import createBlob
 
 
 class ViewTest(unittest.TestCase):
@@ -46,14 +47,14 @@ class ViewTest(unittest.TestCase):
         dbo.permissions.user_roles.t.insert().execute(username="bill", role="releng", data_version=1)
         dbo.permissions.user_roles.t.insert().execute(username="bob", role="relman", data_version=1)
         dbo.releases.t.insert().execute(
-            name='a', product='a', data=json.dumps(dict(name='a', hashFunction="sha512", schema_version=1)), data_version=1)
+            name='a', product='a', data=createBlob(dict(name='a', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(
-            name='ab', product='a', data=json.dumps(dict(name='ab', hashFunction="sha512", schema_version=1)), data_version=1)
+            name='ab', product='a', data=createBlob(dict(name='ab', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(
-            name='b', product='b', data=json.dumps(dict(name='b', hashFunction="sha512", schema_version=1)), data_version=1)
+            name='b', product='b', data=createBlob(dict(name='b', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(
-            name='c', product='c', data=json.dumps(dict(name='c', hashFunction="sha512", schema_version=1)), data_version=1)
-        dbo.releases.t.insert().execute(name='d', product='d', data_version=1, data="""
+            name='c', product='c', data=createBlob(dict(name='c', hashFunction="sha512", schema_version=1)), data_version=1)
+        dbo.releases.t.insert().execute(name='d', product='d', data_version=1, data=createBlob("""
 {
     "name": "d",
     "schema_version": 1,
@@ -72,7 +73,7 @@ class ViewTest(unittest.TestCase):
         }
     }
 }
-""")
+"""))
         dbo.rules.t.insert().execute(
             rule_id=1, priority=100, version='3.5', buildTarget='d', backgroundRate=100, mapping='c', update_type='minor', data_version=1
         )

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -35,15 +35,15 @@ class ViewTest(unittest.TestCase):
         dbo.permissions.t.insert().execute(permission='admin', username='bill', data_version=1)
         dbo.permissions.t.insert().execute(permission='permission', username='bob', data_version=1)
         dbo.permissions.t.insert().execute(permission='release', username='bob',
-                                           options=json.dumps(dict(products=['fake', 'b'], actions=["create", "modify"])), data_version=1)
-        dbo.permissions.t.insert().execute(permission='release_read_only', username='bob', options=json.dumps(dict(actions=["set"])), data_version=1)
-        dbo.permissions.t.insert().execute(permission='rule', username='bob', options=json.dumps(dict(actions=["modify"], products=['fake'])), data_version=1)
-        dbo.permissions.t.insert().execute(permission='build', username='ashanti', options=json.dumps(dict(actions=["modify"], products=['a'])), data_version=1)
-        dbo.permissions.t.insert().execute(permission="scheduled_change", username="mary", options=json.dumps(dict(actions=["enact"])), data_version=1)
+                                           options=dict(products=['fake', 'b'], actions=["create", "modify"]), data_version=1)
+        dbo.permissions.t.insert().execute(permission='release_read_only', username='bob', options=dict(actions=["set"]), data_version=1)
+        dbo.permissions.t.insert().execute(permission='rule', username='bob', options=dict(actions=["modify"], products=['fake']), data_version=1)
+        dbo.permissions.t.insert().execute(permission='build', username='ashanti', options=dict(actions=["modify"], products=['a']), data_version=1)
+        dbo.permissions.t.insert().execute(permission="scheduled_change", username="mary", options=dict(actions=["enact"]), data_version=1)
         dbo.permissions.t.insert().execute(permission='release_locale', username='ashanti',
-                                           options=json.dumps(dict(actions=["modify"], products=['a'])), data_version=1)
+                                           options=dict(actions=["modify"], products=['a']), data_version=1)
         dbo.permissions.t.insert().execute(permission='admin', username='billy',
-                                           options=json.dumps(dict(products=['a'])), data_version=1)
+                                           options=dict(products=['a']), data_version=1)
         dbo.permissions.user_roles.t.insert().execute(username="bill", role="releng", data_version=1)
         dbo.permissions.user_roles.t.insert().execute(username="bob", role="relman", data_version=1)
         dbo.releases.t.insert().execute(

--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -114,7 +114,7 @@ class TestPermissionsAPI_JSON(ViewTest):
         query = dbo.permissions.t.select()
         query = query.where(dbo.permissions.username == 'bob')
         query = query.where(dbo.permissions.permission == 'release_locale')
-        self.assertEqual(query.execute().fetchone(), ('release_locale', 'bob', json.dumps(dict(products=['fake'])), 1))
+        self.assertEqual(query.execute().fetchone(), ('release_locale', 'bob', dict(products=['fake']), 1))
 
     def testPermissionModify(self):
         ret = self._put('/users/bob/permissions/release',
@@ -124,7 +124,7 @@ class TestPermissionsAPI_JSON(ViewTest):
         query = dbo.permissions.t.select()
         query = query.where(dbo.permissions.username == 'bob')
         query = query.where(dbo.permissions.permission == 'release')
-        self.assertEqual(query.execute().fetchone(), ('release', 'bob', json.dumps(dict(products=['different'])), 2))
+        self.assertEqual(query.execute().fetchone(), ('release', 'bob', dict(products=['different']), 2))
 
     def testPermissionModifyWithoutDataVersion(self):
         ret = self._put("/users/bob/permissions/release",

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -2,6 +2,7 @@ import simplejson as json
 
 from sqlalchemy import select
 
+from auslib.blobs.base import createBlob
 from auslib.global_state import dbo
 from auslib.test.admin.views.base import ViewTest
 
@@ -28,7 +29,7 @@ class TestReleasesAPI_JSON(ViewTest):
         ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
         self.assertStatusCode(ret, 200)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads("""
+        self.assertEqual(ret, createBlob("""
 {
     "name": "d",
     "schema_version": 1,
@@ -134,7 +135,7 @@ class TestReleasesAPI_JSON(ViewTest):
                 }
             }
         }"""
-        result_blob = """
+        result_blob = createBlob("""
         {
             "name": "dd",
             "schema_version": 1,
@@ -168,14 +169,14 @@ class TestReleasesAPI_JSON(ViewTest):
                     }
                 }
             }
-        }"""
+        }""")
 
         # Testing Put request to add new release
         ret = self._put('/releases/dd', data=dict(blob=ancestor_blob, name='dd',
                                                   product='dd', data_version=1))
         self.assertStatusCode(ret, 201)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'dd').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads(ancestor_blob))
+        self.assertEqual(ret, createBlob(ancestor_blob))
 
         # Updating same release
         ret = self._put('/releases/dd', data=dict(blob=blob1, name='dd',
@@ -190,7 +191,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertEqual(json.loads(ret.data), dict(new_data_version=3))
 
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'dd').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads(result_blob))
+        self.assertEqual(ret, result_blob)
 
     def testReleasePutUpdateConflictingOutdatedData(self):
         ancestor_blob = """
@@ -268,7 +269,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 201)
 
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'dd').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads(ancestor_blob))
+        self.assertEqual(ret, createBlob(ancestor_blob))
 
         # Updating same release
         ret = self._put('/releases/dd', data=dict(blob=blob1, name='dd',
@@ -347,7 +348,7 @@ class TestReleasesAPI_JSON(ViewTest):
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
         self.assertEqual(ret['name'], 'e')
-        self.assertEqual(json.loads(ret['data']), json.loads("""
+        self.assertEqual(ret['data'], createBlob("""
 {
     "name": "e",
     "hashFunction": "sha512",
@@ -370,7 +371,7 @@ class TestReleasesAPI_JSON(ViewTest):
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
         self.assertEqual(ret['name'], 'e')
-        self.assertEqual(json.loads(ret['data']), json.loads("""
+        self.assertEqual(ret['data'], createBlob("""
 {
     "name": "e",
     "hashFunction": "sha512",
@@ -441,7 +442,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'a').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads("""
+        self.assertEqual(ret, createBlob("""
 {
     "name": "a",
     "schema_version": 1,
@@ -474,7 +475,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'a').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads("""
+        self.assertEqual(ret, createBlob("""
 {
     "name": "a",
     "schema_version": 1,
@@ -524,7 +525,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'e').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads("""
+        self.assertEqual(ret, createBlob("""
 {
     "name": "e",
     "schema_version": 1,
@@ -558,7 +559,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads("""
+        self.assertEqual(ret, createBlob("""
 {
     "name": "d",
     "schema_version": 1,
@@ -601,7 +602,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'e').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads("""
+        self.assertEqual(ret, createBlob("""
 {
     "name": "e",
     "hashFunction": "sha512",
@@ -638,7 +639,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads("""
+        self.assertEqual(ret, createBlob("""
 {
     "name": "d",
     "schema_version": 1,
@@ -687,7 +688,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 201)
         self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'a').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads("""
+        self.assertEqual(ret, createBlob("""
 {
     "name": "a",
     "schema_version": 1,
@@ -708,7 +709,7 @@ class TestReleasesAPI_JSON(ViewTest):
 }
 """))
         ret = select([dbo.releases.data]).where(dbo.releases.name == 'ab').execute().fetchone()[0]
-        self.assertEqual(json.loads(ret), json.loads("""
+        self.assertEqual(ret, createBlob("""
 {
     "name": "ab",
     "schema_version": 1,
@@ -838,7 +839,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'new_release')
         self.assertEquals(r[0]['product'], 'Firefox')
-        self.assertEquals(json.loads(r[0]['data']), json.loads("""
+        self.assertEquals(r[0]['data'], createBlob("""
 {
     "name": "new_release",
     "hashFunction": "sha512",
@@ -888,7 +889,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'd')
         self.assertEquals(r[0]['product'], 'Firefox')
-        self.assertEquals(json.loads(r[0]['data']), json.loads("""
+        self.assertEquals(r[0]['data'], createBlob("""
 {
     "name": "d",
     "schema_version": 3,
@@ -928,7 +929,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'gmprel')
         self.assertEquals(r[0]['product'], 'a')
-        self.assertEquals(json.loads(r[0]['data']), json.loads("""
+        self.assertEquals(r[0]['data'], createBlob("""
 {
     "name": "gmprel",
     "schema_version": 1000,
@@ -1003,7 +1004,7 @@ class TestReleasesAPI_JSON(ViewTest):
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
         self.assertEqual(ret['name'], 'e')
-        self.assertEqual(json.loads(ret['data']), json.loads("""
+        self.assertEqual(ret['data'], createBlob("""
 {
     "name": "e",
     "hashFunction": "sha512",
@@ -1091,7 +1092,7 @@ class TestReleaseHistoryView(ViewTest):
         table = dbo.releases
         row, = table.select(where=[table.name == 'd'])
         self.assertEqual(row['data_version'], 3)
-        data = json.loads(row['data'])
+        data = row['data']
         self.assertEqual(data['fakePartials'], False)
         self.assertEqual(data['detailsUrl'], 'boop')
 
@@ -1116,7 +1117,7 @@ class TestReleaseHistoryView(ViewTest):
 
         row, = table.select(where=[table.name == 'd'])
         self.assertEqual(row['data_version'], 4)
-        data = json.loads(row['data'])
+        data = row['data']
         self.assertEqual(data['fakePartials'], True)
         self.assertEqual(data['detailsUrl'], 'beep')
 

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -10,7 +10,7 @@ import unittest
 from auslib.global_state import dbo
 from auslib.errors import BadDataError
 from auslib.web.base import app
-from auslib.blobs.base import BlobValidationError
+from auslib.blobs.base import BlobValidationError, createBlob
 from auslib.blobs.apprelease import ReleaseBlobBase, ReleaseBlobV1, ReleaseBlobV2, \
     ReleaseBlobV3, ReleaseBlobV4, ReleaseBlobV5, ReleaseBlobV6, ReleaseBlobV7, DesupportBlob, \
     UnifiedFileUrlsMixin
@@ -463,7 +463,7 @@ class TestSchema2Blob(unittest.TestCase):
         dbo.setDb('sqlite:///:memory:')
         dbo.create()
         dbo.setDomainWhitelist(self.whitelistedDomains)
-        dbo.releases.t.insert().execute(name='j1', product='j', version='39.0', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='j1', product='j', version='39.0', data_version=1, data=createBlob("""
 {
     "name": "j1",
     "schema_version": 2,
@@ -476,7 +476,7 @@ class TestSchema2Blob(unittest.TestCase):
         }
     }
 }
-""")
+"""))
         self.blobJ2 = ReleaseBlobV2()
         self.blobJ2.loadJSON("""
 {
@@ -690,7 +690,7 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
         dbo.setDb('sqlite:///:memory:')
         dbo.create()
         dbo.setDomainWhitelist(self.whitelistedDomains)
-        dbo.releases.t.insert().execute(name='j1', product='j', version='0.5', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='j1', product='j', version='0.5', data_version=1, data=createBlob("""
 {
     "name": "j1",
     "schema_version": 2,
@@ -704,7 +704,7 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
         }
     }
 }
-""")
+"""))
         self.blobJ2 = ReleaseBlobV2()
         self.blobJ2.loadJSON("""
 {
@@ -812,7 +812,7 @@ class TestSchema3Blob(unittest.TestCase):
         dbo.setDb('sqlite:///:memory:')
         dbo.create()
         dbo.setDomainWhitelist(self.whitelistedDomains)
-        dbo.releases.t.insert().execute(name='f1', product='f', version='22.0', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='f1', product='f', version='22.0', data_version=1, data=createBlob("""
 {
     "name": "f1",
     "schema_version": 3,
@@ -825,8 +825,8 @@ class TestSchema3Blob(unittest.TestCase):
         }
     }
 }
-""")
-        dbo.releases.t.insert().execute(name='f2', product='f', version='23.0', data_version=1, data="""
+"""))
+        dbo.releases.t.insert().execute(name='f2', product='f', version='23.0', data_version=1, data=createBlob("""
 {
     "name": "f2",
     "schema_version": 3,
@@ -839,7 +839,7 @@ class TestSchema3Blob(unittest.TestCase):
         }
     }
 }
-""")
+"""))
         self.blobF3 = ReleaseBlobV3()
         self.blobF3.loadJSON("""
 {
@@ -898,7 +898,7 @@ class TestSchema3Blob(unittest.TestCase):
     }
 }
 """)
-        dbo.releases.t.insert().execute(name='g1', product='g', version='23.0', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='g1', product='g', version='23.0', data_version=1, data=createBlob("""
 {
     "name": "g1",
     "schema_version": 3,
@@ -911,7 +911,7 @@ class TestSchema3Blob(unittest.TestCase):
         }
     }
 }
-""")
+"""))
         self.blobG2 = ReleaseBlobV3()
         self.blobG2.loadJSON("""
 {
@@ -1149,7 +1149,7 @@ class TestSchema4Blob(unittest.TestCase):
         dbo.setDb('sqlite:///:memory:')
         dbo.create()
         dbo.setDomainWhitelist(self.whitelistedDomains)
-        dbo.releases.t.insert().execute(name='h0', product='h', version='29.0', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='h0', product='h', version='29.0', data_version=1, data=createBlob("""
 {
     "name": "h0",
     "schema_version": 4,
@@ -1162,8 +1162,8 @@ class TestSchema4Blob(unittest.TestCase):
         }
     }
 }
-""")
-        dbo.releases.t.insert().execute(name='h1', product='h', version='30.0', data_version=1, data="""
+"""))
+        dbo.releases.t.insert().execute(name='h1', product='h', version='30.0', data_version=1, data=createBlob("""
 {
     "name": "h1",
     "schema_version": 4,
@@ -1176,7 +1176,7 @@ class TestSchema4Blob(unittest.TestCase):
         }
     }
 }
-""")
+"""))
         self.blobH2 = ReleaseBlobV4()
         self.blobH2.loadJSON("""
 {
@@ -1634,7 +1634,7 @@ class TestSchema5Blob(unittest.TestCase):
         app.config['WHITELISTED_DOMAINS'] = self.whitelistedDomains
         dbo.setDb('sqlite:///:memory:')
         dbo.create()
-        dbo.releases.t.insert().execute(name='h1', product='h', version='30.0', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='h1', product='h', version='30.0', data_version=1, data=createBlob("""
 {
     "name": "h1",
     "schema_version": 5,
@@ -1647,7 +1647,7 @@ class TestSchema5Blob(unittest.TestCase):
         }
     }
 }
-""")
+"""))
         self.blobH2 = ReleaseBlobV5()
         self.blobH2.loadJSON("""
 {
@@ -1755,7 +1755,7 @@ class TestSchema6Blob(unittest.TestCase):
         app.config['WHITELISTED_DOMAINS'] = self.whitelistedDomains
         dbo.setDb('sqlite:///:memory:')
         dbo.create()
-        dbo.releases.t.insert().execute(name='h1', product='h', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='h1', product='h', data_version=1, data=createBlob("""
 {
     "name": "h1",
     "schema_version": 6,
@@ -1768,7 +1768,7 @@ class TestSchema6Blob(unittest.TestCase):
         }
     }
 }
-""")
+"""))
         self.blobH2 = ReleaseBlobV6()
         self.blobH2.loadJSON("""
 {
@@ -1939,7 +1939,7 @@ class TestSchema7Blob(unittest.TestCase):
         app.config['WHITELISTED_DOMAINS'] = self.whitelistedDomains
         dbo.setDb('sqlite:///:memory:')
         dbo.create()
-        dbo.releases.t.insert().execute(name='h1', product='h', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='h1', product='h', data_version=1, data=createBlob("""
 {
     "name": "h1",
     "schema_version": 7,
@@ -1952,7 +1952,7 @@ class TestSchema7Blob(unittest.TestCase):
         }
     }
 }
-""")
+"""))
         self.blobH2 = ReleaseBlobV7()
         self.blobH2.loadJSON("""
 {

--- a/auslib/test/blobs/test_superblob.py
+++ b/auslib/test/blobs/test_superblob.py
@@ -1,10 +1,9 @@
 import unittest
 
 from auslib.blobs.superblob import SuperBlob
-from auslib.test.test_db import MemoryDatabaseMixin
 
 
-class TestSchema1Blob(unittest.TestCase, MemoryDatabaseMixin):
+class TestSchema1Blob(unittest.TestCase):
     maxDiff = 2000
 
     def setUp(self):

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -3,6 +3,7 @@ import unittest
 
 from auslib.global_state import dbo
 from auslib.AUS import AUS
+from auslib.blobs.base import createBlob
 
 
 def RandomAUSTestWithoutFallback(AUS, backgroundRate, force, mapping):
@@ -74,11 +75,11 @@ class TestAUSThrottlingWithoutFallback(unittest.TestCase):
         dbo.create()
         dbo.releases.t.insert().execute(
             name='b', product='b', data_version=1,
-            data='{"name": "b", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}')
+            data=createBlob({"name": "b", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}))
 
         dbo.releases.t.insert().execute(
             name='fallback', product='c', data_version=1,
-            data='{"name": "fallback", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}')
+            data=createBlob({"name": "fallback", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}))
 
     def tearDown(self):
         dbo.reset()
@@ -120,11 +121,11 @@ class TestAUSThrottlingWithFallback(unittest.TestCase):
         dbo.create()
         dbo.releases.t.insert().execute(
             name='b', product='b', data_version=1,
-            data='{"name": "b", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}')
+            data=createBlob({"name": "b", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}))
 
         dbo.releases.t.insert().execute(
             name='fallback', product='b', data_version=1,
-            data='{"name": "fallback", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}')
+            data=createBlob({"name": "fallback", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}))
 
     def tearDown(self):
         dbo.reset()

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1,7 +1,6 @@
 import logging
 import mock
 import os
-import simplejson as json
 import sys
 from tempfile import mkstemp
 import unittest
@@ -655,7 +654,7 @@ class ScheduledChangesTableMixin(object):
         self.sc_table.conditions.t.insert().execute(sc_id=5, when=39000, data_version=1)
         self.db.permissions.t.insert().execute(permission="admin", username="bob", data_version=1)
         self.db.permissions.t.insert().execute(permission="admin", username="mary", data_version=1)
-        self.db.permissions.t.insert().execute(permission="scheduled_change", username="nancy", options='{"actions": ["enact"]}', data_version=1)
+        self.db.permissions.t.insert().execute(permission="scheduled_change", username="nancy", options={"actions": ["enact"]}, data_version=1)
 
 
 class TestScheduledChangesTable(unittest.TestCase, ScheduledChangesTableMixin, MemoryDatabaseMixin):
@@ -1750,7 +1749,7 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
                                          data_version=1)
         self.permissions.t.insert().execute(permission="admin", username="bill", data_version=1)
         self.permissions.t.insert().execute(permission="admin", username="me", data_version=1)
-        self.permissions.t.insert().execute(permission="release", username="bob", options=json.dumps(dict(products=["c"])), data_version=1)
+        self.permissions.t.insert().execute(permission="release", username="bob", options=dict(products=["c"]), data_version=1)
 
     def tearDown(self):
         dbo.reset()
@@ -2729,7 +2728,7 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
     }
 }
 """)
-        result_blob = json.loads("""
+        result_blob = createBlob("""
 {
     "name": "p",
     "schema_version": 1,
@@ -2880,14 +2879,14 @@ class TestPermissions(unittest.TestCase, MemoryDatabaseMixin):
         self.user_roles = self.db.permissions.user_roles
         self.permissions.t.insert().execute(permission='admin', username='bill', data_version=1)
         self.permissions.t.insert().execute(permission="permission", username="bob", data_version=1)
-        self.permissions.t.insert().execute(permission="release", username="bob", options=json.dumps(dict(products=["fake"])), data_version=1)
+        self.permissions.t.insert().execute(permission="release", username="bob", options=dict(products=["fake"]), data_version=1)
         self.permissions.t.insert().execute(permission="rule", username="cathy", data_version=1)
-        self.permissions.t.insert().execute(permission="rule", username="bob", options=json.dumps(dict(actions=["modify"])), data_version=1)
-        self.permissions.t.insert().execute(permission="rule", username="fred", options=json.dumps(dict(products=["foo", "bar"], actions=["modify"])),
+        self.permissions.t.insert().execute(permission="rule", username="bob", options=dict(actions=["modify"]), data_version=1)
+        self.permissions.t.insert().execute(permission="rule", username="fred", options=dict(products=["foo", "bar"], actions=["modify"]),
                                             data_version=1)
         self.permissions.t.insert().execute(permission='admin',
                                             username='george',
-                                            options=json.dumps(dict(products=["foo"])),
+                                            options=dict(products=["foo"]),
                                             data_version=1)
         self.user_roles.t.insert().execute(username="bob", role="releng", data_version=1)
         self.user_roles.t.insert().execute(username="bob", role="dev", data_version=1)
@@ -2919,7 +2918,7 @@ class TestPermissions(unittest.TestCase, MemoryDatabaseMixin):
         self.permissions.insert("bob", username="cathy", permission="release", options=dict(products=["SeaMonkey"]))
         query = self.permissions.t.select().where(self.permissions.username == "cathy")
         query = query.where(self.permissions.permission == "release")
-        self.assertEquals(query.execute().fetchall(), [("release", "cathy", json.dumps(dict(products=["SeaMonkey"])), 1)])
+        self.assertEquals(query.execute().fetchall(), [("release", "cathy", dict(products=["SeaMonkey"]), 1)])
 
     def testGrantPermissionsUnknownPermission(self):
         self.assertRaises(ValueError, self.permissions.insert, changed_by="bob", username="bud", permission="bad")
@@ -3010,7 +3009,7 @@ class TestPermissions(unittest.TestCase, MemoryDatabaseMixin):
         self.assertRaises(ValueError, self.permissions.getOptions, "fake", "fake")
 
     def testGetOptionsNoOptions(self):
-        self.assertEquals(self.permissions.getOptions("cathy", "rule"), {})
+        self.assertEquals(self.permissions.getOptions("cathy", "rule"), None)
 
     def testHasPermissionAdmin(self):
         self.assertTrue(self.permissions.hasPermission("bill", "rule", "delete"))

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1740,13 +1740,13 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.rules = dbo.rules
         self.releases = dbo.releases
         self.permissions = dbo.permissions
-        self.releases.t.insert().execute(name='a', product='a', data=json.dumps(dict(name="a", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='a', product='a', data=dict(name="a", schema_version=1, hashFunction="sha512"),
                                          data_version=1)
-        self.releases.t.insert().execute(name='ab', product='a', data=json.dumps(dict(name="ab", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='ab', product='a', data=dict(name="ab", schema_version=1, hashFunction="sha512"),
                                          data_version=1)
-        self.releases.t.insert().execute(name='b', product='b', data=json.dumps(dict(name="b", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='b', product='b', data=dict(name="b", schema_version=1, hashFunction="sha512"),
                                          data_version=1)
-        self.releases.t.insert().execute(name='c', product='c', data=json.dumps(dict(name="c", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='c', product='c', data=dict(name="c", schema_version=1, hashFunction="sha512"),
                                          data_version=1)
         self.permissions.t.insert().execute(permission="admin", username="bill", data_version=1)
         self.permissions.t.insert().execute(permission="admin", username="me", data_version=1)
@@ -1788,7 +1788,7 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
 
     def testGetReleaseInfoWithFallbackMapping(self):
         self.releases.t.insert().execute(name='fallback', product='e',
-                                         data=json.dumps(dict(name="e", schema_version=1, hashFunction="sha512")),
+                                         data=dict(name="e", schema_version=1, hashFunction="sha512"),
                                          data_version=1)
         self.rules.t.insert().execute(rule_id=1, priority=100, fallbackMapping="fallback", version='3.5',
                                       whitelist='e', update_type='z', data_version=1)

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1740,13 +1740,13 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.rules = dbo.rules
         self.releases = dbo.releases
         self.permissions = dbo.permissions
-        self.releases.t.insert().execute(name='a', product='a', data=dict(name="a", schema_version=1, hashFunction="sha512"),
+        self.releases.t.insert().execute(name='a', product='a', data=createBlob(dict(name="a", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
-        self.releases.t.insert().execute(name='ab', product='a', data=dict(name="ab", schema_version=1, hashFunction="sha512"),
+        self.releases.t.insert().execute(name='ab', product='a', data=createBlob(dict(name="ab", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
-        self.releases.t.insert().execute(name='b', product='b', data=dict(name="b", schema_version=1, hashFunction="sha512"),
+        self.releases.t.insert().execute(name='b', product='b', data=createBlob(dict(name="b", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
-        self.releases.t.insert().execute(name='c', product='c', data=dict(name="c", schema_version=1, hashFunction="sha512"),
+        self.releases.t.insert().execute(name='c', product='c', data=createBlob(dict(name="c", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
         self.permissions.t.insert().execute(permission="admin", username="bill", data_version=1)
         self.permissions.t.insert().execute(permission="admin", username="me", data_version=1)
@@ -1762,11 +1762,11 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.assertEquals(len(self.releases.getReleases(limit=1)), 1)
 
     def testGetReleasesWithWhere(self):
-        expected = [dict(product='b', name='b', data=dict(name="b", schema_version=1, hashFunction="sha512"), data_version=1)]
+        expected = [dict(product='b', name='b', data=createBlob(dict(name="b", schema_version=1, hashFunction="sha512")), data_version=1)]
         self.assertEquals(self.releases.getReleases(name='b'), expected)
 
     def testGetReleaseBlob(self):
-        expected = dict(name="c", schema_version=1, hashFunction="sha512")
+        expected = createBlob(dict(name="c", schema_version=1, hashFunction="sha512"))
         self.assertEquals(self.releases.getReleaseBlob(name='c'), expected)
 
     def testGetReleaseBlobNonExistentRelease(self):
@@ -1788,7 +1788,7 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
 
     def testGetReleaseInfoWithFallbackMapping(self):
         self.releases.t.insert().execute(name='fallback', product='e',
-                                         data=dict(name="e", schema_version=1, hashFunction="sha512"),
+                                         data=createBlob(dict(name="e", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
         self.rules.t.insert().execute(rule_id=1, priority=100, fallbackMapping="fallback", version='3.5',
                                       whitelist='e', update_type='z', data_version=1)
@@ -1845,14 +1845,14 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.assertEquals(release, [])
 
     def testDeleteWithRuleMapping(self):
-        self.releases.t.insert().execute(name='d', product='d', data=json.dumps(dict(name="d", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='d', product='d', data=createBlob(dict(name="d", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
         self.rules.t.insert().execute(rule_id=1, priority=100, version='3.5', buildTarget='d', backgroundRate=100, mapping='d', update_type='z',
                                       data_version=1)
         self.assertRaises(ValueError, self.releases.delete, {"name": "d"}, changed_by='me', old_data_version=1)
 
     def testDeleteWithRuleWhitelist(self):
-        self.releases.t.insert().execute(name='e', product='e', data=json.dumps(dict(name="e", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='e', product='e', data=createBlob(dict(name="e", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
         self.rules.t.insert().execute(rule_id=1, priority=100, version='3.5', buildTarget='e', backgroundRate=100, whitelist='e', update_type='z',
                                       data_version=1)
@@ -1860,7 +1860,7 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
 
     def testDeleteWithRuleFallbackMapping(self):
         self.releases.t.insert().execute(name='fallback', product='e',
-                                         data=json.dumps(dict(name="e", schema_version=1, hashFunction="sha512")),
+                                         data=createBlob(dict(name="e", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
         self.rules.t.insert().execute(rule_id=1, priority=100, fallbackMapping="fallback", version='3.5', buildTarget='e', backgroundRate=100,
                                       whitelist='e', update_type='z',
@@ -2054,9 +2054,9 @@ class TestBlobCaching(unittest.TestCase, MemoryDatabaseMixin):
         self.rules = dbo.rules
         self.releases = dbo.releases
         self.permissions = dbo.permissions
-        self.releases.t.insert().execute(name='a', product='a', data=json.dumps(dict(name="a", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='a', product='a', data=createBlob(dict(name="a", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
-        self.releases.t.insert().execute(name='b', product='b', data=json.dumps(dict(name="b", schema_version=1, hashFunction="sha512")),
+        self.releases.t.insert().execute(name='b', product='b', data=createBlob(dict(name="b", schema_version=1, hashFunction="sha512")),
                                          data_version=1)
         self.permissions.t.insert().execute(permission="admin", username="bill", data_version=1)
         self.permissions.t.insert().execute(permission="admin", username="bob", data_version=1)
@@ -2261,7 +2261,7 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
         self.db = AUSDatabase(self.dburi)
         self.db.create()
         self.releases = self.db.releases
-        self.releases.t.insert().execute(name='a', product='a', data_version=1, data="""
+        self.releases.t.insert().execute(name='a', product='a', data_version=1, data=createBlob("""
 {
     "name": "a",
     "schema_version": 1,
@@ -2285,21 +2285,21 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
         }
     }
 }
-""")
-        self.releases.t.insert().execute(name='b', product='b', data_version=1, data="""
+"""))
+        self.releases.t.insert().execute(name='b', product='b', data_version=1, data=createBlob("""
 {
     "name": "b",
     "hashFunction": "sha512",
     "schema_version": 1
 }
-""")
+"""))
         self.db.permissions.t.insert().execute(permission="admin", username="bill", data_version=1)
         self.db.permissions.t.insert().execute(permission="admin", username="me", data_version=1)
 
     def testAddRelease(self):
         blob = ReleaseBlobV1(name="d", hashFunction="sha512")
         self.releases.insert(changed_by="bill", name='d', product='d', data=blob)
-        expected = [('d', 'd', False, json.dumps(dict(name="d", schema_version=1, hashFunction="sha512")), 1)]
+        expected = [('d', 'd', False, createBlob(dict(name="d", schema_version=1, hashFunction="sha512")), 1)]
         self.assertEquals(self.releases.t.select().where(self.releases.name == 'd').execute().fetchall(), expected)
 
     def testAddReleaseAlreadyExists(self):
@@ -2309,7 +2309,7 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
     def testUpdateRelease(self):
         blob = ReleaseBlobV1(name='a', hashFunction="sha512")
         self.releases.update({"name": "a"}, {"product": "z", "data": blob}, "bill", 1)
-        expected = [('a', 'z', False, json.dumps(dict(name='a', schema_version=1, hashFunction="sha512")), 2)]
+        expected = [('a', 'z', False, createBlob(dict(name='a', schema_version=1, hashFunction="sha512")), 2)]
         self.assertEquals(self.releases.t.select().where(self.releases.name == 'a').execute().fetchall(), expected)
 
     def testUpdateReleaseWhenReadOnly(self):
@@ -2321,7 +2321,7 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
     def testUpdateReleaseWithBlob(self):
         blob = ReleaseBlobV1(name='b', schema_version=1, hashFunction="sha512")
         self.releases.update({"name": "b"}, {"product": "z", "data": blob}, "bill", 1)
-        expected = [('b', 'z', False, json.dumps(dict(name='b', schema_version=1, hashFunction="sha512")), 2)]
+        expected = [('b', 'z', False, createBlob(dict(name='b', schema_version=1, hashFunction="sha512")), 2)]
         self.assertEquals(self.releases.t.select().where(self.releases.name == 'b').execute().fetchall(), expected)
 
     def testUpdateReleaseInvalidBlob(self):
@@ -2338,8 +2338,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='p', locale='c', data=data, old_data_version=1, changed_by='bill')
-        ret = json.loads(select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0])
-        expected = json.loads("""
+        ret = select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0]
+        expected = createBlob("""
 {
     "name": "a",
     "schema_version": 1,
@@ -2382,8 +2382,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='p', locale='c', data=data, old_data_version=1, changed_by='bill', alias=['p4'])
-        ret = json.loads(select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0])
-        expected = json.loads("""
+        ret = select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0]
+        expected = createBlob("""
 {
     "name": "a",
     "hashFunction": "sha512",
@@ -2429,8 +2429,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='p', locale='l', data=data, old_data_version=1, changed_by='bill')
-        ret = json.loads(select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0])
-        expected = json.loads("""
+        ret = select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0]
+        expected = createBlob("""
 {
     "name": "a",
     "hashFunction": "sha512",
@@ -2466,8 +2466,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             }
         }
         self.releases.addLocaleToRelease(name='b', product='b', platform='q', locale='l', data=data, old_data_version=1, changed_by='bill')
-        ret = json.loads(select([self.releases.data]).where(self.releases.name == 'b').execute().fetchone()[0])
-        expected = json.loads("""
+        ret = select([self.releases.data]).where(self.releases.name == 'b').execute().fetchone()[0]
+        expected = createBlob("""
 {
     "name": "b",
     "hashFunction": "sha512",
@@ -2498,8 +2498,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='p3', locale='l', data=data, old_data_version=1, changed_by='bill')
-        ret = json.loads(select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0])
-        expected = json.loads("""
+        ret = select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0]
+        expected = createBlob("""
 {
     "name": "a",
     "hashFunction": "sha512",
@@ -2544,8 +2544,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='q', locale='l', data=data, old_data_version=1, changed_by='bill')
-        ret = json.loads(select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0])
-        expected = json.loads("""
+        ret = select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0]
+        expected = createBlob("""
 {
     "name": "a",
     "hashFunction": "sha512",
@@ -2592,8 +2592,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='p2', locale='j', data=data, old_data_version=1, changed_by='bill')
-        ret = json.loads(select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0])
-        expected = json.loads("""
+        ret = select([self.releases.data]).where(self.releases.name == 'a').execute().fetchone()[0]
+        expected = createBlob("""
 {
     "name": "a",
     "hashFunction": "sha512",
@@ -2771,7 +2771,7 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
         self.releases.insert(changed_by="bill", name='p', product='z', data=ancestor_blob)
         self.releases.update({"name": "p"}, {"product": "z", "data": blob1}, changed_by='bill', old_data_version=1)
         self.releases.update({"name": "p"}, {"product": "z", "data": blob2}, changed_by='bill', old_data_version=1)
-        ret = json.loads(select([self.releases.data]).where(self.releases.name == 'p').execute().fetchone()[0])
+        ret = select([self.releases.data]).where(self.releases.name == 'p').execute().fetchone()[0]
         self.assertEqual(result_blob, ret)
 
     def testAddConflictingOutdatedData(self):
@@ -3118,11 +3118,11 @@ class TestChangeNotifiers(unittest.TestCase):
         self.db.rules.scheduled_changes.conditions.t.insert().execute(sc_id=1, when=10000000000000000, data_version=1)
         self.db.permissions.t.insert().execute(permission="admin", username="bob", data_version=1)
         self.db.releases.t.insert().execute(name='a', product='a', read_only=True,
-                                            data=json.dumps(dict(name="a", schema_version=1, hashFunction="sha512")),
+                                            data=createBlob(dict(name="a", schema_version=1, hashFunction="sha512")),
                                             data_version=1)
         self.db.releases.t.insert().execute(name='b', product='b',
                                             read_only=False,
-                                            data=json.dumps(dict(name="b", schema_version=1, hashFunction="sha512")),
+                                            data=createBlob(dict(name="b", schema_version=1, hashFunction="sha512")),
                                             data_version=1)
 
     def _runTest(self, changer):

--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -4,6 +4,7 @@ from tempfile import mkstemp
 import unittest
 from xml.dom import minidom
 
+from auslib.blobs.base import createBlob
 from auslib.global_state import dbo
 from auslib.web.base import app
 from auslib.web.views.client import ClientRequestView
@@ -65,7 +66,7 @@ class ClientTestBase(ClientTestCommon):
         self.view = ClientRequestView()
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping='b', update_type='minor', product='b',
                                      data_version=1)
-        dbo.releases.t.insert().execute(name='b', product='b', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='b', product='b', data_version=1, data=createBlob("""
 {
     "name": "b",
     "schema_version": 1,
@@ -96,11 +97,11 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
 
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping='s', update_type='minor', product='s',
                                      systemCapabilities="SSE", data_version=1)
-        dbo.releases.t.insert().execute(name='s', product='s', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='s', product='s', data_version=1, data=createBlob("""
 {
     "name": "s",
     "schema_version": 1,
@@ -123,10 +124,10 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
         dbo.rules.t.insert().execute(priority=90, backgroundRate=0, mapping='q', update_type='minor', product='q',
                                      fallbackMapping='fallback', data_version=1)
-        dbo.releases.t.insert().execute(name='q', product='q', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='q', product='q', data_version=1, data=createBlob("""
 {
     "name": "q",
     "schema_version": 1,
@@ -149,8 +150,8 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
-        dbo.releases.t.insert().execute(name='fallback', product='q', data_version=1, data="""
+"""))
+        dbo.releases.t.insert().execute(name='fallback', product='q', data_version=1, data=createBlob("""
 {
     "name": "fallback",
     "schema_version": 1,
@@ -173,11 +174,11 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
 
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping='c', update_type='minor', product='c',
                                      distribution='default', data_version=1)
-        dbo.releases.t.insert().execute(name='c', product='c', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='c', product='c', data_version=1, data=createBlob("""
 {
     "name": "c",
     "schema_version": 1,
@@ -200,9 +201,9 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping='d', update_type='minor', product='d', data_version=1)
-        dbo.releases.t.insert().execute(name='d', product='d', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='d', product='d', data_version=1, data=createBlob("""
 {
     "name": "d",
     "schema_version": 1,
@@ -225,10 +226,10 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
 
         dbo.rules.t.insert().execute(priority=90, backgroundRate=0, mapping='e', update_type='minor', product='e', data_version=1)
-        dbo.releases.t.insert().execute(name='e', product='e', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='e', product='e', data_version=1, data=createBlob("""
 {
     "name": "e",
     "schema_version": 1,
@@ -249,14 +250,14 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
 
         dbo.rules.t.insert().execute(priority=100, backgroundRate=100, mapping='foxfood-whitelisted', update_type='minor', product='b2g',
                                      whitelist='b2g-whitelist', data_version=1)
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping='foxfood-whitelisted', update_type='minor', product='b2g',
                                      channel="foxfood", whitelist='b2g-whitelist', data_version=1)
         dbo.rules.t.insert().execute(priority=80, backgroundRate=100, mapping='foxfood-fallback', update_type='minor', product='b2g', data_version=1)
-        dbo.releases.t.insert().execute(name='b2g-whitelist', product='b2g', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='b2g-whitelist', product='b2g', data_version=1, data=createBlob("""
 {
   "name": "b2g-whitelist",
   "schema_version": 3000,
@@ -266,9 +267,9 @@ class ClientTestBase(ClientTestCommon):
     { "imei": "000000000000002" }
   ]
 }
-""")
+"""))
 
-        dbo.releases.t.insert().execute(name='foxfood-whitelisted', product='b2g', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='foxfood-whitelisted', product='b2g', data_version=1, data=createBlob("""
 {
     "name": "foxfood-whitelisted",
     "schema_version": 1,
@@ -290,8 +291,8 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
-        dbo.releases.t.insert().execute(name='foxfood-fallback', product='b2g', data_version=1, data="""
+"""))
+        dbo.releases.t.insert().execute(name='foxfood-fallback', product='b2g', data_version=1, data=createBlob("""
 {
     "name": "foxfood-fallback",
     "schema_version": 1,
@@ -313,7 +314,7 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
         dbo.rules.t.insert().execute(priority=200, backgroundRate=100,
                                      mapping='gmp', update_type='minor',
                                      product='gmp',
@@ -330,21 +331,21 @@ class ClientTestBase(ClientTestCommon):
                                      mapping='response-b', update_type='minor',
                                      product='response-b', data_version=1)
         dbo.releases.t.insert().execute(name='gmp-with-one-response-product',
-                                        product='gmp-with-one-response-product', data_version=1, data="""
+                                        product='gmp-with-one-response-product', data_version=1, data=createBlob("""
 {
     "name": "superblob",
     "schema_version": 4000,
     "products": ["response-a"]
 }
-""")
-        dbo.releases.t.insert().execute(name='gmp', product='gmp', data_version=1, data="""
+"""))
+        dbo.releases.t.insert().execute(name='gmp', product='gmp', data_version=1, data=createBlob("""
 {
     "name": "superblob",
     "schema_version": 4000,
     "products": ["response-a", "response-b"]
 }
-""")
-        dbo.releases.t.insert().execute(name='response-a', product='response-a', data_version=1, data="""
+"""))
+        dbo.releases.t.insert().execute(name='response-a', product='response-a', data_version=1, data=createBlob("""
 {
     "name": "response-a",
     "schema_version": 1,
@@ -379,8 +380,8 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
-        dbo.releases.t.insert().execute(name='response-b', product='response-b', data_version=1, data="""
+"""))
+        dbo.releases.t.insert().execute(name='response-b', product='response-b', data_version=1, data=createBlob("""
 {
     "name": "response-b",
     "schema_version": 1,
@@ -402,24 +403,24 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
         dbo.rules.t.insert().execute(priority=180, backgroundRate=100,
                                      mapping='systemaddons-uninstall', update_type='minor',
                                      product='systemaddons-uninstall', data_version=1)
         dbo.releases.t.insert().execute(name='systemaddons-uninstall',
-                                        product='systemaddons-uninstall', data_version=1, data="""
+                                        product='systemaddons-uninstall', data_version=1, data=createBlob("""
 {
     "name": "fake",
     "schema_version": 5000,
     "hashFunction": "SHA512",
     "uninstall": true
 }
-""")
+"""))
         dbo.rules.t.insert().execute(priority=180, backgroundRate=100,
                                      mapping='systemaddons', update_type='minor',
                                      product='systemaddons', data_version=1)
         dbo.releases.t.insert().execute(name='systemaddons',
-                                        product='systemaddons', data_version=1, data="""
+                                        product='systemaddons', data_version=1, data=createBlob("""
 {
     "name": "fake",
     "schema_version": 5000,
@@ -438,12 +439,12 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
 
         dbo.rules.t.insert().execute(priority=1000, backgroundRate=0, mapping='product_that_should_not_be_updated-1.1',
                                      update_type='minor', product='product_that_should_not_be_updated',
                                      data_version=1)
-        dbo.releases.t.insert().execute(name='product_that_should_not_be_updated-1.1', product='product_that_should_not_be_updated', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='product_that_should_not_be_updated-1.1', product='product_that_should_not_be_updated', data_version=1, data=createBlob("""
 {
     "name": "product_that_should_not_be_updated-1.1",
     "schema_version": 1,
@@ -466,12 +467,12 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
 
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping='product_that_should_not_be_updated-2.0',
                                      update_type='minor', product='product_that_should_not_be_updated',
                                      data_version=1)
-        dbo.releases.t.insert().execute(name='product_that_should_not_be_updated-2.0', product='product_that_should_not_be_updated', data_version=1, data="""
+        dbo.releases.t.insert().execute(name='product_that_should_not_be_updated-2.0', product='product_that_should_not_be_updated', data_version=1, data=createBlob("""
 {
     "name": "product_that_should_not_be_updated-2.0",
     "schema_version": 1,
@@ -494,7 +495,7 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
         dbo.rules.t.insert().execute(priority=200, backgroundRate=100,
                                      mapping='superblobaddon-with-multiple-response-blob', update_type='minor',
                                      product='superblobaddon-with-multiple-response-blob',
@@ -504,24 +505,24 @@ class ClientTestBase(ClientTestCommon):
                                      product='superblobaddon-with-one-response-blob',
                                      data_version=1)
         dbo.releases.t.insert().execute(name='superblobaddon-with-one-response-blob',
-                                        product='superblobaddon-with-one-response-blob', data_version=1, data="""
+                                        product='superblobaddon-with-one-response-blob', data_version=1, data=createBlob("""
 {
     "name": "superblobaddon",
     "schema_version": 4000,
     "revision": 123,
     "blobs": ["responseblob-a"]
 }
-""")
+"""))
         dbo.releases.t.insert().execute(name='superblobaddon-with-multiple-response-blob',
-                                        product='superblobaddon-with-multiple-response-blob', data_version=1, data="""
+                                        product='superblobaddon-with-multiple-response-blob', data_version=1, data=createBlob("""
 {
     "name": "superblobaddon",
     "schema_version": 4000,
     "revision": 124,
     "blobs": ["responseblob-a", "responseblob-b"]
 }
-""")
-        dbo.releases.t.insert().execute(name='responseblob-a', product='responseblob-a', data_version=1, data="""
+"""))
+        dbo.releases.t.insert().execute(name='responseblob-a', product='responseblob-a', data_version=1, data=createBlob("""
 {
     "name": "responseblob-a",
     "schema_version": 5000,
@@ -562,8 +563,8 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
-        dbo.releases.t.insert().execute(name='responseblob-b', product='responseblob-b', data_version=1, data="""
+"""))
+        dbo.releases.t.insert().execute(name='responseblob-b', product='responseblob-b', data_version=1, data=createBlob("""
 {
     "name": "responseblob-b",
     "schema_version": 5000,
@@ -583,7 +584,7 @@ class ClientTestBase(ClientTestCommon):
         }
     }
 }
-""")
+"""))
 
     def tearDown(self):
         os.close(self.version_fd)


### PR DESCRIPTION
While working on https://bugzilla.mozilla.org/show_bug.cgi?id=1310188 I discovered a bunch of test failures rooted in the releases.data and permissions.options columns. The problem boiled down to the fact that we retrieve the Scheduled Changes from the database when doing an update() or delete(), then pass the data to the base class to do a dry run of enacting the change. Because the rows are retrieved with ScheduledChanges.select(), the mirrored versions of releases.data and permissions.options end up as a string, _not_ a Blob/dict. This causes problems when the base classes try to validate the data, eg when .validate() is called here: https://github.com/mozilla/balrog/blob/a72bbc2289761ec20478665e16d21682a169d46e/auslib/db.py#L1558

This pull request fixes the issue by doing serialization/deserialization at the lowest possible level, using a custom column type as described here: http://docs.sqlalchemy.org/en/latest/core/custom_types.html. This might seem a bit heavy handed, but the only alternative I could come up with was monkey-patching self.scheduled_changes.select in Releases/Permissions.__init__, which seemed much worse.

Most of the patch is simply getting rid of now-unnecessary json.loads/dumps, and fixing some tests to compare against deserialized versions blobs/options instead of strings. A couple of other things of note:
- I had to get a bit more familiar with auslib/admin/views/history.py to make it cope properly. I ended up improving the release diffs to show data version + get rid of of unnecessary context at the same time.
- I made a small interface change to Permissions.getOptions() - it now returns None instead of {} if no options are found to simplify that code a bit. Its only consumer is hasPermission, which has been updated to cope.
- I was initially concerned that I might break caching, or make it less efficient. Manual tests + the cache tests (which verify hits/misses) have given me confidence that I didn't. AFAICT, the only thing that has changed is where deserialization happens, not whether it happens at all.
- I haven't touched the migration scripts because the underlying column type is still the same - the only change is in Python code that sits on top of it. It's a bit weird to have the types differ, but I didn't think it was useful to make a migration script that did nothing.