### PR TITLE
1321036 verify column attributes

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -2285,7 +2285,7 @@ class Permissions(AUSTable):
 
 class Dockerflow(AUSTable):
     def __init__(self, db, metadata, dialect):
-        self.table = Table('dockerflow', metadata, Column('watchdog', Integer))
+        self.table = Table('dockerflow', metadata, Column('watchdog', Integer, nullable=False))
         AUSTable.__init__(self, db, dialect, history=False, versioned=False)
 
     def getDockerflowEntry(self, transaction=None):

--- a/auslib/migrate/versions/022_fix_column_attributes.py
+++ b/auslib/migrate/versions/022_fix_column_attributes.py
@@ -1,0 +1,45 @@
+from sqlalchemy import MetaData, Table
+
+
+data_version_nullable_tbls = [
+    'permissions_req_signoffs_scheduled_changes_conditions',
+    'permissions_scheduled_changes',
+    'permissions_scheduled_changes_conditions',
+    'product_req_signoffs_scheduled_changes_conditions',
+    'releases_scheduled_changes',
+    'releases_scheduled_changes_conditions',
+    'rules_scheduled_changes',
+    'rules_scheduled_changes_conditions',
+    'user_roles'
+]
+
+when_nullable_tbls = [
+    'permissions_scheduled_changes_conditions',
+    'releases_scheduled_changes_conditions'
+]
+
+
+def _change_nullable_attr(table_name, column, metadata, nullable):
+    tbl = Table(table_name, metadata, autoload=True)
+
+    tbl.c[column].alter(nullable=nullable)
+
+
+def upgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+
+    for tbl in data_version_nullable_tbls:
+        _change_nullable_attr(tbl, 'data_version', metadata, False)
+
+    for tbl in when_nullable_tbls:
+        _change_nullable_attr(tbl, 'when', metadata, True)
+
+
+def downgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+
+    for tbl in data_version_nullable_tbls:
+        _change_nullable_attr(tbl, 'data_version', metadata, True)
+
+    for tbl in when_nullable_tbls:
+        _change_nullable_attr(tbl, 'when', metadata, False)

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import simplejson as json
 from tempfile import mkstemp
@@ -6,6 +7,11 @@ import unittest
 from auslib.global_state import dbo, cache
 from auslib.admin.base import app
 from auslib.blobs.base import createBlob
+
+
+def setUpModule():
+    # Silence SQLAlchemy-Migrate's debugging logger
+    logging.getLogger('migrate').setLevel(logging.CRITICAL)
 
 
 class ViewTest(unittest.TestCase):

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -4,6 +4,7 @@ except ImportError:
     # so you're in python <2.7
     from ordereddict import OrderedDict
 
+import logging
 import mock
 import unittest
 
@@ -14,6 +15,11 @@ from auslib.blobs.base import BlobValidationError, createBlob
 from auslib.blobs.apprelease import ReleaseBlobBase, ReleaseBlobV1, ReleaseBlobV2, \
     ReleaseBlobV3, ReleaseBlobV4, ReleaseBlobV5, ReleaseBlobV6, ReleaseBlobV7, DesupportBlob, \
     UnifiedFileUrlsMixin
+
+
+def setUpModule():
+    # Silence SQLAlchemy-Migrate's debugging logger
+    logging.getLogger('migrate').setLevel(logging.CRITICAL)
 
 
 class SimpleBlob(ReleaseBlobBase):

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -1,9 +1,15 @@
+import logging
 import mock
 import unittest
 
 from auslib.global_state import dbo
 from auslib.AUS import AUS
 from auslib.blobs.base import createBlob
+
+
+def setUpModule():
+    # Silence SQLAlchemy-Migrate's debugging logger
+    logging.getLogger('migrate').setLevel(logging.CRITICAL)
 
 
 def RandomAUSTestWithoutFallback(AUS, backgroundRate, force, mapping):

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -17,9 +17,14 @@ from auslib.db import AUSDatabase, AUSTable, AlreadySetupError, \
     ReadOnlyError, PermissionDeniedError, ChangeScheduledError, \
     MismatchedDataVersionError, SignoffsTable, SignoffRequiredError, \
     verify_signoffs
-import auslib.db
 from auslib.blobs.base import BlobValidationError, createBlob
 from auslib.blobs.apprelease import ReleaseBlobV1
