### PR TITLE
bug 1326283: send http 400 for bad data error

### DIFF
--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -918,12 +918,11 @@ class ClientTestWithErrorHandlers(ClientTestCommon):
             self.assertEqual('I break!', str(exc.exception.message))
 
     def testSentryBadDataError(self):
-        with mock.patch("auslib.web.views.client.ClientRequestView.get") as m:
+        with mock.patch("auslib.web.views.client.ClientRequestView.get") as m, mock.patch("auslib.web.base.sentry") as sentry:
             m.side_effect = BadDataError("exterminate!")
-            with mock.patch("auslib.web.base.sentry") as sentry, self.assertRaises(Exception) as exc:
-                self.client.get("/update/4/b/1.0/1/p/l/a/a/a/a/1/update.xml")
+            ret = self.client.get("/update/4/b/1.0/1/p/l/a/a/a/a/1/update.xml")
             self.assertFalse(sentry.captureException.called)
-            self.assertEqual('exterminate!', str(exc.exception.message))
+            self.assertEqual(ret.status_code, 400, ret.data)
 
     def testSentryRealError(self):
         with mock.patch("auslib.web.views.client.ClientRequestView.get") as m:

--- a/auslib/web/base.py
+++ b/auslib/web/base.py
@@ -1,7 +1,7 @@
 import logging
 log = logging.getLogger(__name__)
 
-from flask import Flask, make_response, send_from_directory, abort
+from flask import Flask, make_response, send_from_directory, abort, Response
 
 from raven.contrib.flask import Sentry
 
@@ -37,13 +37,15 @@ def fourohfour(error):
 @app.errorhandler(Exception)
 def generic(error):
     """Deals with any unhandled exceptions. If the exception is not a
-    BadDataError, it will be sent to Sentry. Regardless of the exception,
-    a 500 response is returned."""
+    BadDataError, it will be sent to Sentry, and a 400 will be returned,
+    because BadDataErrors are considered to be the client's fault.
+    Otherwise, the error is just re-raised (which causes a 500)."""
 
-    if not isinstance(error, BadDataError):
-        if sentry.client:
-            sentry.captureException()
+    if isinstance(error, BadDataError):
+        return Response(status=400, response=error.message)
 
+    if sentry.client:
+        sentry.captureException()
     raise error
 
 


### PR DESCRIPTION
We stopped eating exceptions in https://bugzilla.mozilla.org/show_bug.cgi?id=1281459, which caused an increase of 500s in Datadog. The vast majority of these are BadDataError, which means the client did something dumb (usually caused by people or addons doing dumb things with the update URL). We should send 400 for these instead of 500, since it is the client's fault.