### PR TITLE
Bug 1304375 - no error in UI when release cannot be deleted

### DIFF
--- a/auslib/admin/views/base.py
+++ b/auslib/admin/views/base.py
@@ -51,6 +51,10 @@ def handleGeneralExceptions(messages):
                 msg = "Permission denied to perform the request. {}".format(e.message)
                 logging.warning(msg)
                 return Response(status=403, response=json.dumps({"exception": msg}), mimetype="application/json")
+            except ValueError as e:
+                msg = "Error. {}".format(e.message)
+                logging.warning(msg)
+                return Response(status=403, response=json.dumps({"exception": msg}), mimetype="application/json")
         return decorated
     return wrap
 

--- a/auslib/admin/views/base.py
+++ b/auslib/admin/views/base.py
@@ -54,7 +54,7 @@ def handleGeneralExceptions(messages):
             except ValueError as e:
                 msg = "Error. {}".format(e.message)
                 logging.warning(msg)
-                return Response(status=403, response=json.dumps({"exception": msg}), mimetype="application/json")
+                return Response(status=400, response=json.dumps({"exception": msg}), mimetype="application/json")
         return decorated
     return wrap
 

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -439,8 +439,8 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 403)
         
     def testDeleteWithRules(self):
-        ret = self._delete("/releases/d", qs=dict(name='ab', data_version=1))
-        self.assertStatusCode(ret, 403)
+        ret = self._delete("/releases/a", qs=dict(data_version=1))
+        self.assertStatusCode(ret, 400)
 
     def testLocalePut(self):
         data = json.dumps({

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -26,10 +26,13 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 404)
 
     def testReleasePostUpdateExisting(self):
-        data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1))
-        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
+        data = json.dumps(
+            dict(detailsUrl='blah', fakePartials=True, schema_version=1))
+        ret = self._post('/releases/d', data=dict(data=data,
+                                                  product='d', data_version=1))
         self.assertStatusCode(ret, 200)
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'd').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "d",
@@ -54,8 +57,10 @@ class TestReleasesAPI_JSON(ViewTest):
 """))
 
     def testReleasePostUpdateExistingWithoutPermission(self):
-        data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1))
-        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1), username="hannah")
+        data = json.dumps(
+            dict(detailsUrl='blah', fakePartials=True, schema_version=1))
+        ret = self._post('/releases/d', data=dict(data=data,
+                                                  product='d', data_version=1), username="hannah")
         self.assertStatusCode(ret, 403)
 
     def testReleasePutUpdateMergeableOutdatedData(self):
@@ -176,7 +181,8 @@ class TestReleasesAPI_JSON(ViewTest):
         ret = self._put('/releases/dd', data=dict(blob=ancestor_blob, name='dd',
                                                   product='dd', data_version=1))
         self.assertStatusCode(ret, 201)
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'dd').execute().fetchone()[0]
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'dd').execute().fetchone()[0]
         self.assertEqual(ret, createBlob(ancestor_blob))
 
         # Updating same release
@@ -191,7 +197,8 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 200)
         self.assertEqual(json.loads(ret.data), dict(new_data_version=3))
 
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'dd').execute().fetchone()[0]
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'dd').execute().fetchone()[0]
         self.assertEqual(ret, result_blob)
 
     def testReleasePutUpdateConflictingOutdatedData(self):
@@ -266,10 +273,12 @@ class TestReleasesAPI_JSON(ViewTest):
             }
         }"""
         # Testing Put request to add new release
-        ret = self._put('/releases/dd', data=dict(blob=ancestor_blob, name='dd', product='dd', data_version=1))
+        ret = self._put('/releases/dd', data=dict(blob=ancestor_blob,
+                                                  name='dd', product='dd', data_version=1))
         self.assertStatusCode(ret, 201)
 
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'dd').execute().fetchone()[0]
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'dd').execute().fetchone()[0]
         self.assertEqual(ret, createBlob(ancestor_blob))
 
         # Updating same release
@@ -305,16 +314,19 @@ class TestReleasesAPI_JSON(ViewTest):
                 }
             }
         }"""
-        ret = self._post('/releases/ee', data=dict(data=blob, hashFunction="sha512", name='ee', product='ee', data_version=1))
+        ret = self._post('/releases/ee', data=dict(data=blob,
+                                                   hashFunction="sha512", name='ee', product='ee', data_version=1))
         self.assertStatusCode(ret, 201)
 
         # Updating same release
-        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
+        self.assertEqual(ret.data, json.dumps(
+            dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = self._post('/releases/ee', data=dict(data=blob,
                                                    hashFunction="sha512",
                                                    name='ee', product='ee', data_version=2))
         self.assertStatusCode(ret, 200)
-        self.assertEqual(ret.data, json.dumps(dict(new_data_version=3)), "Data: %s" % ret.data)
+        self.assertEqual(ret.data, json.dumps(
+            dict(new_data_version=3)), "Data: %s" % ret.data)
 
         # Outdated Data Error on same release
         ret = self._post('/releases/ee', data=dict(hashFunction="sha512",
@@ -324,34 +336,43 @@ class TestReleasesAPI_JSON(ViewTest):
 
     def testReleasePostMismatchedName(self):
         data = json.dumps(dict(name="eee", schema_version=1))
-        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
+        ret = self._post('/releases/d', data=dict(data=data,
+                                                  product='d', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testReleasePostUpdateChangeHashFunction(self):
-        data = json.dumps(dict(detailsUrl='blah', hashFunction="sha1024", schema_version=1))
-        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
+        data = json.dumps(
+            dict(detailsUrl='blah', hashFunction="sha1024", schema_version=1))
+        ret = self._post('/releases/d', data=dict(data=data,
+                                                  product='d', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testReleasePostUpdateChangeProduct(self):
         data = json.dumps(dict(detailsUrl="abc", schema_version=1))
-        ret = self._post("/releases/c", data=dict(data=data, product="h", data_version=1))
+        ret = self._post("/releases/c", data=dict(data=data,
+                                                  product="h", data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testReleasePostInvalidBlob(self):
         data = json.dumps(dict(uehont="uhetn", schema_version=1))
-        ret = self._post("/releases/c", data=dict(data=data, product="c", data_version=1))
+        ret = self._post("/releases/c", data=dict(data=data,
+                                                  product="c", data_version=1))
         self.assertStatusCode(ret, 400)
         self.assertIn("Additional properties are not allowed", ret.data)
 
     def testReleasePostWithSignoffRequired(self):
-        data = json.dumps(dict(bouncerProducts=dict(partial='foo'), name='a', hashFunction="sha512"))
-        ret = self._post("/releases/a", data=dict(data=data, product="a", data_version=1, schema_version=1))
+        data = json.dumps(dict(bouncerProducts=dict(
+            partial='foo'), name='a', hashFunction="sha512"))
+        ret = self._post("/releases/a", data=dict(data=data,
+                                                  product="a", data_version=1, schema_version=1))
         self.assertStatusCode(ret, 400)
         self.assertIn("This change requires signoff", ret.data)
 
     def testReleasePostCreatesNewReleasev1(self):
-        data = json.dumps(dict(bouncerProducts=dict(partial='foo'), name='e', hashFunction="sha512"))
-        ret = self._post('/releases/e', data=dict(data=data, product='e', schema_version=1))
+        data = json.dumps(dict(bouncerProducts=dict(
+            partial='foo'), name='e', hashFunction="sha512"))
+        ret = self._post('/releases/e', data=dict(data=data,
+                                                  product='e', schema_version=1))
         self.assertStatusCode(ret, 201)
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
@@ -368,13 +389,17 @@ class TestReleasesAPI_JSON(ViewTest):
 """))
 
     def testReleasePostCreatesNewReleaseNopermission(self):
-        data = json.dumps(dict(bouncerProducts=dict(partial='foo'), name='e', hashFunction="sha512"))
-        ret = self._post('/releases/e', data=dict(data=data, product='e', schema_version=1), username="kate")
+        data = json.dumps(dict(bouncerProducts=dict(
+            partial='foo'), name='e', hashFunction="sha512"))
+        ret = self._post('/releases/e', data=dict(data=data,
+                                                  product='e', schema_version=1), username="kate")
         self.assertStatusCode(ret, 403)
 
     def testReleasePostCreatesNewReleasev2(self):
-        data = json.dumps(dict(bouncerProducts=dict(complete='foo'), name='e', hashFunction="sha512"))
-        ret = self._post('/releases/e', data=dict(data=data, product='e', schema_version=2))
+        data = json.dumps(dict(bouncerProducts=dict(
+            complete='foo'), name='e', hashFunction="sha512"))
+        ret = self._post('/releases/e', data=dict(data=data,
+                                                  product='e', schema_version=2))
         self.assertStatusCode(ret, 201)
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
@@ -396,14 +421,17 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 400)
 
     def testReleasePostRejectedURL(self):
-        data = json.dumps(dict(platforms=dict(p=dict(locales=dict(f=dict(complete=dict(fileUrl='http://evil.com')))))))
-        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
+        data = json.dumps(dict(platforms=dict(
+            p=dict(locales=dict(f=dict(complete=dict(fileUrl='http://evil.com')))))))
+        ret = self._post('/releases/d', data=dict(data=data,
+                                                  product='d', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testDeleteRelease(self):
         ret = self._delete("/releases/d", qs=dict(data_version=1))
         self.assertStatusCode(ret, 200)
-        ret = dbo.releases.t.count().where(dbo.releases.name == 'd').execute().first()[0]
+        ret = dbo.releases.t.count().where(
+            dbo.releases.name == 'd').execute().first()[0]
         self.assertEqual(ret, 0)
 
     def testDeleteReleaseOutdatedData(self):
@@ -418,26 +446,32 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 404)
 
     def testDeleteWithoutPermission(self):
-        ret = self._delete("/releases/d", username="bob", qs=dict(data_version=1))
+        ret = self._delete("/releases/d", username="bob",
+                           qs=dict(data_version=1))
         self.assertStatusCode(ret, 403)
 
     def testDeleteWithoutPermissionForAction(self):
-        ret = self._delete("/releases/d", username="bob", qs=dict(data_version=1))
+        ret = self._delete("/releases/d", username="bob",
+                           qs=dict(data_version=1))
         self.assertStatusCode(ret, 403)
 
     def testDeleteWithProductAdminPermission(self):
-        ret = self._delete("/releases/d", username="bill", qs=dict(data_version=1))
+        ret = self._delete("/releases/d", username="bill",
+                           qs=dict(data_version=1))
         self.assertStatusCode(ret, 200)
 
     def testDeleteWithoutProductAdminPermission(self):
-        ret = self._delete("/releases/d", username="billy", qs=dict(data_version=1))
+        ret = self._delete("/releases/d", username="billy",
+                           qs=dict(data_version=1))
         self.assertStatusCode(ret, 403)
 
     def testDeleteReadOnlyRelease(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "d").execute()
-        ret = self._delete("/releases/d", username="bill", qs=dict(data_version=2))
+        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(
+            dbo.releases.name == "d").execute()
+        ret = self._delete("/releases/d", username="bill",
+                           qs=dict(data_version=2))
         self.assertStatusCode(ret, 403)
-        
+
     def testDeleteWithRules(self):
         ret = self._delete("/releases/a", qs=dict(data_version=1))
         self.assertStatusCode(ret, 400)
@@ -450,10 +484,13 @@ class TestReleasesAPI_JSON(ViewTest):
                 "hashValue": "abc",
             }
         })