+
+
+def setUpModule():
+    # This is meant to silence the debug information coming from SQLAlchemy-Migrate since
+    # AUSDatabase provides decent debugging logs by itself.
+    logging.getLogger('migrate').setLevel(logging.CRITICAL)
 
 
 class MemoryDatabaseMixin(object):
@@ -914,10 +919,19 @@ class TestScheduledChangesTable(unittest.TestCase, ScheduledChangesTableMixin, M
         self.assertEquals(cond_row.data_version, 1)
 
     @mock.patch("time.time", mock.MagicMock(return_value=200))
-    def testInsertWithNonNullableColumn(self):
-        what = {"bar": "abc", "when": 34567000, "change_type": "insert"}
-        # TODO: we should really be checking directly for IntegrityError, but AUSTransaction eats it.
-        self.assertRaisesRegexp(TransactionError, "IntegrityError", self.sc_table.insert, changed_by="bob", **what)
+    def testInsertWithNonNullablePKColumn(self):
+        class TestTable(AUSTable):
+            def __init__(self, db, metadata):
+                self.table = Table('test_table_null_pk', metadata,
+                                   Column('foo_id', Integer, primary_key=True),
+                                   Column('bar', String(15), primary_key=True, nullable=False),
+                                   Column('baz', String(15)))
+                super(TestTable, self).__init__(db, 'sqlite', scheduled_changes=True, history=False, versioned=True)
+        table = TestTable(self.db, self.metadata)
+        self.metadata.create_all()
+        table_sc = table.scheduled_changes
+        what = {'baz': 'baz', 'change_type': 'insert', 'when': 876000}
+        self.assertRaisesRegexp(ValueError, 'Missing primary key column ', table_sc.insert, changed_by="alice", **what)
 
     @mock.patch("time.time", mock.MagicMock(return_value=200))
     def testInsertForExistingNoSuchRow(self):
@@ -3868,112 +3882,11 @@ class TestChangeNotifiers(unittest.TestCase):
 class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
     @classmethod
     def setUpClass(cls):
-        cls.basic_tables = ('Dockerflow', 'Permissions', 'UserRoles', 'Releases', 'Rules',)
-        cls.properties = ('nullable',
-                          'primary_key',
-                          # 'autoincrement',
-                          'constraints',
-                          'foreign_keys',
-                          'index',
-                          'timetuple', )
-        cls.property_err_msg = ("Property '{property}' on '{table_name}.{column}' differs between model "
-                                "and migration: (model) {model_prop} != (reflected) {reflected_prop}")
-
-    def setUp(self):
-        NamedFileDatabaseMixin.setUp(self)
-        self.db = AUSDatabase(self.dburi)
-        self.db.metadata.create_all()
-        self.aus_db_tables = [self.db.rulesTable, self.db.releasesTable,
-                              self.db.permissionsTable, self.db.dockerflowTable]
-
-    def _collect_table_model_pairs(self, table, table_cls, reflected_tables, accumulator, create_fn):
-        if isinstance(table, table_cls):
-            accumulator.append((reflected_tables[table.table.name], table.table,))
-
-        possible_child_tables = ('signoffs', 'conditions', 'history', 'scheduled_changes',)
-
-        for child_table in possible_child_tables:
-            if hasattr(table, child_table) and getattr(table, child_table) is not None:
-                self._collect_table_model_pairs(getattr(table, child_table), table_cls, reflected_tables, accumulator, create_fn)
-
-    def _is_column_unique(self, col_obj):
-        col_engine = col_obj.table.metadata.bind
-        table_name = col_obj.table.name
-        res = col_engine.execute("SELECT sql FROM sqlite_master WHERE name = :table_name", table_name=table_name)
-        res = res.fetchone()[0]
-
-        if re.search(r'(?:CONSTRAINT (\w+) +)?UNIQUE *\({0}\)'.format(col_obj.name), res) is None:
-            return None
-        return True
-
-    def assert_column_attributes_for_model(self, subtable_cls, tbl_creator_fn):
-        tables = []
-
-        db = self._get_migrated_db()
-        meta_data = self._get_reflected_metadata(db)
-
-        for base_table in self.aus_db_tables:
-            self._collect_table_model_pairs(base_table, subtable_cls, meta_data.tables, tables, tbl_creator_fn)
-
-        self.assert_attributes_for_tables(tables)
-
-    def assert_attributes_for_tables(self, tables):
-        """
-        Expects and iterable of sqlalchemy (Table, Table,) pairs where
-        the first one is the result of running migrations and the second
-        one is the result of instantiating the model directly from db.py
-        """
-        for reflected_table, table_model_instance in tables:
-
-            for col_name in table_model_instance.c.keys():
-                db_py_col = table_model_instance.c[col_name]
-                reflected_db_col = reflected_table.c[col_name]
-
-                for col_property in self.properties:
-                    db_py_col_property = getattr(db_py_col, col_property)
-                    reflected_db_col_property = getattr(reflected_db_col, col_property)
-
-                    self.assertEqual(
-                        db_py_col_property, reflected_db_col_property,
-                        self.property_err_msg.format(
-                            property=col_property,
-                            table_name=table_model_instance.name,
-                            column=col_name,
-                            model_prop=db_py_col_property,
-                            reflected_prop=reflected_db_col_property))
-
-                # Testing 'unique' separately since Sqlalchemy < 1.0.0 can't reflect this attribute for this version of sqlite
-                ref_uniq = self._is_column_unique(reflected_db_col)
-                self.assertEqual(
-                    db_py_col.unique, ref_uniq,
-                    self.property_err_msg.format(
-                        property="unique",
-                        table_name=table_model_instance.name,
-                        column=col_name,
-                        model_prop=db_py_col.unique,
-                        reflected_prop=ref_uniq))
-
-    def _get_migrated_db(self):
-        db = AUSDatabase('sqlite:///' + self.getTempfile())
-        db.create()
-        return db
-
-    def _get_reflected_metadata(self, db):
-        """
-        @type db: AUSDatabase
-        """
-        mt = MetaData()
-        engine = create_engine(db.dburi)
-        mt.bind = engine
-        mt.reflect()
-        return mt
-
-    def testAllTablesExist(self):
-        expected_tables = set([
+        cls.db_tables = set([
             "dockerflow",
             # TODO: dive into this more
             # Migrate version only exists in production-like databases.
-            #"migrate_version", # noqa
+            # "migrate_version", # noqa
             "permissions",
             "permissions_history",
             "permissions_scheduled_changes",
@@ -4017,7 +3930,95 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
             "user_roles",
             "user_roles_history",
         ])
-        self.assertEquals(set(self.db.metadata.tables.keys()), expected_tables)
+
+        # autoincrement isn't tested as Sqlite does not support this outside of INTEGER PRIMARY KEYS.
+        # If the testing db is ever switched to mysql, this should be revisited.
+        cls.properties = ('nullable',
+                          'primary_key',
+                          # 'autoincrement',
+                          'constraints',
+                          'foreign_keys',
+                          'index',
+                          'timetuple', )
+        cls.property_err_msg = ("Property '{property}' on '{table_name}.{column}' differs between model "
+                                "and migration: (model) {model_prop} != (migration) {reflected_prop}")
+
+    def setUp(self):
+        NamedFileDatabaseMixin.setUp(self)
+        self.db = AUSDatabase(self.dburi)
+        self.db.metadata.create_all()
+
+    def _is_column_unique(self, col_obj):
+        """
+        Check to see if a column is unique using a Sqlite-specific query.
+        """
+        col_engine = col_obj.table.metadata.bind
+        table_name = col_obj.table.name
+        res = col_engine.execute("SELECT sql FROM sqlite_master WHERE name = :table_name", table_name=table_name)
+        res = res.fetchone()[0]
+
+        # Return None instead of False in order to adhere to SQLAlchemy's style: Column.unique returns None
+        # if it hasn't been explicitly set.
+        if re.search(r'(?:CONSTRAINT (\w+) +)?UNIQUE *\({0}\)'.format(col_obj.name), res) is None:
+            return None
+        return True
+
+    def _get_migrated_db(self):
+        db = AUSDatabase('sqlite:///' + self.getTempfile())
+        db.create()
+        return db
+
+    def _get_reflected_metadata(self, db):
+        """
+        @type db: AUSDatabase
+        """
+        mt = MetaData()
+        engine = create_engine(db.dburi)
+        mt.bind = engine
+        mt.reflect()
+        return mt
+
+    def assert_attributes_for_tables(self, tables):
+        """
+        Expects an iterable of sqlalchemy (Table, Table) pairs. The first table
+        should be the result of migrations, the second should be the model
+        taken directly from db.py.
+        """
+        failures = []
+        for reflected_table, table_model_instance in tables:
+
+            for col_name in table_model_instance.c.keys():
+                db_py_col = table_model_instance.c[col_name]
+                reflected_db_col = reflected_table.c[col_name]
+
+                for col_property in self.properties:
+                    db_py_col_property = getattr(db_py_col, col_property)
+                    reflected_db_col_property = getattr(reflected_db_col, col_property)
+
+                    if db_py_col_property != reflected_db_col_property:
+                        failures.append(
+                            self.property_err_msg.format(
+                                property=col_property,
+                                table_name=table_model_instance.name,
+                                column=col_name,
+                                model_prop=db_py_col_property,
+                                reflected_prop=reflected_db_col_property))
+
+                # Testing 'unique' separately since Sqlalchemy < 1.0.0 can't reflect this attribute for this version of sqlite
+                ref_uniq = self._is_column_unique(reflected_db_col)
+                if db_py_col.unique != ref_uniq:
+                    failures.append(
+                        self.property_err_msg.format(
+                            property="unique",
+                            table_name=table_model_instance.name,
+                            column=col_name,
+                            model_prop=db_py_col.unique,
+                            reflected_prop=ref_uniq))
+
+        self.assertEqual(failures, [], 'Column properties different between models and migrations:\n' + '\n'.join(failures))
+
+    def testAllTablesExist(self):
+        self.assertEquals(set(self.db.metadata.tables.keys()), self.db_tables)
 
     def testModelIsSameAsRepository(self):
         db2 = self._get_migrated_db()
@@ -4031,39 +4032,7 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
         db = self._get_migrated_db()
         meta_data = self._get_reflected_metadata(db)
 
-        for table_name in self.basic_tables:
-            table_class = getattr(auslib.db, table_name)
-            empty_meta = MetaData()
-            tbl_obj = table_class(None, empty_meta, 'sqlite')
-            reflected_table = meta_data.tables[tbl_obj.table.name]
-            table_instances.append((reflected_table, tbl_obj.table,))
+        for table_name in self.db_tables:
+            table_instances.append((meta_data.tables[table_name], self.db.metadata.tables[table_name]))
 
         self.assert_attributes_for_tables(table_instances)
-
-    def testScheduledChangeTableColumnAttributes(self):
-        def scheduled_change_table_creator(table):
-            return auslib.db.ScheduledChangeTable(None, 'sqlite', MetaData(), table.baseTable, ('time', 'uptake', ))
-
-        self.assert_column_attributes_for_model(auslib.db.ScheduledChangeTable, scheduled_change_table_creator)
-
-    def testConditionsTablesColumnAttributes(self):
-        def conditions_table_creator(table):
-            return auslib.db.ConditionsTable(None, 'sqlite', MetaData(), table.table.name.replace('_conditions', ''),
-                                             auslib.db.ConditionsTable.condition_groups.keys())
-
-        self.assert_column_attributes_for_model(auslib.db.ConditionsTable,
-                                                conditions_table_creator)
-
-    def testSignoffsTablesColumnAttributes(self):
-        def signoffs_table_creator(table):
-            return auslib.db.SignoffsTable(None, MetaData(), 'sqlite', table.table.name.replace('_signoffs', ''))
-
-        self.assert_column_attributes_for_model(auslib.db.SignoffsTable,
-                                                signoffs_table_creator)
-
-    def testHistoryTableColumnAttributes(self):
-        def history_table_creator(table):
-            return auslib.db.History(None, 'sqlite', MetaData(), table.baseTable)
-
-        self.assert_column_attributes_for_model(auslib.db.History,
-                                                history_table_creator)

--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -1,3 +1,4 @@
+import logging
 import mock
 import os
 from tempfile import mkstemp
@@ -9,6 +10,11 @@ from auslib.global_state import dbo
 from auslib.web.base import app
 from auslib.web.views.client import ClientRequestView
 from auslib.errors import BadDataError
+
+
+def setUpModule():
+    # Silence SQLAlchemy-Migrate's debugging logger
+    logging.getLogger('migrate').setLevel(logging.CRITICAL)
 
 
 class ClientTestCommon(unittest.TestCase):


### PR DESCRIPTION
This is a work in progress PR for https://bugzilla.mozilla.org/show_bug.cgi?id=1321036.

I've finished the tests that check out column attributes. In the process I've found that some columns in the models don't match up with the columns in the database, mainly when it comes to null values. We touched on this on IRC the other day and I thought I'd get the columns in questions in front of your eyes before changing the models. 

It looks like some of the "child" models are setting `nullable` to `False` - for example the `data_version` column, _but other_ "child" models have the same column's nullable attribute set to True. For example - `ScheduledChanges.data_version.nullable` differs depending on what the parent model is. 

You can run the tests on this branch (`./run-tests.sh backend auslib/test/test_db.py::TestDBModel`) (edit: or you can just go to line 3327 [in the test log](https://tools.taskcluster.net/task-group-inspector/#/ApFImzLyQgqBGcoZ-Q28sg/ApFImzLyQgqBGcoZ-Q28sg?_k=hodcw6) in Taskcluster) to get this list of differences:

 - "Property 'nullable' on 'releases_scheduled_changes_conditions.when' differs between model and migration: (model) True != (reflected) False",
 - "Property 'nullable' on 'releases_scheduled_changes_conditions.data_version' differs between model and migration: (model) False != (reflected) True",
 - "Property 'nullable' on 'product_req_signoffs_scheduled_changes_conditions.data_version' differs between model and migration: (model) False != (reflected) True",
 - "Property 'unique' on 'rules_scheduled_changes.base_alias' differs between model and migration: (model) True != (reflected) None",
 - "Property 'nullable' on 'rules_scheduled_changes.base_update_type' differs between model and migration: (model) False != (reflected) True",
 - "Property 'nullable' on 'rules_scheduled_changes.data_version' differs between model and migration: (model) False != (reflected) True",
 - "Property 'nullable' on 'permissions_scheduled_changes.base_permission' differs between model and migration: (model) True != (reflected) False",
 - "Property 'nullable' on 'permissions_scheduled_changes.base_username' differs between model and migration: (model) True != (reflected) False",
 - "Property 'nullable' on 'permissions_scheduled_changes.data_version' differs between model and migration: (model) False != (reflected) True",
 - "Property 'nullable' on 'permissions_req_signoffs_scheduled_changes_conditions.data_version' differs between model and migration: (model) False != (reflected) True",
 - "Property 'nullable' on 'permissions_scheduled_changes_conditions.when' differs between model and migration: (model) True != (reflected) False",
 - "Property 'nullable' on 'permissions_scheduled_changes_conditions.data_version' differs between model and migration: (model) False != (reflected) True",
 - "Property 'unique' on 'rules_history.alias' differs between model and migration: (model) True != (reflected) None",
 - "Property 'nullable' on 'rules_scheduled_changes_conditions.data_version' differs between model and migration: (model) False != (reflected) True",
 - "Property 'nullable' on 'product_req_signoffs_scheduled_changes.base_product' differs between model and migration: (model) True != (reflected) False",
 - "Property 'nullable' on 'product_req_signoffs_scheduled_changes.base_channel' differs between model and migration: (model) True != (reflected) False",
 - "Property 'nullable' on 'product_req_signoffs_scheduled_changes.base_role' differs between model and migration: (model) True != (reflected) False",
 - "Property 'nullable' on 'product_req_signoffs_scheduled_changes.base_signoffs_required' differs between model and migration: (model) False != (reflected) True",
 - "Property 'nullable' on 'user_roles.data_version' differs between model and migration: (model) False != (reflected) True",
 - "Property 'unique' on 'rules_scheduled_changes_history.base_alias' differs between model and migration: (model) True != (reflected) None",
 - "Property 'nullable' on 'permissions_req_signoffs_scheduled_changes.base_product' differs between model and migration: (model) True != (reflected) False",
 - "Property 'nullable' on 'permissions_req_signoffs_scheduled_changes.base_role' differs between model and migration: (model) True != (reflected) False",
 - "Property 'nullable' on 'permissions_req_signoffs_scheduled_changes.base_signoffs_required' differs between model and migration: (model) False != (reflected) True",
 - "Property 'nullable' on 'releases_scheduled_changes.base_name' differs between model and migration: (model) True != (reflected) False",
 - "Property 'nullable' on 'releases_scheduled_changes.base_product' differs between model and migration: (model) False != (reflected) True",
 - "Property 'nullable' on 'releases_scheduled_changes.base_data' differs between model and migration: (model) False != (reflected) True",
 - "Property 'nullable' on 'releases_scheduled_changes.data_version' differs between model and migration: (model) False != (reflected) True"

I'm still trying to find a system in how changes to these columns propagate from parent to child models and I was wondering if you have any advice? 

Thanks!