### PR TITLE
bug 1315369: pull latest balrogdb from hosted location when rebuildi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ dist
 ui/node_modules
 
 .DS_Store
+
+scripts/prod_db_dump.sql

--- a/scripts/import-db.py
+++ b/scripts/import-db.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+from calendar import timegm
+from datetime import datetime
+from httplib import HTTPSConnection
+import logging
+import os
+from socket import gaierror
+import time
+from urllib2 import urlopen, HTTPError, URLError
+
+
+HOST = 'https://balrog-public-dump-prod.s3.amazonaws.com'
+PATH = '/dump.sql.txt'
+LOCAL_DB_PATH = os.getenv('LOCAL_DUMP', '/app/scripts/prod_db_dump.sql')
+TIMEOUT = 10
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s: %(message)s')
+
+
+def getRemoteDBModifiedTS():
+    """
+    Performs a HEAD request to get the Last-Modified date-time
+    of a database dump file and parses it into a UNIX timestamp.
+    """
+    debug_msg = 'Unable to get timestamp of remote database dump - {0}'
+    logging.info("Getting timestamp of database dump at '%s'", HOST + PATH)
+    try:
+        # Removing the scheme from the URL
+        conn = HTTPSConnection(HOST[8:], timeout=TIMEOUT)
+        conn.request('HEAD', PATH)
+    except gaierror as e:
+        logging.debug(
+            debug_msg.format(
+                "Cannot connect to '%s', error: %s"),
+            HOST + PATH, e)
+        exit()
+
+    rsp = conn.getresponse()
+
+    if rsp.status != 200:
+        logging.debug(
+            debug_msg.format('Server responded with: %d %s'), rsp.status,
+            rsp.reason)
+        exit()
+
+    last_modified = rsp.getheader('last-modified', None)
+    if last_modified is None:
+        logging.debug(debug_msg.format(
+            'Response doesnt include Last-Modified Header'))
+        exit()
+
+    last_m_dt = datetime.strptime(
+        last_modified.split(', ')[1], '%d %b %Y %H:%M:%S %Z')
+    return timegm(last_m_dt.timetuple())
+
+
+def getLocalDBModifiedTS():
+    """
+    Gets the UNIX timestamp of the local database dump file.
+    Returns 0 on error.
+    """
+    try:
+        return int(os.path.getmtime(LOCAL_DB_PATH))
+    except OSError:
+        return 0
+
+
+def setLocalDBTimestamp(prod_db_ts):
+    """
+    Sets mtime on the local database dump file to the remote database dump
+    file's mtime. Sets atime to now.
+    """
+    now_ts = int(time.time())
+    os.utime(LOCAL_DB_PATH, (now_ts, prod_db_ts,))
+
+
+def setLocalDBPermissions():
+    os.chmod(LOCAL_DB_PATH, 0666)
+
+
+if __name__ == '__main__':
+    prod_db_ts = getRemoteDBModifiedTS()
+    local_db_ts = getLocalDBModifiedTS()
+
+    if prod_db_ts > 0:
+        if not os.path.exists(LOCAL_DB_PATH) or (prod_db_ts > local_db_ts):
+            logging.info("Downloading latest database dump to '%s'",
+                         LOCAL_DB_PATH)
+            try:
+                rsp = urlopen(HOST + PATH, timeout=TIMEOUT)
+            except (HTTPError, URLError) as e:
+                logging.debug('Downloading the latest database dump failed'
+                              'due to network error: %s', e)
+                exit()
+
+            with open(LOCAL_DB_PATH, 'wb') as f:
+                f.write(rsp.read())
+
+            setLocalDBTimestamp(prod_db_ts)
+            setLocalDBPermissions()

--- a/scripts/import-db.py
+++ b/scripts/import-db.py
@@ -99,3 +99,5 @@ if __name__ == '__main__':
 
             setLocalDBTimestamp(prod_db_ts)
             setLocalDBPermissions()
+        else:
+            logging.info("Cached dump is up-to-date")


### PR DESCRIPTION
…ng local db

This is a patch for https://bugzilla.mozilla.org/show_bug.cgi?id=1315369. It modifies the `initdb_and_run.sh` script to attempt to use the newest available database dump when populating the local database.

At first, it compares the time stamp of the dump at the specified URL and the local dump. If the dump at the specified URL is newer, or if the local dump doesn't exist, the script downloads the new dump and uses it to populate the database. If there is no network connectivity, the script uses the local dump, which is the newest available dump in this situation. If there is no network connectivity _and_ no local dump, the script will use the dump that's part of the repository (`scripts/sample-data.sql.bz2`).

**Edit 12/16/2016**: It just hit me that maybe adding `wget` as a dependency to the Dockerfile isn't the best solution here and that most of this can be performed by a Python script. What do you think?

