### PR TITLE
bug 1138418: Sanity check for hashes

### DIFF
--- a/auslib/blobs/apprelease.py
+++ b/auslib/blobs/apprelease.py
@@ -118,6 +118,16 @@ class ReleaseBlobBase(Blob):
         return '        <patch type="%s" URL="%s" hashFunction="%s" hashValue="%s" size="%s"/>' % \
             (patchType, url, self["hashFunction"], patch["hashValue"], patch["filesize"])
 
+    def validate(self, *args, **kwargs, ignore=False):
+        Blob.validate(self, *args, **kwargs)
+        required_length = Blob.hashes[self["hashFunction"].upper()]
+        if not ignore:
+            for platform in self["platforms"]:
+                for locale in platform["locales"]:
+                    for state in locale:
+                        if len(state["hashValue"]) != required_length:
+                            raise ValueError("Length of hash is not equal to that of {} function".format(self["hashFunction"]))
+
     def getInnerHeaderXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
         buildTarget = updateQuery["buildTarget"]
         locale = updateQuery["locale"]

--- a/auslib/blobs/base.py
+++ b/auslib/blobs/base.py
@@ -58,6 +58,7 @@ def createBlob(data):
 
 class Blob(dict):
     jsonschema = None
+    hashes = dict(SHA1=40, SHA256=64, SHA512=128, SHA384=96)
 
     def __init__(self, *args, **kwargs):
         super(Blob, self).__init__(self, *args, **kwargs)

--- a/auslib/blobs/gmp.py
+++ b/auslib/blobs/gmp.py
@@ -61,6 +61,15 @@ class GMPBlobV1(Blob):
 
         return vendorXML
 
+    def validate(self, *args, **kwargs, ignore=False):
+        Blob.validate(self, *args, **kwargs)
+        required_length = Blob.hashes[self["hashFunction"].upper()]
+        if not ignore:
+            for vendors in self["vendors"]:
+                for platform in vendors["platforms"]:
+                    if len(platform["hashValue"]) != required_length:
+                        raise ValueError("Length of hash is not equal to that of {} function".format(self["hashFunction"]))
+
     def containsForbiddenDomain(self, product, whitelistedDomains):
         """Returns True if the blob contains any file URLs that contain a
            domain that we're not allowed to serve updates to."""

--- a/auslib/blobs/systemaddons.py
+++ b/auslib/blobs/systemaddons.py
@@ -74,6 +74,15 @@ class SystemAddonsBlob(Blob):
 
         return addonXML
 
+    def validate(self, *args, **kwargs, ignore=False):
+        Blob.validate(self, *args, **kwargs)
+        required_length = Blob.hashes[self["hashFunction"].upper()]
+        if not ignore:
+            for addons in self["addons"]:
+                for platform in addons["platforms"]:
+                    if len(platform["hashValue"]) != required_length:
+                        raise ValueError("Length of hash is not equal to that of {} function".format(self["hashFunction"]))
+
     def getInnerHeaderXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
         if self.get("uninstall", False) or self.hasUpdates(updateQuery, whitelistedDomains):
             return '    <addons>'


### PR DESCRIPTION
Does this look like the right way of doing it ? Addressing to these comments :
> Zach and I exchanged some e-mail and it looks like he'll be taking a crack at this. I'll assign it to you to make sure no one else picks it up!
The best place to do this is probably in the individual blob classes that require a hash function (https://github.com/mozilla/balrog/blob/master/auslib/blobs/apprelease.py, https://github.com/mozilla/balrog/blob/master/auslib/blobs/gmp.py, and https://github.com/mozilla/balrog/blob/master/auslib/blobs/systemaddons.py). They will need to override the base class' validate method (but still call it to do the schema validation), and then walk through the blob data to ensure that all hashValues are the correct length for the given hashFunction

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/balrog/190)
<!-- Reviewable:end -->