-        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data,
+                                                             product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'ab').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(
+            dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'ab').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "ab",
@@ -483,10 +520,13 @@ class TestReleasesAPI_JSON(ViewTest):
                 "hashValue": "abc",
             }
         })
-        ret = self._put('/releases/ab/builds/p/l', username="ashanti", data=dict(data=data, product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', username="ashanti",
+                        data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'ab').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(
+            dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'ab').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "ab",
@@ -510,17 +550,20 @@ class TestReleasesAPI_JSON(ViewTest):
 
     def testLocalePutWithBadHashFunction(self):
         data = json.dumps(dict(complete=dict(filesize='435')))
-        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data,
+                                                             product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 400)
 
     def testLocalePutWithoutPermission(self):
         data = '{"complete": {"filesize": 435, "from": "*", "hashValue": "abc"}}'
-        ret = self._put('/releases/ab/builds/p/l', username='liu', data=dict(data=data, product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', username='liu',
+                        data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 403)
 
     def testLocalePutWithoutPermissionForProduct(self):
         data = '{"complete": {"filesize": 435, "from": "*", "hashValue": "abc"}}'
-        ret = self._put('/releases/ab/builds/p/l', username='bob', data=dict(data=data, product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', username='bob',
+                        data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 403)
 
     def testLocalePutForNewRelease(self):
@@ -533,10 +576,13 @@ class TestReleasesAPI_JSON(ViewTest):
         })
         # setting schema_version in the incoming blob is a hack for testing
         # SingleLocaleView._put() doesn't give us access to the form
-        ret = self._put('/releases/e/builds/p/a', data=dict(data=data, product='e', hashFunction="sha512", schema_version=1))
+        ret = self._put('/releases/e/builds/p/a', data=dict(data=data,
+                                                            product='e', hashFunction="sha512", schema_version=1))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'e').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(
+            dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'e').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "e",
@@ -567,10 +613,13 @@ class TestReleasesAPI_JSON(ViewTest):
                 "fileUrl": "http://good.com/blah",
             }
         })
-        ret = self._put('/releases/d/builds/p/g', data=dict(data=data, product='d', data_version=1, schema_version=1))
+        ret = self._put('/releases/d/builds/p/g', data=dict(data=data,
+                                                            product='d', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(
+            dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'd').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "d",
@@ -610,10 +659,13 @@ class TestReleasesAPI_JSON(ViewTest):
         })
         # setting schema_version in the incoming blob is a hack for testing
         # SingleLocaleView._put() doesn't give us access to the form
-        ret = self._put('/releases/e/builds/p/a', data=dict(data=data, product='e', alias='["p2"]', schema_version=1, hashFunction="sha512"))
+        ret = self._put('/releases/e/builds/p/a', data=dict(data=data, product='e',
+                                                            alias='["p2"]', schema_version=1, hashFunction="sha512"))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'e').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(
+            dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'e').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "e",
@@ -647,10 +699,13 @@ class TestReleasesAPI_JSON(ViewTest):
                 "fileUrl": "http://good.com/blah",
             }
         })
-        ret = self._put('/releases/d/builds/q/g', data=dict(data=data, product='d', data_version=1, alias='["q2"]', schema_version=1))
+        ret = self._put('/releases/d/builds/q/g', data=dict(data=data,
+                                                            product='d', data_version=1, alias='["q2"]', schema_version=1))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(
+            dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'd').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "d",
@@ -695,11 +750,14 @@ class TestReleasesAPI_JSON(ViewTest):
                 "hashValue": "abc",
             }
         })
-        data = dict(data=data, product='a', copyTo=json.dumps(['b']), data_version=1, schema_version=1)
+        data = dict(data=data, product='a', copyTo=json.dumps(
+            ['b']), data_version=1, schema_version=1)
         ret = self._put('/releases/ab/builds/p/l', data=data)
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'ab').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(
+            dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'ab').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "ab",
@@ -720,7 +778,8 @@ class TestReleasesAPI_JSON(ViewTest):
     }
 }
 """))
-        ret = select([dbo.releases.data]).where(dbo.releases.name == 'b').execute().fetchone()[0]
+        ret = select([dbo.releases.data]).where(
+            dbo.releases.name == 'b').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "b",
@@ -743,12 +802,14 @@ class TestReleasesAPI_JSON(ViewTest):
 """))
 
     def testLocalePutBadJSON(self):
-        ret = self._put('/releases/ab/builds/p/l', data=dict(data='a', product='a'))
+        ret = self._put('/releases/ab/builds/p/l',
+                        data=dict(data='a', product='a'))
         self.assertStatusCode(ret, 400)
 
     def testLocaleRejectedURL(self):
         data = json.dumps(dict(complete=dict(fileUrl='http://evil.com')))
-        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1))
+        ret = self._put('/releases/ab/builds/p/l',
+                        data=dict(data=data, product='a', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testLocaleGet(self):
@@ -770,7 +831,8 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 401)
 
     def testLocalePutReadOnlyRelease(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "ab").execute()
+        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(
+            dbo.releases.name == "ab").execute()
         data = json.dumps({
             "complete": {
                 "filesize": 435,
@@ -778,7 +840,8 @@ class TestReleasesAPI_JSON(ViewTest):
                 "hashValue": "abc",
             }
         })
-        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data,
+                                                             product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 403)
 
     def testLocalePutWithProductAdmin(self):
@@ -807,7 +870,8 @@ class TestReleasesAPI_JSON(ViewTest):
 
     def testLocalePutCantChangeProduct(self):
         data = json.dumps(dict(complete=dict(filesize=435)))
-        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='b', schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l',
+                        data=dict(data=data, product='b', schema_version=1))
         self.assertStatusCode(ret, 400)
 
     def testLocaleGet404(self):
@@ -846,8 +910,10 @@ class TestReleasesAPI_JSON(ViewTest):
 }
 """))
 
-        self.assertEquals(ret.status_code, 201, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
-        r = dbo.releases.t.select().where(dbo.releases.name == 'new_release').execute().fetchall()
+        self.assertEquals(ret.status_code, 201, "Status Code: %d, Data: %s" % (
+            ret.status_code, ret.data))
+        r = dbo.releases.t.select().where(
+            dbo.releases.name == 'new_release').execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'new_release')
         self.assertEquals(r[0]['product'], 'Firefox')
@@ -896,7 +962,8 @@ class TestReleasesAPI_JSON(ViewTest):
     "actions": "doit"
 }
 """))
-        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (
+            ret.status_code, ret.data))
         r = dbo.releases.t.select().where(dbo.releases.name == 'd').execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'd')
@@ -936,8 +1003,10 @@ class TestReleasesAPI_JSON(ViewTest):
 }
 """))
 
-        self.assertEquals(ret.status_code, 201, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
-        r = dbo.releases.t.select().where(dbo.releases.name == 'gmprel').execute().fetchall()
+        self.assertEquals(ret.status_code, 201, "Status Code: %d, Data: %s" % (
+            ret.status_code, ret.data))
+        r = dbo.releases.t.select().where(
+            dbo.releases.name == 'gmprel').execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'gmprel')
         self.assertEquals(r[0]['product'], 'a')
@@ -1010,8 +1079,10 @@ class TestReleasesAPI_JSON(ViewTest):
 """))
 
     def testReleasesPost(self):
-        data = json.dumps(dict(bouncerProducts=dict(partial='foo'), name='e', schema_version=1, hashFunction="sha512"))
-        ret = self._post('/releases', data=dict(blob=data, name="e", product='e'))
+        data = json.dumps(dict(bouncerProducts=dict(
+            partial='foo'), name='e', schema_version=1, hashFunction="sha512"))
+        ret = self._post(
+            '/releases', data=dict(blob=data, name="e", product='e'))
         self.assertStatusCode(ret, 201)
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
@@ -1035,19 +1106,25 @@ class TestReleasesScheduledChanges(ViewTest):
         super(TestReleasesScheduledChanges, self).setUp()
         dbo.releases.scheduled_changes.t.insert().execute(
             sc_id=1, scheduled_by="bill", change_type="insert", data_version=1, base_name="m", base_product="m",
-            base_data=createBlob(dict(name="m", hashFunction="sha512", schema_version=1))
+            base_data=createBlob(
+                dict(name="m", hashFunction="sha512", schema_version=1))
         )
-        dbo.releases.scheduled_changes.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=50, sc_id=1)
+        dbo.releases.scheduled_changes.history.t.insert().execute(
+            change_id=1, changed_by="bill", timestamp=50, sc_id=1)
         dbo.releases.scheduled_changes.history.t.insert().execute(
             change_id=2, changed_by="bill", timestamp=51, sc_id=1, scheduled_by="bill", change_type="insert", data_version=1, base_name="m",
             base_product="m", base_data=createBlob(dict(name="m", hashFunction="sha512", schema_version=1))
         )
-        dbo.releases.scheduled_changes.signoffs.t.insert().execute(sc_id=1, username="bill", role="releng")
-        dbo.releases.scheduled_changes.signoffs.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=100, sc_id=1, username="bill")
+        dbo.releases.scheduled_changes.signoffs.t.insert().execute(
+            sc_id=1, username="bill", role="releng")
+        dbo.releases.scheduled_changes.signoffs.history.t.insert().execute(
+            change_id=1, changed_by="bill", timestamp=100, sc_id=1, username="bill")
         dbo.releases.scheduled_changes.signoffs.history.t.insert().execute(change_id=2, changed_by="bill", timestamp=101, sc_id=1,
                                                                            username="bill", role="releng")
