### PR TITLE
bug 1325460: rule history ui broken by bug 1285975

### DIFF
--- a/agent/tox.ini
+++ b/agent/tox.ini
@@ -11,7 +11,9 @@ setenv =
 deps =
     asynctest
     flake8
-    coverage
+# Pin coverage to work around https://bitbucket.org/ned/coveragepy/issues/541/coverage-43-breaks-nosetest-with-coverage
+# Long term fix: https://bugzilla.mozilla.org/show_bug.cgi?id=1326046
+    coverage==4.2
     pyflakes
     pytest
     pytest-catchlog

--- a/ui/app/js/controllers/rules_controller.js
+++ b/ui/app/js/controllers/rules_controller.js
@@ -130,7 +130,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
   $scope.removeFilterSearchWord = Search.removeFilterSearchWord;
 
   $scope.filterBySelect = function(rule) {
-    if ($scope.pr_ch_selected[0].toLowerCase() === "all rules") {
+    // Always return all entries if "all rules" is the filter
+    // or if $scope.rule_id is set (meaning we're on the history page).
+    if ($scope.pr_ch_selected[0].toLowerCase() === "all rules" || $scope.rule_id) {
       return true;
     }
     else if ($scope.pr_ch_selected && $scope.pr_ch_selected.length > 1) {


### PR DESCRIPTION
It looks like the issue here is that https://github.com/mozilla/balrog/commit/a23096f36fa474ac8df6c83d8f5abbea7c04f605#diff-71ee39a9a5979b46096d0bbc53a88574L8 changed the default value of $scope.pr_ch_options. This was the correct thing to do for the main rules page, but it broke the check that filterBySelect does to see if it should return all revisions or not.

This is a quick bustage fix because having broken history is really bad. In the medium-to-long term, we should probably rework the UI so that code like this is not shared.