-        dbo.releases.scheduled_changes.conditions.t.insert().execute(sc_id=1, when=4000000000, data_version=1)
-        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=50, sc_id=1)
+        dbo.releases.scheduled_changes.conditions.t.insert().execute(
+            sc_id=1, when=4000000000, data_version=1)
+        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
+            change_id=1, changed_by="bill", timestamp=50, sc_id=1)
         dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
             change_id=2, changed_by="bill", timestamp=51, sc_id=1, when=4000000000, data_version=1
         )
@@ -1056,13 +1133,16 @@ class TestReleasesScheduledChanges(ViewTest):
             sc_id=2, scheduled_by="bill", change_type="update", data_version=1, base_name="c", base_product="c",
             base_data=createBlob(dict(name="c", hashFunction="sha512", schema_version=1, extv="2.0")), base_data_version=1
         )
-        dbo.releases.scheduled_changes.history.t.insert().execute(change_id=3, changed_by="bill", timestamp=70, sc_id=2)
+        dbo.releases.scheduled_changes.history.t.insert().execute(
+            change_id=3, changed_by="bill", timestamp=70, sc_id=2)
         dbo.releases.scheduled_changes.history.t.insert().execute(
             change_id=4, changed_by="bill", timestamp=71, sc_id=2, scheduled_by="bill", change_type="update", data_version=1, base_name="c",
             base_product="c", base_data=createBlob(dict(name="c", hashFunction="sha512", schema_version=1, extv="2.0")), base_data_version=1
         )
-        dbo.releases.scheduled_changes.conditions.t.insert().execute(sc_id=2, when=6000000000, data_version=1)
-        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(change_id=3, changed_by="bill", timestamp=70, sc_id=2)
+        dbo.releases.scheduled_changes.conditions.t.insert().execute(
+            sc_id=2, when=6000000000, data_version=1)
+        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
+            change_id=3, changed_by="bill", timestamp=70, sc_id=2)
         dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
             change_id=4, changed_by="bill", timestamp=71, sc_id=2, when=6000000000, data_version=1
         )
@@ -1071,7 +1151,8 @@ class TestReleasesScheduledChanges(ViewTest):
             sc_id=3, complete=True, scheduled_by="bill", change_type="update", data_version=2, base_name="b", base_product="b",
             base_data=createBlob(dict(name="b", hashFunction="sha512", schema_version=1)), base_data_version=1
         )
-        dbo.releases.scheduled_changes.history.t.insert().execute(change_id=5, changed_by="bill", timestamp=6, sc_id=3)
+        dbo.releases.scheduled_changes.history.t.insert().execute(
+            change_id=5, changed_by="bill", timestamp=6, sc_id=3)
         dbo.releases.scheduled_changes.history.t.insert().execute(
             change_id=6, changed_by="bill", timestamp=7, sc_id=3, complete=False, scheduled_by="bill", change_type="update", data_version=1, base_name="b",
             base_product="b", base_data=createBlob(dict(name="b", hashFunction="sha512", schema_version=1)), base_data_version=1
@@ -1080,8 +1161,10 @@ class TestReleasesScheduledChanges(ViewTest):
             change_id=7, changed_by="bill", timestamp=25, sc_id=3, complete=True, change_type="update", scheduled_by="bill", data_version=2, base_name="b",
             base_product="b", base_data=createBlob(dict(name="b", hashFunction="sha512", schema_version=1)), base_data_version=1
         )
-        dbo.releases.scheduled_changes.conditions.t.insert().execute(sc_id=3, when=10000000, data_version=2)
-        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(change_id=5, changed_by="bill", timestamp=6, sc_id=3)
+        dbo.releases.scheduled_changes.conditions.t.insert().execute(
+            sc_id=3, when=10000000, data_version=2)
+        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
+            change_id=5, changed_by="bill", timestamp=6, sc_id=3)
         dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
             change_id=6, changed_by="bill", timestamp=7, sc_id=3, when=10000000, data_version=1
         )
@@ -1092,13 +1175,16 @@ class TestReleasesScheduledChanges(ViewTest):
         dbo.releases.scheduled_changes.t.insert().execute(
             sc_id=4, complete=False, scheduled_by="bill", change_type="delete", data_version=1, base_name="ab", base_data_version=1,
         )
-        dbo.releases.scheduled_changes.history.t.insert().execute(change_id=8, changed_by="bill", timestamp=25, sc_id=4)
+        dbo.releases.scheduled_changes.history.t.insert().execute(
+            change_id=8, changed_by="bill", timestamp=25, sc_id=4)
         dbo.releases.scheduled_changes.history.t.insert().execute(
             change_id=9, changed_by="bill", timestamp=26, sc_id=4, complete=False, scheduled_by="bill", change_type="delete", data_version=1,
             base_name="ab", base_data_version=1
         )
-        dbo.releases.scheduled_changes.conditions.t.insert().execute(sc_id=4, when=230000000, data_version=1)
-        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(change_id=8, changed_by="bill", timestamp=25, sc_id=4)
+        dbo.releases.scheduled_changes.conditions.t.insert().execute(
+            sc_id=4, when=230000000, data_version=1)
+        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
+            change_id=8, changed_by="bill", timestamp=25, sc_id=4)
         dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
             change_id=9, changed_by="bill", timestamp=26, sc_id=4, when=230000000, data_version=1
         )
@@ -1163,7 +1249,8 @@ class TestReleasesScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/releases", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"sc_id": 5})
-        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(
+            dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1171,7 +1258,8 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_name": "d", "base_data": {"name": "d", "hashFunction": "sha256", "schema_version": 1}, "base_data_version": 1
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
+            dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 5, "data_version": 1, "when": 2300000000}
         self.assertEquals(dict(cond[0]), cond_expected)
@@ -1184,7 +1272,8 @@ class TestReleasesScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/releases", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"sc_id": 5})
-        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(
+            dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1192,7 +1281,8 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_name": "d", "base_data": None, "base_data_version": 1,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
+            dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 5, "data_version": 1, "when": 4200000000}
         self.assertEquals(dict(cond[0]), cond_expected)
@@ -1206,7 +1296,8 @@ class TestReleasesScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/releases", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"sc_id": 5})
-        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(
+            dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1214,7 +1305,8 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_name": "q", "base_data": {"name": "q", "hashFunction": "sha512", "schema_version": 1}, "base_data_version": None,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
+            dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 5, "data_version": 1, "when": 5200000000}
         self.assertEquals(dict(cond[0]), cond_expected)
@@ -1229,7 +1321,8 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"new_data_version": 2})
 
-        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(
+            dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1238,7 +1331,8 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_data_version": 1,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 2).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
+            dbo.releases.scheduled_changes.conditions.sc_id == 2).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 2, "data_version": 2, "when": 78900000000}
         self.assertEquals(dict(cond[0]), cond_expected)
@@ -1253,7 +1347,8 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"new_data_version": 2})
 
-        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(
+            dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1262,7 +1357,8 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_data_version": None,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 1).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
+            dbo.releases.scheduled_changes.conditions.sc_id == 1).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 1, "data_version": 2, "when": 4000000000}
         self.assertEquals(dict(cond[0]), cond_expected)
@@ -1277,7 +1373,8 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"new_data_version": 2})
 
-        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(
+            dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1286,24 +1383,29 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_data_version": None,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 1).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
+            dbo.releases.scheduled_changes.conditions.sc_id == 1).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 1, "data_version": 2, "when": 4000000000}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     def testDeleteScheduledChange(self):
-        ret = self._delete("/scheduled_changes/releases/2", qs={"data_version": 1})
+        ret = self._delete("/scheduled_changes/releases/2",
+                           qs={"data_version": 1})
         self.assertEquals(ret.status_code, 200, ret.data)
-        got = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
+        got = dbo.releases.scheduled_changes.t.select().where(
+            dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
         self.assertEquals(got, [])
-        cond_got = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 2).execute().fetchall()
+        cond_got = dbo.releases.scheduled_changes.conditions.t.select().where(
+            dbo.releases.scheduled_changes.conditions.sc_id == 2).execute().fetchall()
         self.assertEquals(cond_got, [])
 
     def testEnactScheduledChangeExistingRelease(self):
         ret = self._post("/scheduled_changes/releases/2/enact")
         self.assertEquals(ret.status_code, 200, ret.data)
 
-        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(
+            dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1313,7 +1415,8 @@ class TestReleasesScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-        base_row = dict(dbo.releases.t.select().where(dbo.releases.name == "c").execute().fetchall()[0])
+        base_row = dict(dbo.releases.t.select().where(
+            dbo.releases.name == "c").execute().fetchall()[0])
         base_expected = {
             "name": "c", "product": "c", "read_only": False,
             "data": {"name": "c", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"}, "data_version": 2,
@@ -1324,7 +1427,8 @@ class TestReleasesScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/releases/1/enact")
         self.assertEquals(ret.status_code, 200, ret.data)
 
-        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(
+            dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1334,7 +1438,8 @@ class TestReleasesScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-        base_row = dict(dbo.releases.t.select().where(dbo.releases.name == "m").execute().fetchall()[0])
+        base_row = dict(dbo.releases.t.select().where(
+            dbo.releases.name == "m").execute().fetchall()[0])
         base_expected = {
             "name": "m", "product": "m", "read_only": False,
             "data": {"name": "m", "hashFunction": "sha512", "schema_version": 1}, "data_version": 1,
@@ -1345,7 +1450,8 @@ class TestReleasesScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/releases/4/enact")
         self.assertEquals(ret.status_code, 200, ret.data)
 
-        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 4).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(
+            dbo.releases.scheduled_changes.sc_id == 4).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1354,7 +1460,8 @@ class TestReleasesScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-        base_row = dbo.releases.t.select().where(dbo.releases.name == "ab").execute().fetchall()
+        base_row = dbo.releases.t.select().where(
+            dbo.releases.name == "ab").execute().fetchall()
         self.assertEquals(len(base_row), 0)
 
     def testGetScheduledChangeHistoryRevisions(self):
@@ -1380,25 +1487,34 @@ class TestReleasesScheduledChanges(ViewTest):
 
     @mock.patch("time.time", mock.MagicMock(return_value=100))
     def testSignoffWithPermission(self):
-        ret = self._post("/scheduled_changes/releases/2/signoffs", data=dict(role="qa"), username="bill")
+        ret = self._post("/scheduled_changes/releases/2/signoffs",
+                         data=dict(role="qa"), username="bill")
         self.assertEquals(ret.status_code, 200, ret.data)
-        r = dbo.releases.scheduled_changes.signoffs.t.select().where(dbo.releases.scheduled_changes.signoffs.sc_id == 2).execute().fetchall()
+        r = dbo.releases.scheduled_changes.signoffs.t.select().where(
+            dbo.releases.scheduled_changes.signoffs.sc_id == 2).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
-        self.assertEquals(db_data, {"sc_id": 2, "username": "bill", "role": "qa"})
-        r = dbo.releases.scheduled_changes.signoffs.history.t.select().where(dbo.releases.scheduled_changes.signoffs.history.sc_id == 2).execute().fetchall()
+        self.assertEquals(
+            db_data, {"sc_id": 2, "username": "bill", "role": "qa"})
+        r = dbo.releases.scheduled_changes.signoffs.history.t.select().where(
+            dbo.releases.scheduled_changes.signoffs.history.sc_id == 2).execute().fetchall()
         self.assertEquals(len(r), 2)
-        self.assertEquals(dict(r[0]), {"change_id": 3, "changed_by": "bill", "timestamp": 99999, "sc_id": 2, "username": "bill", "role": None})
-        self.assertEquals(dict(r[1]), {"change_id": 4, "changed_by": "bill", "timestamp": 100000, "sc_id": 2, "username": "bill", "role": "qa"})
+        self.assertEquals(dict(r[0]), {"change_id": 3, "changed_by": "bill",
+                                       "timestamp": 99999, "sc_id": 2, "username": "bill", "role": None})
+        self.assertEquals(dict(r[1]), {"change_id": 4, "changed_by": "bill",
+                                       "timestamp": 100000, "sc_id": 2, "username": "bill", "role": "qa"})
 
     def testSignoffWithoutPermission(self):
-        ret = self._post("/scheduled_changes/releases/2/signoffs", data=dict(role="relman"), username="bill")
+        ret = self._post("/scheduled_changes/releases/2/signoffs",
+                         data=dict(role="relman"), username="bill")
         self.assertEquals(ret.status_code, 403, ret.data)
 
     def testRevokeSignoff(self):
-        ret = self._delete("/scheduled_changes/releases/1/signoffs", username="bill")
+        ret = self._delete(
+            "/scheduled_changes/releases/1/signoffs", username="bill")
         self.assertEquals(ret.status_code, 200, ret.data)
-        r = dbo.releases.scheduled_changes.signoffs.t.select().where(dbo.releases.scheduled_changes.signoffs.sc_id == 1).execute().fetchall()
+        r = dbo.releases.scheduled_changes.signoffs.t.select().where(
+            dbo.releases.scheduled_changes.signoffs.sc_id == 1).execute().fetchall()
         self.assertEquals(len(r), 0)
 
 
@@ -1406,7 +1522,8 @@ class TestReleaseHistoryView(ViewTest):
 
     def testGetRevisions(self):
         # Make some changes to a release
-        data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1))
+        data = json.dumps(
+            dict(detailsUrl='blah', fakePartials=True, schema_version=1))
         ret = self._post(
             '/releases/d',
             data=dict(
@@ -1439,7 +1556,8 @@ class TestReleaseHistoryView(ViewTest):
 
     def testPostRevisionRollback(self):
         # Make some changes to a release
-        data = json.dumps(dict(detailsUrl='beep', fakePartials=True, schema_version=1))
+        data = json.dumps(
+            dict(detailsUrl='beep', fakePartials=True, schema_version=1))
         ret = self._post(
             '/releases/d',
             data=dict(
@@ -1450,7 +1568,8 @@ class TestReleaseHistoryView(ViewTest):
         )
         self.assertStatusCode(ret, 200)
 
-        data = json.dumps(dict(detailsUrl='boop', fakePartials=False, schema_version=1))
+        data = json.dumps(
+            dict(detailsUrl='boop', fakePartials=False, schema_version=1))
         ret = self._post(
             '/releases/d',
             data=dict(
@@ -1473,7 +1592,8 @@ class TestReleaseHistoryView(ViewTest):
         self.assertEqual(count, 2)
 
         row, = table.history.select(
-            where=[(table.history.product == 'd') & (table.history.data_version == 2)],
+            where=[(table.history.product == 'd') & (
+                table.history.data_version == 2)],
             limit=1
         )
         change_id = row['change_id']
@@ -1494,7 +1614,8 @@ class TestReleaseHistoryView(ViewTest):
         self.assertEqual(data['detailsUrl'], 'beep')
 
     def testPostRevisionRollbackBadRequests(self):
-        data = json.dumps(dict(detailsUrl='beep', fakePartials=True, schema_version=1))
+        data = json.dumps(
+            dict(detailsUrl='beep', fakePartials=True, schema_version=1))
         ret = self._post(
             '/releases/d',
             data=dict(
@@ -1505,7 +1626,8 @@ class TestReleaseHistoryView(ViewTest):
         )
         self.assertStatusCode(ret, 200)
         # when posting you need both the release name and the change_id
-        ret = self._post('/releases/CRAZYNAME/revisions', json.dumps({'change_id': 1}))
+        ret = self._post('/releases/CRAZYNAME/revisions',
+                         json.dumps({'change_id': 1}))
         self.assertEquals(ret.status_code, 404, ret.data)
 
         url = '/releases/d/revisions'
@@ -1524,7 +1646,8 @@ class TestSingleColumn_JSON(ViewTest):
         ret = self._get("/releases/columns/product")
         ret_data = json.loads(ret.data)
         self.assertEquals(ret_data['count'], expected['count'])
-        self.assertEquals(ret_data['product'].sort(), expected['product'].sort())
+        self.assertEquals(ret_data['product'].sort(),
+                          expected['product'].sort())
 
     def testGetReleaseColumn404(self):
         ret = self.client.get("/releases/columns/blah")
@@ -1535,7 +1658,8 @@ class TestReadOnlyView(ViewTest):
 
     def testReadOnlyGet(self):
         ret = self._get('/releases/b/read_only')
-        is_read_only = dbo.releases.t.select(dbo.releases.name == 'b').execute().first()['read_only']
+        is_read_only = dbo.releases.t.select(
+            dbo.releases.name == 'b').execute().first()['read_only']
         self.assertEqual(json.loads(ret.data)['read_only'], is_read_only)
 
     def testReadOnlySetTrueAdmin(self):
@@ -1553,7 +1677,8 @@ class TestReadOnlyView(ViewTest):
         self.assertEqual(read_only, True)
 
     def testReadOnlySetFalseAdmin(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "a").execute()
+        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(
+            dbo.releases.name == "a").execute()
         data = dict(name='b', read_only='', product='b', data_version=2)
         ret = self._put('/releases/b/read_only', username='bill', data=data)
         self.assertStatusCode(ret, 201)
@@ -1561,7 +1686,8 @@ class TestReadOnlyView(ViewTest):
         self.assertEqual(read_only, False)
 
     def testReadOnlyUnsetWithoutPermissionForProduct(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "a").execute()
+        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(
+            dbo.releases.name == "a").execute()
         data = dict(name='b', read_only='', product='b', data_version=2)
         ret = self._put('/releases/b/read_only', username='me', data=data)
         self.assertStatusCode(ret, 403)
@@ -1593,7 +1719,8 @@ class TestReadOnlyView(ViewTest):
 
         # Resetting flag, which should fail with 403
         data_unset = dict(name='b', read_only='', product='b', data_version=2)
-        ret = self._put('/releases/b/read_only', username='bob', data=data_unset)
+        ret = self._put('/releases/b/read_only',
+                        username='bob', data=data_unset)
         self.assertStatusCode(ret, 403)
 
 
@@ -1610,7 +1737,8 @@ class TestRuleIdsReturned(ViewTest):
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)
-        not_whitelisted_rel = next(rel for rel in releases_data['releases'] if rel['name'] == rel_name)
+        not_whitelisted_rel = next(rel for rel in releases_data[
+                                   'releases'] if rel['name'] == rel_name)
         self.assertEqual(len(not_whitelisted_rel['rule_ids']), 0)
         self.assertFalse(rule_id in not_whitelisted_rel['rule_ids'])
 
@@ -1619,7 +1747,8 @@ class TestRuleIdsReturned(ViewTest):
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)
-        whitelisted_rel = next(rel for rel in releases_data['releases'] if rel['name'] == rel_name)
+        whitelisted_rel = next(rel for rel in releases_data[
+                               'releases'] if rel['name'] == rel_name)
         self.assertEqual(len(whitelisted_rel['rule_ids']), 1)
         self.assertTrue(rule_id in whitelisted_rel['rule_ids'])
 
@@ -1629,7 +1758,8 @@ class TestRuleIdsReturned(ViewTest):
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)
-        not_mapped_rel = next(rel for rel in releases_data['releases'] if rel['name'] == rel_name)
+        not_mapped_rel = next(rel for rel in releases_data[
+                              'releases'] if rel['name'] == rel_name)
         self.assertEqual(len(not_mapped_rel['rule_ids']), 0)
         self.assertFalse(rule_id in not_mapped_rel['rule_ids'])
 
@@ -1638,6 +1768,7 @@ class TestRuleIdsReturned(ViewTest):
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)
-        mapped_rel = next(rel for rel in releases_data['releases'] if rel['name'] == rel_name)
+        mapped_rel = next(rel for rel in releases_data[
+                          'releases'] if rel['name'] == rel_name)
         self.assertEqual(len(mapped_rel['rule_ids']), 1)
         self.assertTrue(rule_id in mapped_rel['rule_ids'])

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -437,6 +437,10 @@ class TestReleasesAPI_JSON(ViewTest):
         dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "d").execute()
         ret = self._delete("/releases/d", username="bill", qs=dict(data_version=2))
         self.assertStatusCode(ret, 403)
+        
+    def testDeleteWithRules(self):
+        ret = self._delete("/releases/d", qs=dict(name='ab', data_version=1))
+        self.assertStatusCode(ret, 403)
 
     def testLocalePut(self):
         data = json.dumps({

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -26,13 +26,10 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 404)
 
     def testReleasePostUpdateExisting(self):
-        data = json.dumps(
-            dict(detailsUrl='blah', fakePartials=True, schema_version=1))
-        ret = self._post('/releases/d', data=dict(data=data,
-                                                  product='d', data_version=1))
+        data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1))
+        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
         self.assertStatusCode(ret, 200)
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'd').execute().fetchone()[0]
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "d",
@@ -57,10 +54,8 @@ class TestReleasesAPI_JSON(ViewTest):
 """))
 
     def testReleasePostUpdateExistingWithoutPermission(self):
-        data = json.dumps(
-            dict(detailsUrl='blah', fakePartials=True, schema_version=1))
-        ret = self._post('/releases/d', data=dict(data=data,
-                                                  product='d', data_version=1), username="hannah")
+        data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1))
+        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1), username="hannah")
         self.assertStatusCode(ret, 403)
 
     def testReleasePutUpdateMergeableOutdatedData(self):
@@ -181,8 +176,7 @@ class TestReleasesAPI_JSON(ViewTest):
         ret = self._put('/releases/dd', data=dict(blob=ancestor_blob, name='dd',
                                                   product='dd', data_version=1))
         self.assertStatusCode(ret, 201)
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'dd').execute().fetchone()[0]
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'dd').execute().fetchone()[0]
         self.assertEqual(ret, createBlob(ancestor_blob))
 
         # Updating same release
@@ -197,8 +191,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 200)
         self.assertEqual(json.loads(ret.data), dict(new_data_version=3))
 
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'dd').execute().fetchone()[0]
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'dd').execute().fetchone()[0]
         self.assertEqual(ret, result_blob)
 
     def testReleasePutUpdateConflictingOutdatedData(self):
@@ -273,12 +266,10 @@ class TestReleasesAPI_JSON(ViewTest):
             }
         }"""
         # Testing Put request to add new release
-        ret = self._put('/releases/dd', data=dict(blob=ancestor_blob,
-                                                  name='dd', product='dd', data_version=1))
+        ret = self._put('/releases/dd', data=dict(blob=ancestor_blob, name='dd', product='dd', data_version=1))
         self.assertStatusCode(ret, 201)
 
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'dd').execute().fetchone()[0]
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'dd').execute().fetchone()[0]
         self.assertEqual(ret, createBlob(ancestor_blob))
 
         # Updating same release
@@ -314,19 +305,16 @@ class TestReleasesAPI_JSON(ViewTest):
                 }
             }
         }"""
-        ret = self._post('/releases/ee', data=dict(data=blob,
-                                                   hashFunction="sha512", name='ee', product='ee', data_version=1))
+        ret = self._post('/releases/ee', data=dict(data=blob, hashFunction="sha512", name='ee', product='ee', data_version=1))
         self.assertStatusCode(ret, 201)
 
         # Updating same release
-        self.assertEqual(ret.data, json.dumps(
-            dict(new_data_version=2)), "Data: %s" % ret.data)
+        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
         ret = self._post('/releases/ee', data=dict(data=blob,
                                                    hashFunction="sha512",
                                                    name='ee', product='ee', data_version=2))
         self.assertStatusCode(ret, 200)
-        self.assertEqual(ret.data, json.dumps(
-            dict(new_data_version=3)), "Data: %s" % ret.data)
+        self.assertEqual(ret.data, json.dumps(dict(new_data_version=3)), "Data: %s" % ret.data)
 
         # Outdated Data Error on same release
         ret = self._post('/releases/ee', data=dict(hashFunction="sha512",
@@ -336,43 +324,34 @@ class TestReleasesAPI_JSON(ViewTest):
 
     def testReleasePostMismatchedName(self):
         data = json.dumps(dict(name="eee", schema_version=1))
-        ret = self._post('/releases/d', data=dict(data=data,
-                                                  product='d', data_version=1))
+        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testReleasePostUpdateChangeHashFunction(self):
-        data = json.dumps(
-            dict(detailsUrl='blah', hashFunction="sha1024", schema_version=1))
-        ret = self._post('/releases/d', data=dict(data=data,
-                                                  product='d', data_version=1))
+        data = json.dumps(dict(detailsUrl='blah', hashFunction="sha1024", schema_version=1))
+        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testReleasePostUpdateChangeProduct(self):
         data = json.dumps(dict(detailsUrl="abc", schema_version=1))
-        ret = self._post("/releases/c", data=dict(data=data,
-                                                  product="h", data_version=1))
+        ret = self._post("/releases/c", data=dict(data=data, product="h", data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testReleasePostInvalidBlob(self):
         data = json.dumps(dict(uehont="uhetn", schema_version=1))
-        ret = self._post("/releases/c", data=dict(data=data,
-                                                  product="c", data_version=1))
+        ret = self._post("/releases/c", data=dict(data=data, product="c", data_version=1))
         self.assertStatusCode(ret, 400)
         self.assertIn("Additional properties are not allowed", ret.data)
 
     def testReleasePostWithSignoffRequired(self):
-        data = json.dumps(dict(bouncerProducts=dict(
-            partial='foo'), name='a', hashFunction="sha512"))
-        ret = self._post("/releases/a", data=dict(data=data,
-                                                  product="a", data_version=1, schema_version=1))
+        data = json.dumps(dict(bouncerProducts=dict(partial='foo'), name='a', hashFunction="sha512"))
+        ret = self._post("/releases/a", data=dict(data=data, product="a", data_version=1, schema_version=1))
         self.assertStatusCode(ret, 400)
         self.assertIn("This change requires signoff", ret.data)
 
     def testReleasePostCreatesNewReleasev1(self):
-        data = json.dumps(dict(bouncerProducts=dict(
-            partial='foo'), name='e', hashFunction="sha512"))
-        ret = self._post('/releases/e', data=dict(data=data,
-                                                  product='e', schema_version=1))
+        data = json.dumps(dict(bouncerProducts=dict(partial='foo'), name='e', hashFunction="sha512"))
+        ret = self._post('/releases/e', data=dict(data=data, product='e', schema_version=1))
         self.assertStatusCode(ret, 201)
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
@@ -389,17 +368,13 @@ class TestReleasesAPI_JSON(ViewTest):
 """))
 
     def testReleasePostCreatesNewReleaseNopermission(self):
-        data = json.dumps(dict(bouncerProducts=dict(
-            partial='foo'), name='e', hashFunction="sha512"))
-        ret = self._post('/releases/e', data=dict(data=data,
-                                                  product='e', schema_version=1), username="kate")
+        data = json.dumps(dict(bouncerProducts=dict(partial='foo'), name='e', hashFunction="sha512"))
+        ret = self._post('/releases/e', data=dict(data=data, product='e', schema_version=1), username="kate")
         self.assertStatusCode(ret, 403)
 
     def testReleasePostCreatesNewReleasev2(self):
-        data = json.dumps(dict(bouncerProducts=dict(
-            complete='foo'), name='e', hashFunction="sha512"))
-        ret = self._post('/releases/e', data=dict(data=data,
-                                                  product='e', schema_version=2))
+        data = json.dumps(dict(bouncerProducts=dict(complete='foo'), name='e', hashFunction="sha512"))
+        ret = self._post('/releases/e', data=dict(data=data, product='e', schema_version=2))
         self.assertStatusCode(ret, 201)
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
@@ -421,17 +396,14 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 400)
 
     def testReleasePostRejectedURL(self):
-        data = json.dumps(dict(platforms=dict(
-            p=dict(locales=dict(f=dict(complete=dict(fileUrl='http://evil.com')))))))
-        ret = self._post('/releases/d', data=dict(data=data,
-                                                  product='d', data_version=1))
+        data = json.dumps(dict(platforms=dict(p=dict(locales=dict(f=dict(complete=dict(fileUrl='http://evil.com')))))))
+        ret = self._post('/releases/d', data=dict(data=data, product='d', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testDeleteRelease(self):
         ret = self._delete("/releases/d", qs=dict(data_version=1))
         self.assertStatusCode(ret, 200)
-        ret = dbo.releases.t.count().where(
-            dbo.releases.name == 'd').execute().first()[0]
+        ret = dbo.releases.t.count().where(dbo.releases.name == 'd').execute().first()[0]
         self.assertEqual(ret, 0)
 
     def testDeleteReleaseOutdatedData(self):
@@ -446,30 +418,24 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 404)
 
     def testDeleteWithoutPermission(self):
-        ret = self._delete("/releases/d", username="bob",
-                           qs=dict(data_version=1))
+        ret = self._delete("/releases/d", username="bob", qs=dict(data_version=1))
         self.assertStatusCode(ret, 403)
 
     def testDeleteWithoutPermissionForAction(self):
-        ret = self._delete("/releases/d", username="bob",
-                           qs=dict(data_version=1))
+        ret = self._delete("/releases/d", username="bob", qs=dict(data_version=1))
         self.assertStatusCode(ret, 403)
 
     def testDeleteWithProductAdminPermission(self):
-        ret = self._delete("/releases/d", username="bill",
-                           qs=dict(data_version=1))
+        ret = self._delete("/releases/d", username="bill", qs=dict(data_version=1))
         self.assertStatusCode(ret, 200)
 
     def testDeleteWithoutProductAdminPermission(self):
-        ret = self._delete("/releases/d", username="billy",
-                           qs=dict(data_version=1))
+        ret = self._delete("/releases/d", username="billy", qs=dict(data_version=1))
         self.assertStatusCode(ret, 403)
 
     def testDeleteReadOnlyRelease(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(
-            dbo.releases.name == "d").execute()
-        ret = self._delete("/releases/d", username="bill",
-                           qs=dict(data_version=2))
+        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "d").execute()
+        ret = self._delete("/releases/d", username="bill", qs=dict(data_version=2))
         self.assertStatusCode(ret, 403)
 
     def testDeleteWithRules(self):
@@ -484,13 +450,10 @@ class TestReleasesAPI_JSON(ViewTest):
                 "hashValue": "abc",
             }
         })
-        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data,
-                                                             product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(
-            dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'ab').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'ab').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "ab",
@@ -520,13 +483,10 @@ class TestReleasesAPI_JSON(ViewTest):
                 "hashValue": "abc",
             }
         })
-        ret = self._put('/releases/ab/builds/p/l', username="ashanti",
-                        data=dict(data=data, product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', username="ashanti", data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(
-            dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'ab').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'ab').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "ab",
@@ -550,20 +510,17 @@ class TestReleasesAPI_JSON(ViewTest):
 
     def testLocalePutWithBadHashFunction(self):
         data = json.dumps(dict(complete=dict(filesize='435')))
-        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data,
-                                                             product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 400)
 
     def testLocalePutWithoutPermission(self):
         data = '{"complete": {"filesize": 435, "from": "*", "hashValue": "abc"}}'
-        ret = self._put('/releases/ab/builds/p/l', username='liu',
-                        data=dict(data=data, product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', username='liu', data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 403)
 
     def testLocalePutWithoutPermissionForProduct(self):
         data = '{"complete": {"filesize": 435, "from": "*", "hashValue": "abc"}}'
-        ret = self._put('/releases/ab/builds/p/l', username='bob',
-                        data=dict(data=data, product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', username='bob', data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 403)
 
     def testLocalePutForNewRelease(self):
@@ -576,13 +533,10 @@ class TestReleasesAPI_JSON(ViewTest):
         })
         # setting schema_version in the incoming blob is a hack for testing
         # SingleLocaleView._put() doesn't give us access to the form
-        ret = self._put('/releases/e/builds/p/a', data=dict(data=data,
-                                                            product='e', hashFunction="sha512", schema_version=1))
+        ret = self._put('/releases/e/builds/p/a', data=dict(data=data, product='e', hashFunction="sha512", schema_version=1))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(
-            dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'e').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'e').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "e",
@@ -613,13 +567,10 @@ class TestReleasesAPI_JSON(ViewTest):
                 "fileUrl": "http://good.com/blah",
             }
         })
-        ret = self._put('/releases/d/builds/p/g', data=dict(data=data,
-                                                            product='d', data_version=1, schema_version=1))
+        ret = self._put('/releases/d/builds/p/g', data=dict(data=data, product='d', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(
-            dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'd').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "d",
@@ -659,13 +610,10 @@ class TestReleasesAPI_JSON(ViewTest):
         })
         # setting schema_version in the incoming blob is a hack for testing
         # SingleLocaleView._put() doesn't give us access to the form
-        ret = self._put('/releases/e/builds/p/a', data=dict(data=data, product='e',
-                                                            alias='["p2"]', schema_version=1, hashFunction="sha512"))
+        ret = self._put('/releases/e/builds/p/a', data=dict(data=data, product='e', alias='["p2"]', schema_version=1, hashFunction="sha512"))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(
-            dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'e').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'e').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "e",
@@ -699,13 +647,10 @@ class TestReleasesAPI_JSON(ViewTest):
                 "fileUrl": "http://good.com/blah",
             }
         })
-        ret = self._put('/releases/d/builds/q/g', data=dict(data=data,
-                                                            product='d', data_version=1, alias='["q2"]', schema_version=1))
+        ret = self._put('/releases/d/builds/q/g', data=dict(data=data, product='d', data_version=1, alias='["q2"]', schema_version=1))
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(
-            dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'd').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'd').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "d",
@@ -750,14 +695,11 @@ class TestReleasesAPI_JSON(ViewTest):
                 "hashValue": "abc",
             }
         })
-        data = dict(data=data, product='a', copyTo=json.dumps(
-            ['b']), data_version=1, schema_version=1)
+        data = dict(data=data, product='a', copyTo=json.dumps(['b']), data_version=1, schema_version=1)
         ret = self._put('/releases/ab/builds/p/l', data=data)
         self.assertStatusCode(ret, 201)
-        self.assertEqual(ret.data, json.dumps(
-            dict(new_data_version=2)), "Data: %s" % ret.data)
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'ab').execute().fetchone()[0]
+        self.assertEqual(ret.data, json.dumps(dict(new_data_version=2)), "Data: %s" % ret.data)
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'ab').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "ab",
@@ -778,8 +720,7 @@ class TestReleasesAPI_JSON(ViewTest):
     }
 }
 """))
-        ret = select([dbo.releases.data]).where(
-            dbo.releases.name == 'b').execute().fetchone()[0]
+        ret = select([dbo.releases.data]).where(dbo.releases.name == 'b').execute().fetchone()[0]
         self.assertEqual(ret, createBlob("""
 {
     "name": "b",
@@ -802,14 +743,12 @@ class TestReleasesAPI_JSON(ViewTest):
 """))
 
     def testLocalePutBadJSON(self):
-        ret = self._put('/releases/ab/builds/p/l',
-                        data=dict(data='a', product='a'))
+        ret = self._put('/releases/ab/builds/p/l', data=dict(data='a', product='a'))
         self.assertStatusCode(ret, 400)
 
     def testLocaleRejectedURL(self):
         data = json.dumps(dict(complete=dict(fileUrl='http://evil.com')))
-        ret = self._put('/releases/ab/builds/p/l',
-                        data=dict(data=data, product='a', data_version=1))
+        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1))
         self.assertStatusCode(ret, 400)
 
     def testLocaleGet(self):
@@ -831,8 +770,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 401)
 
     def testLocalePutReadOnlyRelease(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(
-            dbo.releases.name == "ab").execute()
+        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "ab").execute()
         data = json.dumps({
             "complete": {
                 "filesize": 435,
@@ -840,8 +778,7 @@ class TestReleasesAPI_JSON(ViewTest):
                 "hashValue": "abc",
             }
         })
-        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data,
-                                                             product='a', data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 403)
 
     def testLocalePutWithProductAdmin(self):
@@ -870,8 +807,7 @@ class TestReleasesAPI_JSON(ViewTest):
 
     def testLocalePutCantChangeProduct(self):
         data = json.dumps(dict(complete=dict(filesize=435)))
-        ret = self._put('/releases/ab/builds/p/l',
-                        data=dict(data=data, product='b', schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='b', schema_version=1))
         self.assertStatusCode(ret, 400)
 
     def testLocaleGet404(self):
@@ -910,10 +846,8 @@ class TestReleasesAPI_JSON(ViewTest):
 }
 """))
 
-        self.assertEquals(ret.status_code, 201, "Status Code: %d, Data: %s" % (
-            ret.status_code, ret.data))
-        r = dbo.releases.t.select().where(
-            dbo.releases.name == 'new_release').execute().fetchall()
+        self.assertEquals(ret.status_code, 201, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+        r = dbo.releases.t.select().where(dbo.releases.name == 'new_release').execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'new_release')
         self.assertEquals(r[0]['product'], 'Firefox')
@@ -962,8 +896,7 @@ class TestReleasesAPI_JSON(ViewTest):
     "actions": "doit"
 }
 """))
-        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (
-            ret.status_code, ret.data))
+        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
         r = dbo.releases.t.select().where(dbo.releases.name == 'd').execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'd')
@@ -1003,10 +936,8 @@ class TestReleasesAPI_JSON(ViewTest):
 }
 """))
 
-        self.assertEquals(ret.status_code, 201, "Status Code: %d, Data: %s" % (
-            ret.status_code, ret.data))
-        r = dbo.releases.t.select().where(
-            dbo.releases.name == 'gmprel').execute().fetchall()
+        self.assertEquals(ret.status_code, 201, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+        r = dbo.releases.t.select().where(dbo.releases.name == 'gmprel').execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['name'], 'gmprel')
         self.assertEquals(r[0]['product'], 'a')
@@ -1079,10 +1010,8 @@ class TestReleasesAPI_JSON(ViewTest):
 """))
 
     def testReleasesPost(self):
-        data = json.dumps(dict(bouncerProducts=dict(
-            partial='foo'), name='e', schema_version=1, hashFunction="sha512"))
-        ret = self._post(
-            '/releases', data=dict(blob=data, name="e", product='e'))
+        data = json.dumps(dict(bouncerProducts=dict(partial='foo'), name='e', schema_version=1, hashFunction="sha512"))
+        ret = self._post('/releases', data=dict(blob=data, name="e", product='e'))
         self.assertStatusCode(ret, 201)
         ret = dbo.releases.t.select().where(dbo.releases.name == 'e').execute().fetchone()
         self.assertEqual(ret['product'], 'e')
@@ -1106,25 +1035,19 @@ class TestReleasesScheduledChanges(ViewTest):
         super(TestReleasesScheduledChanges, self).setUp()
         dbo.releases.scheduled_changes.t.insert().execute(
             sc_id=1, scheduled_by="bill", change_type="insert", data_version=1, base_name="m", base_product="m",
-            base_data=createBlob(
-                dict(name="m", hashFunction="sha512", schema_version=1))
+            base_data=createBlob(dict(name="m", hashFunction="sha512", schema_version=1))
         )
-        dbo.releases.scheduled_changes.history.t.insert().execute(
-            change_id=1, changed_by="bill", timestamp=50, sc_id=1)
+        dbo.releases.scheduled_changes.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=50, sc_id=1)
         dbo.releases.scheduled_changes.history.t.insert().execute(
             change_id=2, changed_by="bill", timestamp=51, sc_id=1, scheduled_by="bill", change_type="insert", data_version=1, base_name="m",
             base_product="m", base_data=createBlob(dict(name="m", hashFunction="sha512", schema_version=1))
         )
-        dbo.releases.scheduled_changes.signoffs.t.insert().execute(
-            sc_id=1, username="bill", role="releng")
-        dbo.releases.scheduled_changes.signoffs.history.t.insert().execute(
-            change_id=1, changed_by="bill", timestamp=100, sc_id=1, username="bill")
+        dbo.releases.scheduled_changes.signoffs.t.insert().execute(sc_id=1, username="bill", role="releng")
+        dbo.releases.scheduled_changes.signoffs.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=100, sc_id=1, username="bill")
         dbo.releases.scheduled_changes.signoffs.history.t.insert().execute(change_id=2, changed_by="bill", timestamp=101, sc_id=1,
                                                                            username="bill", role="releng")
-        dbo.releases.scheduled_changes.conditions.t.insert().execute(
-            sc_id=1, when=4000000000, data_version=1)
-        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
-            change_id=1, changed_by="bill", timestamp=50, sc_id=1)
+        dbo.releases.scheduled_changes.conditions.t.insert().execute(sc_id=1, when=4000000000, data_version=1)
+        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=50, sc_id=1)
         dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
             change_id=2, changed_by="bill", timestamp=51, sc_id=1, when=4000000000, data_version=1
         )
@@ -1133,16 +1056,13 @@ class TestReleasesScheduledChanges(ViewTest):
             sc_id=2, scheduled_by="bill", change_type="update", data_version=1, base_name="c", base_product="c",
             base_data=createBlob(dict(name="c", hashFunction="sha512", schema_version=1, extv="2.0")), base_data_version=1
         )
-        dbo.releases.scheduled_changes.history.t.insert().execute(
-            change_id=3, changed_by="bill", timestamp=70, sc_id=2)
+        dbo.releases.scheduled_changes.history.t.insert().execute(change_id=3, changed_by="bill", timestamp=70, sc_id=2)
         dbo.releases.scheduled_changes.history.t.insert().execute(
             change_id=4, changed_by="bill", timestamp=71, sc_id=2, scheduled_by="bill", change_type="update", data_version=1, base_name="c",
             base_product="c", base_data=createBlob(dict(name="c", hashFunction="sha512", schema_version=1, extv="2.0")), base_data_version=1
         )
-        dbo.releases.scheduled_changes.conditions.t.insert().execute(
-            sc_id=2, when=6000000000, data_version=1)
-        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
-            change_id=3, changed_by="bill", timestamp=70, sc_id=2)
+        dbo.releases.scheduled_changes.conditions.t.insert().execute(sc_id=2, when=6000000000, data_version=1)
+        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(change_id=3, changed_by="bill", timestamp=70, sc_id=2)
         dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
             change_id=4, changed_by="bill", timestamp=71, sc_id=2, when=6000000000, data_version=1
         )
@@ -1151,8 +1071,7 @@ class TestReleasesScheduledChanges(ViewTest):
             sc_id=3, complete=True, scheduled_by="bill", change_type="update", data_version=2, base_name="b", base_product="b",
             base_data=createBlob(dict(name="b", hashFunction="sha512", schema_version=1)), base_data_version=1
         )
-        dbo.releases.scheduled_changes.history.t.insert().execute(
-            change_id=5, changed_by="bill", timestamp=6, sc_id=3)
+        dbo.releases.scheduled_changes.history.t.insert().execute(change_id=5, changed_by="bill", timestamp=6, sc_id=3)
         dbo.releases.scheduled_changes.history.t.insert().execute(
             change_id=6, changed_by="bill", timestamp=7, sc_id=3, complete=False, scheduled_by="bill", change_type="update", data_version=1, base_name="b",
             base_product="b", base_data=createBlob(dict(name="b", hashFunction="sha512", schema_version=1)), base_data_version=1
@@ -1161,10 +1080,8 @@ class TestReleasesScheduledChanges(ViewTest):
             change_id=7, changed_by="bill", timestamp=25, sc_id=3, complete=True, change_type="update", scheduled_by="bill", data_version=2, base_name="b",
             base_product="b", base_data=createBlob(dict(name="b", hashFunction="sha512", schema_version=1)), base_data_version=1
         )
-        dbo.releases.scheduled_changes.conditions.t.insert().execute(
-            sc_id=3, when=10000000, data_version=2)
-        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
-            change_id=5, changed_by="bill", timestamp=6, sc_id=3)
+        dbo.releases.scheduled_changes.conditions.t.insert().execute(sc_id=3, when=10000000, data_version=2)
+        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(change_id=5, changed_by="bill", timestamp=6, sc_id=3)
         dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
             change_id=6, changed_by="bill", timestamp=7, sc_id=3, when=10000000, data_version=1
         )
@@ -1175,16 +1092,13 @@ class TestReleasesScheduledChanges(ViewTest):
         dbo.releases.scheduled_changes.t.insert().execute(
             sc_id=4, complete=False, scheduled_by="bill", change_type="delete", data_version=1, base_name="ab", base_data_version=1,
         )
-        dbo.releases.scheduled_changes.history.t.insert().execute(
-            change_id=8, changed_by="bill", timestamp=25, sc_id=4)
+        dbo.releases.scheduled_changes.history.t.insert().execute(change_id=8, changed_by="bill", timestamp=25, sc_id=4)
         dbo.releases.scheduled_changes.history.t.insert().execute(
             change_id=9, changed_by="bill", timestamp=26, sc_id=4, complete=False, scheduled_by="bill", change_type="delete", data_version=1,
             base_name="ab", base_data_version=1
         )
-        dbo.releases.scheduled_changes.conditions.t.insert().execute(
-            sc_id=4, when=230000000, data_version=1)
-        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
-            change_id=8, changed_by="bill", timestamp=25, sc_id=4)
+        dbo.releases.scheduled_changes.conditions.t.insert().execute(sc_id=4, when=230000000, data_version=1)
+        dbo.releases.scheduled_changes.conditions.history.t.insert().execute(change_id=8, changed_by="bill", timestamp=25, sc_id=4)
         dbo.releases.scheduled_changes.conditions.history.t.insert().execute(
             change_id=9, changed_by="bill", timestamp=26, sc_id=4, when=230000000, data_version=1
         )
@@ -1249,8 +1163,7 @@ class TestReleasesScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/releases", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"sc_id": 5})
-        r = dbo.releases.scheduled_changes.t.select().where(
-            dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1258,8 +1171,7 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_name": "d", "base_data": {"name": "d", "hashFunction": "sha256", "schema_version": 1}, "base_data_version": 1
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
-            dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 5, "data_version": 1, "when": 2300000000}
         self.assertEquals(dict(cond[0]), cond_expected)
@@ -1272,8 +1184,7 @@ class TestReleasesScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/releases", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"sc_id": 5})
-        r = dbo.releases.scheduled_changes.t.select().where(
-            dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1281,8 +1192,7 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_name": "d", "base_data": None, "base_data_version": 1,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
-            dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 5, "data_version": 1, "when": 4200000000}
         self.assertEquals(dict(cond[0]), cond_expected)
@@ -1296,8 +1206,7 @@ class TestReleasesScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/releases", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"sc_id": 5})
-        r = dbo.releases.scheduled_changes.t.select().where(
-            dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 5).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1305,8 +1214,7 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_name": "q", "base_data": {"name": "q", "hashFunction": "sha512", "schema_version": 1}, "base_data_version": None,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
-            dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 5, "data_version": 1, "when": 5200000000}
         self.assertEquals(dict(cond[0]), cond_expected)
@@ -1321,8 +1229,7 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"new_data_version": 2})
 
-        r = dbo.releases.scheduled_changes.t.select().where(
-            dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1331,8 +1238,7 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_data_version": 1,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
-            dbo.releases.scheduled_changes.conditions.sc_id == 2).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 2).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 2, "data_version": 2, "when": 78900000000}
         self.assertEquals(dict(cond[0]), cond_expected)
@@ -1347,8 +1253,7 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"new_data_version": 2})
 
-        r = dbo.releases.scheduled_changes.t.select().where(
-            dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1357,8 +1262,7 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_data_version": None,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
-            dbo.releases.scheduled_changes.conditions.sc_id == 1).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 1).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 1, "data_version": 2, "when": 4000000000}
         self.assertEquals(dict(cond[0]), cond_expected)
@@ -1373,8 +1277,7 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertEquals(ret.status_code, 200, ret.data)
         self.assertEquals(json.loads(ret.data), {"new_data_version": 2})
 
-        r = dbo.releases.scheduled_changes.t.select().where(
-            dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1383,29 +1286,24 @@ class TestReleasesScheduledChanges(ViewTest):
             "base_data_version": None,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.releases.scheduled_changes.conditions.t.select().where(
-            dbo.releases.scheduled_changes.conditions.sc_id == 1).execute().fetchall()
+        cond = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 1).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 1, "data_version": 2, "when": 4000000000}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     def testDeleteScheduledChange(self):
-        ret = self._delete("/scheduled_changes/releases/2",
-                           qs={"data_version": 1})
+        ret = self._delete("/scheduled_changes/releases/2", qs={"data_version": 1})
         self.assertEquals(ret.status_code, 200, ret.data)
-        got = dbo.releases.scheduled_changes.t.select().where(
-            dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
+        got = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
         self.assertEquals(got, [])
-        cond_got = dbo.releases.scheduled_changes.conditions.t.select().where(
-            dbo.releases.scheduled_changes.conditions.sc_id == 2).execute().fetchall()
+        cond_got = dbo.releases.scheduled_changes.conditions.t.select().where(dbo.releases.scheduled_changes.conditions.sc_id == 2).execute().fetchall()
         self.assertEquals(cond_got, [])
 
     def testEnactScheduledChangeExistingRelease(self):
         ret = self._post("/scheduled_changes/releases/2/enact")
         self.assertEquals(ret.status_code, 200, ret.data)
 
-        r = dbo.releases.scheduled_changes.t.select().where(
-            dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1415,8 +1313,7 @@ class TestReleasesScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-        base_row = dict(dbo.releases.t.select().where(
-            dbo.releases.name == "c").execute().fetchall()[0])
+        base_row = dict(dbo.releases.t.select().where(dbo.releases.name == "c").execute().fetchall()[0])
         base_expected = {
             "name": "c", "product": "c", "read_only": False,
             "data": {"name": "c", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"}, "data_version": 2,
@@ -1427,8 +1324,7 @@ class TestReleasesScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/releases/1/enact")
         self.assertEquals(ret.status_code, 200, ret.data)
 
-        r = dbo.releases.scheduled_changes.t.select().where(
-            dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 1).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1438,8 +1334,7 @@ class TestReleasesScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-        base_row = dict(dbo.releases.t.select().where(
-            dbo.releases.name == "m").execute().fetchall()[0])
+        base_row = dict(dbo.releases.t.select().where(dbo.releases.name == "m").execute().fetchall()[0])
         base_expected = {
             "name": "m", "product": "m", "read_only": False,
             "data": {"name": "m", "hashFunction": "sha512", "schema_version": 1}, "data_version": 1,
@@ -1450,8 +1345,7 @@ class TestReleasesScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/releases/4/enact")
         self.assertEquals(ret.status_code, 200, ret.data)
 
-        r = dbo.releases.scheduled_changes.t.select().where(
-            dbo.releases.scheduled_changes.sc_id == 4).execute().fetchall()
+        r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 4).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
@@ -1460,8 +1354,7 @@ class TestReleasesScheduledChanges(ViewTest):
         }
         self.assertEquals(db_data, expected)
 
-        base_row = dbo.releases.t.select().where(
-            dbo.releases.name == "ab").execute().fetchall()
+        base_row = dbo.releases.t.select().where(dbo.releases.name == "ab").execute().fetchall()
         self.assertEquals(len(base_row), 0)
 
     def testGetScheduledChangeHistoryRevisions(self):
@@ -1487,34 +1380,25 @@ class TestReleasesScheduledChanges(ViewTest):
 
     @mock.patch("time.time", mock.MagicMock(return_value=100))
     def testSignoffWithPermission(self):
-        ret = self._post("/scheduled_changes/releases/2/signoffs",
-                         data=dict(role="qa"), username="bill")
+        ret = self._post("/scheduled_changes/releases/2/signoffs", data=dict(role="qa"), username="bill")
         self.assertEquals(ret.status_code, 200, ret.data)
-        r = dbo.releases.scheduled_changes.signoffs.t.select().where(
-            dbo.releases.scheduled_changes.signoffs.sc_id == 2).execute().fetchall()
+        r = dbo.releases.scheduled_changes.signoffs.t.select().where(dbo.releases.scheduled_changes.signoffs.sc_id == 2).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
-        self.assertEquals(
-            db_data, {"sc_id": 2, "username": "bill", "role": "qa"})
-        r = dbo.releases.scheduled_changes.signoffs.history.t.select().where(
-            dbo.releases.scheduled_changes.signoffs.history.sc_id == 2).execute().fetchall()
+        self.assertEquals(db_data, {"sc_id": 2, "username": "bill", "role": "qa"})
+        r = dbo.releases.scheduled_changes.signoffs.history.t.select().where(dbo.releases.scheduled_changes.signoffs.history.sc_id == 2).execute().fetchall()
         self.assertEquals(len(r), 2)
-        self.assertEquals(dict(r[0]), {"change_id": 3, "changed_by": "bill",
-                                       "timestamp": 99999, "sc_id": 2, "username": "bill", "role": None})
-        self.assertEquals(dict(r[1]), {"change_id": 4, "changed_by": "bill",
-                                       "timestamp": 100000, "sc_id": 2, "username": "bill", "role": "qa"})
+        self.assertEquals(dict(r[0]), {"change_id": 3, "changed_by": "bill", "timestamp": 99999, "sc_id": 2, "username": "bill", "role": None})
+        self.assertEquals(dict(r[1]), {"change_id": 4, "changed_by": "bill", "timestamp": 100000, "sc_id": 2, "username": "bill", "role": "qa"})
 
     def testSignoffWithoutPermission(self):
-        ret = self._post("/scheduled_changes/releases/2/signoffs",
-                         data=dict(role="relman"), username="bill")
+        ret = self._post("/scheduled_changes/releases/2/signoffs", data=dict(role="relman"), username="bill")
         self.assertEquals(ret.status_code, 403, ret.data)
 
     def testRevokeSignoff(self):
-        ret = self._delete(
-            "/scheduled_changes/releases/1/signoffs", username="bill")
+        ret = self._delete("/scheduled_changes/releases/1/signoffs", username="bill")
         self.assertEquals(ret.status_code, 200, ret.data)
-        r = dbo.releases.scheduled_changes.signoffs.t.select().where(
-            dbo.releases.scheduled_changes.signoffs.sc_id == 1).execute().fetchall()
+        r = dbo.releases.scheduled_changes.signoffs.t.select().where(dbo.releases.scheduled_changes.signoffs.sc_id == 1).execute().fetchall()
         self.assertEquals(len(r), 0)
 
 
@@ -1522,8 +1406,7 @@ class TestReleaseHistoryView(ViewTest):
 
     def testGetRevisions(self):
         # Make some changes to a release
-        data = json.dumps(
-            dict(detailsUrl='blah', fakePartials=True, schema_version=1))
+        data = json.dumps(dict(detailsUrl='blah', fakePartials=True, schema_version=1))
         ret = self._post(
             '/releases/d',
             data=dict(
@@ -1556,8 +1439,7 @@ class TestReleaseHistoryView(ViewTest):
 
     def testPostRevisionRollback(self):
         # Make some changes to a release
-        data = json.dumps(
-            dict(detailsUrl='beep', fakePartials=True, schema_version=1))
+        data = json.dumps(dict(detailsUrl='beep', fakePartials=True, schema_version=1))
         ret = self._post(
             '/releases/d',
             data=dict(
@@ -1568,8 +1450,7 @@ class TestReleaseHistoryView(ViewTest):
         )
         self.assertStatusCode(ret, 200)
 
-        data = json.dumps(
-            dict(detailsUrl='boop', fakePartials=False, schema_version=1))
+        data = json.dumps(dict(detailsUrl='boop', fakePartials=False, schema_version=1))
         ret = self._post(
             '/releases/d',
             data=dict(
@@ -1592,8 +1473,7 @@ class TestReleaseHistoryView(ViewTest):
         self.assertEqual(count, 2)
 
         row, = table.history.select(
-            where=[(table.history.product == 'd') & (
-                table.history.data_version == 2)],
+            where=[(table.history.product == 'd') & (table.history.data_version == 2)],
             limit=1
         )
         change_id = row['change_id']
@@ -1614,8 +1494,7 @@ class TestReleaseHistoryView(ViewTest):
         self.assertEqual(data['detailsUrl'], 'beep')
 
     def testPostRevisionRollbackBadRequests(self):
-        data = json.dumps(
-            dict(detailsUrl='beep', fakePartials=True, schema_version=1))
+        data = json.dumps(dict(detailsUrl='beep', fakePartials=True, schema_version=1))
         ret = self._post(
             '/releases/d',
             data=dict(
@@ -1626,8 +1505,7 @@ class TestReleaseHistoryView(ViewTest):
         )
         self.assertStatusCode(ret, 200)
         # when posting you need both the release name and the change_id
-        ret = self._post('/releases/CRAZYNAME/revisions',
-                         json.dumps({'change_id': 1}))
+        ret = self._post('/releases/CRAZYNAME/revisions', json.dumps({'change_id': 1}))
         self.assertEquals(ret.status_code, 404, ret.data)
 
         url = '/releases/d/revisions'
@@ -1646,8 +1524,7 @@ class TestSingleColumn_JSON(ViewTest):
         ret = self._get("/releases/columns/product")
         ret_data = json.loads(ret.data)
         self.assertEquals(ret_data['count'], expected['count'])
-        self.assertEquals(ret_data['product'].sort(),
-                          expected['product'].sort())
+        self.assertEquals(ret_data['product'].sort(), expected['product'].sort())
 
     def testGetReleaseColumn404(self):
         ret = self.client.get("/releases/columns/blah")
@@ -1658,8 +1535,7 @@ class TestReadOnlyView(ViewTest):
 
     def testReadOnlyGet(self):
         ret = self._get('/releases/b/read_only')
-        is_read_only = dbo.releases.t.select(
-            dbo.releases.name == 'b').execute().first()['read_only']
+        is_read_only = dbo.releases.t.select(dbo.releases.name == 'b').execute().first()['read_only']
         self.assertEqual(json.loads(ret.data)['read_only'], is_read_only)
 
     def testReadOnlySetTrueAdmin(self):
@@ -1677,8 +1553,7 @@ class TestReadOnlyView(ViewTest):
         self.assertEqual(read_only, True)
 
     def testReadOnlySetFalseAdmin(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(
-            dbo.releases.name == "a").execute()
+        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "a").execute()
         data = dict(name='b', read_only='', product='b', data_version=2)
         ret = self._put('/releases/b/read_only', username='bill', data=data)
         self.assertStatusCode(ret, 201)
@@ -1686,8 +1561,7 @@ class TestReadOnlyView(ViewTest):
         self.assertEqual(read_only, False)
 
     def testReadOnlyUnsetWithoutPermissionForProduct(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(
-            dbo.releases.name == "a").execute()
+        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "a").execute()
         data = dict(name='b', read_only='', product='b', data_version=2)
         ret = self._put('/releases/b/read_only', username='me', data=data)
         self.assertStatusCode(ret, 403)
@@ -1719,8 +1593,7 @@ class TestReadOnlyView(ViewTest):
 
         # Resetting flag, which should fail with 403
         data_unset = dict(name='b', read_only='', product='b', data_version=2)
-        ret = self._put('/releases/b/read_only',
-                        username='bob', data=data_unset)
+        ret = self._put('/releases/b/read_only', username='bob', data=data_unset)
         self.assertStatusCode(ret, 403)
 
 
@@ -1737,8 +1610,7 @@ class TestRuleIdsReturned(ViewTest):
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)
-        not_whitelisted_rel = next(rel for rel in releases_data[
-                                   'releases'] if rel['name'] == rel_name)
+        not_whitelisted_rel = next(rel for rel in releases_data['releases'] if rel['name'] == rel_name)
         self.assertEqual(len(not_whitelisted_rel['rule_ids']), 0)
         self.assertFalse(rule_id in not_whitelisted_rel['rule_ids'])
 
@@ -1747,8 +1619,7 @@ class TestRuleIdsReturned(ViewTest):
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)
-        whitelisted_rel = next(rel for rel in releases_data[
-                               'releases'] if rel['name'] == rel_name)
+        whitelisted_rel = next(rel for rel in releases_data['releases'] if rel['name'] == rel_name)
         self.assertEqual(len(whitelisted_rel['rule_ids']), 1)
         self.assertTrue(rule_id in whitelisted_rel['rule_ids'])
 
@@ -1758,8 +1629,7 @@ class TestRuleIdsReturned(ViewTest):
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)
-        not_mapped_rel = next(rel for rel in releases_data[
-                              'releases'] if rel['name'] == rel_name)
+        not_mapped_rel = next(rel for rel in releases_data['releases'] if rel['name'] == rel_name)
         self.assertEqual(len(not_mapped_rel['rule_ids']), 0)
         self.assertFalse(rule_id in not_mapped_rel['rule_ids'])
 
@@ -1768,7 +1638,6 @@ class TestRuleIdsReturned(ViewTest):
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)
-        mapped_rel = next(rel for rel in releases_data[
-                          'releases'] if rel['name'] == rel_name)
+        mapped_rel = next(rel for rel in releases_data['releases'] if rel['name'] == rel_name)
         self.assertEqual(len(mapped_rel['rule_ids']), 1)
         self.assertTrue(rule_id in mapped_rel['rule_ids'])

--- a/ui/app/js/controllers/release_delete_controller.js
+++ b/ui/app/js/controllers/release_delete_controller.js
@@ -17,7 +17,7 @@ function ($scope, $modalInstance, CSRF, Releases, release, releases) {
       })
       .error(function(response) {
          if (typeof response === 'object') {
-          message = '';
+          message = response.exception;
           if (release.read_only) {
             message = 'Product is read only';
           }


### PR DESCRIPTION
The error message when deleting a release with rules pointing to it now shows a more comprehensive error. The response is now a 400 status when the error occurs.

Overview of the changes:

- Added new error response "HasRulesError"
- Modified UI Release Delete controller to display exceptions instead of blank message when errors occur.
