### PR TITLE
Bug 1278539 - History refactor

### DIFF
--- a/auslib/admin/base.py
+++ b/auslib/admin/base.py
@@ -22,13 +22,12 @@ from auslib.admin.views.releases import SingleLocaleView, \
     ReleasesAPIView, SingleReleaseColumnView, ReleaseReadOnlyView, \
     ReleaseScheduledChangesView, ReleaseScheduledChangeView, \
     EnactReleaseScheduledChangeView, ReleaseScheduledChangeHistoryView, \
-    ReleaseScheduledChangeSignoffsView
+    ReleaseScheduledChangeSignoffsView, ReleaseFieldView, ReleaseDiffView
 from auslib.admin.views.rules import RulesAPIView, \
     SingleRuleView, RuleHistoryAPIView, SingleRuleColumnView, \
     RuleScheduledChangesView, RuleScheduledChangeView, \
     EnactRuleScheduledChangeView, RuleScheduledChangeHistoryView, \
     RuleScheduledChangeSignoffsView
-from auslib.admin.views.history import DiffView, FieldView
 from auslib.dockerflow import create_dockerflow_endpoints
 
 
@@ -93,8 +92,8 @@ app.add_url_rule("/releases/<release>/read_only", view_func=ReleaseReadOnlyView.
 app.add_url_rule("/releases/<release>/builds/<platform>/<locale>", view_func=SingleLocaleView.as_view("single_locale"))
 app.add_url_rule("/releases/<release>/revisions", view_func=ReleaseHistoryView.as_view("release_revisions"))
 app.add_url_rule("/releases/columns/<column>", view_func=SingleReleaseColumnView.as_view("release_columns"))
-app.add_url_rule("/history/diff/<type_>/<change_id>/<field>", view_func=DiffView.as_view("diff"))
-app.add_url_rule("/history/view/<type_>/<change_id>/<field>", view_func=FieldView.as_view("field"))
+app.add_url_rule("/history/diff/release/<change_id>/<field>", view_func=ReleaseDiffView.as_view("release_diff"))
+app.add_url_rule("/history/view/release/<change_id>/<field>", view_func=ReleaseFieldView.as_view("release_field"))
 app.add_url_rule("/scheduled_changes/rules", view_func=RuleScheduledChangesView.as_view("scheduled_changes_rules"))
 app.add_url_rule("/scheduled_changes/rules/<int:sc_id>", view_func=RuleScheduledChangeView.as_view("scheduled_change_rules"))
 app.add_url_rule("/scheduled_changes/rules/<int:sc_id>/enact", view_func=EnactRuleScheduledChangeView.as_view("enact_scheduled_change_rules"))

--- a/auslib/admin/views/base.py
+++ b/auslib/admin/views/base.py
@@ -1,11 +1,9 @@
 import json
-import time
 
 from flask import request, Response
 from flask.views import MethodView
 
 from auslib.global_state import dbo
-from auslib.util.timesince import timesince
 from auslib.db import OutdatedDataError, PermissionDeniedError, UpdateMergeError, ChangeScheduledError, \
     SignoffRequiredError
 import logging
@@ -78,64 +76,3 @@ class AdminView(MethodView):
         self.log.debug("processing DELETE request to %s" % request.path)
         with dbo.begin() as trans:
             return self._delete(*args, transaction=trans, **kwargs)
-
-
-class HistoryAdminView(AdminView):
-
-    history_keys = ('timestamp', 'change_id', 'data_version', 'changed_by')
-
-    def getAllRevisionKeys(self, revisions, primary_keys):
-        try:
-            all_keys = sorted([
-                x for x in revisions[0].keys()
-                if x not in self.history_keys and x not in primary_keys
-            ])
-        except IndexError:
-            all_keys = None
-        return all_keys
-
-    def annotateRevisionDifferences(self, revisions):
-        _prev = {}
-        for i, rev in enumerate(revisions):
-            different = []
-            for key, value in rev.items():
-                if key in self.history_keys:
-                    continue
-                if key not in _prev:
-                    _prev[key] = value
-                else:
-                    prev = _prev[key]
-                    if prev != value:
-                        different.append(key)
-                # prep the value for being shown in revision_row.html
-                if value is None:
-                    value = 'NULL'
-                elif isinstance(value, dict):
-                    try:
-                        value = json.dumps(value, indent=2, sort_keys=True)
-                    except ValueError:
-                        pass
-                elif isinstance(value, int):
-                    value = unicode(str(value), 'utf8')
-                elif not isinstance(value, basestring):
-                    value = unicode(value, 'utf8')
-                rev[key] = value
-
-            rev['_different'] = different
-            rev['_time_ago'] = getTimeAgo(rev['timestamp'])
-
-
-def getTimeAgo(timestamp):
-    # keeping this here amongst the view code because the use of the
-    # timesince() function is specific to the view
-    now, then = int(time.time()), int(timestamp / 1000.0)
-    time_ago = timesince(
-        then,
-        now,
-        afterword='ago',
-        minute_granularity=True,
-        max_no_sections=2
-    )
-    if not time_ago:
-        time_ago = 'seconds ago'
-    return time_ago

--- a/auslib/admin/views/history.py
+++ b/auslib/admin/views/history.py
@@ -1,27 +1,17 @@
-import difflib
 import json
-
-from sqlalchemy.sql.expression import null
 
 from flask import Response
 
-from auslib.global_state import dbo
 from auslib.admin.views.base import AdminView
 
 
 class FieldView(AdminView):
-    """/view/:type/:id/:field"""
+    """/view/:id/:field"""
+    def __init__(self, table, *args, **kwargs):
+        self.table = table
 
-    def get_value(self, type_, change_id, field):
-        tables = {
-            'rule': dbo.rules,
-            'permission': dbo.permissions,
-            'release': dbo.releases,
-        }
-        if type_ not in tables:
-            raise KeyError('Bad table')
-        table = tables[type_]
-        revision = table.history.getChange(change_id=change_id)
+    def get_value(self, change_id, field):
+        revision = self.table.history.getChange(change_id=change_id)
         if not revision:
             raise ValueError('Bad change_id')
         if field not in revision:
@@ -42,9 +32,9 @@ class FieldView(AdminView):
             value = unicode(value, 'utf8')
         return value
 
-    def get(self, type_, change_id, field):
+    def get(self, change_id, field):
         try:
-            value = self.get_value(type_, change_id, field)
+            value = self.get_value(change_id, field)
         except KeyError as msg:
             self.log.warning("Bad input: %s", field)
             return Response(status=400, response=str(msg))
@@ -52,45 +42,3 @@ class FieldView(AdminView):
             return Response(status=404, response=str(msg))
         value = self.format_value(value)
         return Response(value, content_type='text/plain')
-
-
-class DiffView(FieldView):
-    """/diff/:type/:id/:field"""
-
-    def get_prev_id(self, value, change_id):
-
-        release_name = value['name']
-
-        table = dbo.releases.history
-        old_revision = table.select(
-            where=[
-                table.name == release_name,
-                table.change_id < change_id,
-                table.data_version != null()
-            ],
-            limit=1,
-            order_by=[table.timestamp.desc()],
-        )
-
-        return old_revision[0]['change_id']
-
-    def get(self, type_, change_id, field):
-        value = self.get_value(type_, change_id, field)
-        data_version = self.get_value(type_, change_id, "data_version")
-
-        prev_id = self.get_prev_id(value, change_id)
-        previous = self.get_value(type_, prev_id, field)
-        prev_data_version = self.get_value(type_, prev_id, "data_version")
-
-        value = self.format_value(value)
-        previous = self.format_value(previous)
-
-        result = difflib.unified_diff(
-            previous.splitlines(),
-            value.splitlines(),
-            fromfile="Data Version {}".format(prev_data_version),
-            tofile="Data Version {}".format(data_version),
-            lineterm=""
-        )
-
-        return Response('\n'.join(result), content_type='text/plain')

--- a/auslib/admin/views/history.py
+++ b/auslib/admin/views/history.py
@@ -1,44 +1,195 @@
 import json
+import time
 
-from flask import Response
+from flask import Response, jsonify, request
+from sqlalchemy import and_
 
 from auslib.admin.views.base import AdminView
+from auslib.util.timesince import timesince
 
 
-class FieldView(AdminView):
-    """/view/:id/:field"""
+class HistoryAdminView(AdminView):
+
+    history_keys = ('timestamp', 'change_id', 'data_version', 'changed_by')
+
+    def annotateRevisionDifferences(self, revisions):
+        _prev = {}
+        for i, rev in enumerate(revisions):
+            different = []
+            for key, value in rev.items():
+                if key in self.history_keys:
+                    continue
+                if key not in _prev:
+                    _prev[key] = value
+                else:
+                    prev = _prev[key]
+                    if prev != value:
+                        different.append(key)
+                # prep the value for being shown in revision_row.html
+                if value is None:
+                    value = 'NULL'
+                elif isinstance(value, dict):
+                    try:
+                        value = json.dumps(value, indent=2, sort_keys=True)
+                    except ValueError:
+                        pass
+                elif isinstance(value, int):
+                    value = unicode(str(value), 'utf8')
+                elif not isinstance(value, basestring):
+                    value = unicode(value, 'utf8')
+                rev[key] = value
+
+            rev['_different'] = different
+            rev['_time_ago'] = self.getTimeAgo(rev['timestamp'])
+
+    def getTimeAgo(self, timestamp):
+        now, then = int(time.time()), int(timestamp / 1000.0)
+        time_ago = timesince(
+            then,
+            now,
+            afterword='ago',
+            minute_granularity=True,
+            max_no_sections=2)
+        if not time_ago:
+            time_ago = 'seconds ago'
+        return time_ago
+
+
+class HistoryView(HistoryAdminView):
+    """Base class for history views. Provides basics operations to get all
+    object revisions and revert object to specific revision.
+
+    @param table: Table.
+    @type table: auslib.db.AUSTable
+    """
+
     def __init__(self, table, *args, **kwargs):
         self.table = table
+        self.history_table = table.history
+        super(HistoryView, self).__init__(*args, **kwargs)
 
-    def get_value(self, change_id, field):
-        revision = self.table.history.getChange(change_id=change_id)
-        if not revision:
-            raise ValueError('Bad change_id')
-        if field not in revision:
-            raise KeyError('Bad field')
-        return revision[field]
+    def get_revisions(self,
+                      get_object_callback,
+                      history_filters_callback,
+                      process_revisions_callback,
+                      revisions_order_by,
+                      obj_not_found_msg='Requested object does not exist',
+                      response_key='revisions'):
+        """Get revisions for Releases, Rules or ScheduledChanges.
+        Uses callable parameters to handle specific AUS object data.
 
-    def format_value(self, value):
-        if isinstance(value, dict):
-            try:
-                value = json.dumps(value, indent=2, sort_keys=True)
-            except ValueError:
-                pass
-        elif value is None:
-            value = 'NULL'
-        elif isinstance(value, int):
-            value = unicode(str(value), 'utf8')
-        else:
-            value = unicode(value, 'utf8')
-        return value
+        @param get_object_callback: A callback to get requested AUS object.
+        @type get_object_callback: callable
 
-    def get(self, change_id, field):
-        try:
-            value = self.get_value(change_id, field)
-        except KeyError as msg:
-            self.log.warning("Bad input: %s", field)
-            return Response(status=400, response=str(msg))
-        except ValueError as msg:
-            return Response(status=404, response=str(msg))
-        value = self.format_value(value)
-        return Response(value, content_type='text/plain')
+        @param history_filters_callback: A callback that get the filters list
+        to query the history.
+        @type history_filters_callback: callable
+
+        @param process_revisions_callback: A callback that process revisions
+        according to the requested AUS object.
+        @type process_revisions_callback: callable
+
+        @param revisions_order_by: Fields list to sort history.
+        @type revisions_order_by: list
+
+        @param obj_not_found_msg: Error message for not found AUS object.
+        @type obj_not_found_msg: string
+
+        @param response_key: Dictionary key to wrap returned revisions.
+        @type response_key: string
+        """
+        page = int(request.args.get('page', 1))
+        limit = int(request.args.get('limit', 10))
+        assert page >= 1
+
+        obj = get_object_callback()
+        if not obj:
+            return Response(status=404,
+                            response=self.not_found_msg)
+
+        offset = limit * (page - 1)
+
+        filters = history_filters_callback(obj)
+        total_count = self.history_table.t.count()\
+                                          .where(and_(*filters))\
+                                          .execute().fetchone()[0]
+
+        revisions = self.history_table.select(
+            where=filters,
+            limit=limit,
+            offset=offset,
+            order_by=revisions_order_by)
+
+        _revisions = process_revisions_callback(revisions)
+
+        ret = {}
+        ret[response_key] = _revisions
+        ret['count'] = total_count
+        return jsonify(ret)
+
+    def revert_to_revision(self,
+                           get_object_callback,
+                           change_field,
+                           get_what_callback,
+                           changed_by,
+                           response_message,
+                           transaction,
+                           obj_not_found_msg='Requested object does not exist'):
+        """Reverts Releases, Rules or ScheduledChanges object to specific
+        revision. Uses callable parameters to handle specific AUS object data.
+
+        @param get_object_callback: A callback to get requested AUS object.
+        @type get_object_callback: callable
+
+        @param change_field: Specific table field to match revision.
+        @type change_field: string
+
+        @param get_what_callback: Criteria to revert revision.
+        @type get_what_callback: callable
+
+        @param changed_by: User.
+        @type changed_by: string
+
+        @param response_message: Success message.
+        @type response_message: string
+
+        @param transaction: Transaction
+        @type transaction: auslib.db.AUSTransaction
+
+        @param obj_not_found_msg: Error message for not found AUS object.
+        @type obj_not_found_msg: string
+        """
+
+        obj = get_object_callback()
+        if not obj:
+            return Response(status=404,
+                            response=obj_not_found_msg)
+
+        change_id = None
+        if request.json:
+            change_id = request.json.get('change_id')
+        if not change_id:
+            self.log.warning("Bad input: %s", "no change_id")
+            return Response(status=400, response='no change_id')
+
+        change = self.history_table.getChange(change_id=change_id)
+        if change is None:
+            return Response(status=400, response='bad change_id')
+
+        obj_id = obj[change_field]
+
+        if change[change_field] != obj_id:
+            return Response(status=400,
+                            response='bad {0}'.format(change_field))
+        old_data_version = obj['data_version']
+
+        # now we're going to make a new insert based on this
+        what = get_what_callback(change)
+        where = {}
+        where[change_field] = obj_id
+        self.table.update(changed_by=changed_by,
+                          where=where,
+                          what=what,
+                          old_data_version=old_data_version,
+                          transaction=transaction)
+        return Response(response_message)

--- a/auslib/admin/views/permissions.py
+++ b/auslib/admin/views/permissions.py
@@ -9,7 +9,7 @@ from auslib.admin.views.forms import NewPermissionForm, ExistingPermissionForm, 
     EditScheduledChangeNewPermissionForm, EditScheduledChangeExistingPermissionForm, \
     ScheduledChangeDeletePermissionForm
 from auslib.admin.views.scheduled_changes import ScheduledChangesView, \
-    ScheduledChangeView, EnactScheduledChangeView, ScheduledChangeHistoryView, \
+    ScheduledChangeView, EnactScheduledChangeView, ScheduledChangeHistoryView,\
     SignoffsView
 
 __all__ = ["UsersView", "PermissionsView", "SpecificPermissionView"]

--- a/auslib/admin/views/releases.py
+++ b/auslib/admin/views/releases.py
@@ -9,7 +9,7 @@ from auslib.global_state import dbo
 from auslib.blobs.base import createBlob, BlobValidationError
 from auslib.db import OutdatedDataError, ReadOnlyError
 from auslib.admin.views.base import (
-    requirelogin, AdminView, HistoryAdminView
+    requirelogin, AdminView
 )
 from auslib.admin.views.csrf import get_csrf_headers
 from auslib.admin.views.forms import PartialReleaseForm, CompleteReleaseForm, DbEditableForm, ReadOnlyForm, \
@@ -18,7 +18,7 @@ from auslib.admin.views.forms import PartialReleaseForm, CompleteReleaseForm, Db
 from auslib.admin.views.scheduled_changes import ScheduledChangesView, \
     ScheduledChangeView, EnactScheduledChangeView, ScheduledChangeHistoryView, \
     SignoffsView
-from auslib.admin.views.history import FieldView
+from auslib.admin.views.history import HistoryView
 
 
 __all__ = ["SingleReleaseView", "SingleLocaleView"]
@@ -351,40 +351,14 @@ class ReleaseReadOnlyView(AdminView):
         return Response(status=201, response=json.dumps(dict(new_data_version=data_version)))
 
 
-class ReleaseHistoryView(HistoryAdminView):
+class ReleaseHistoryView(HistoryView):
     """/releases/:release/revisions"""
 
-    def get(self, release):
-        releases = dbo.releases.getReleases(name=release, limit=1)
-        if not releases:
-            return Response(status=404,
-                            response='Requested release does not exist')
-        release = releases[0]
-        table = dbo.releases.history
+    def __init__(self):
+        super(ReleaseHistoryView, self).__init__(dbo.releases)
 
-        try:
-            page = int(request.args.get('page', 1))
-            limit = int(request.args.get('limit', 10))
-            assert page >= 1
-        except (ValueError, AssertionError) as e:
-            self.log.warning("Bad input: %s", json.dumps(e.args))
-            return Response(status=400, response=json.dumps({"data": e.args}))
-        offset = limit * (page - 1)
-        total_count = table.t.count()\
-            .where(table.name == release['name'])\
-            .where(table.data_version != null())\
-            .execute()\
-            .fetchone()[0]
-
-        revisions = table.select(
-            where=[
-                table.name == release['name'],
-                table.data_version != null()
-            ],
-            limit=limit,
-            offset=offset,
-            order_by=[table.timestamp.desc()],
-        )
+    def _process_revisions(self, revisions):
+        self.annotateRevisionDifferences(revisions)
 
         _mapping = [
             'data_version',
@@ -395,10 +369,7 @@ class ReleaseHistoryView(HistoryAdminView):
             '_time_ago',
             'change_id',
             'changed_by',
-            "timestamp",
-        ]
-
-        self.annotateRevisionDifferences(revisions)
+            "timestamp"]
 
         _revisions = []
         for r in revisions:
@@ -407,41 +378,51 @@ class ReleaseHistoryView(HistoryAdminView):
                 for item in _mapping
             ))
 
-        return jsonify(revisions=_revisions, count=total_count)
+        return _revisions
+
+    def _get_filters(self, release):
+        return [self.history_table.name == release['name'],
+                self.history_table.data_version != null()]
+
+    def _get_what(self, change):
+        return dict(
+            data=createBlob(change['data']),
+            product=change["product"])
+
+    def _get_release(self, release):
+        releases = self.table.getReleases(name=release, limit=1)
+        return releases[0] if releases else None
+
+    def get(self, release):
+        try:
+            return self.get_revisions(
+                get_object_callback=lambda: self._get_release(release),
+                history_filters_callback=self._get_filters,
+                process_revisions_callback=self._process_revisions,
+                revisions_order_by=[self.history_table.timestamp.desc()],
+                obj_not_found_msg='Requested release does not exist')
+        except (ValueError, AssertionError) as e:
+            self.log.warning("Bad input: %s", json.dumps(e.args))
+            return Response(status=400, response=json.dumps({"data": e.args}))
 
     @requirelogin
     def _post(self, release, transaction, changed_by):
-        releases = dbo.releases.getReleases(name=release)
-        if not releases:
-            return Response(status=404, response='bad release')
-        change_id = None
-        if request.json:
-            change_id = request.json.get('change_id')
-        if not change_id:
-            self.log.warning("Bad input: %s", release)
-            return Response(status=400, response='no change_id')
-        change = dbo.releases.history.getChange(change_id=change_id)
-        if change is None:
-            return Response(status=400, response='bad change_id')
-        if change['name'] != release:
-            return Response(status=400, response='bad release')
-        release = releases[0]
-        old_data_version = release['data_version']
-
-        # now we're going to make a new update based on this change
-        blob = createBlob(change['data'])
-
         try:
-            dbo.releases.update(where={"name": change["name"]}, what={"data": blob, "product": change["product"]}, changed_by=changed_by,
-                                old_data_version=old_data_version, transaction=transaction)
+            return self.revert_to_revision(
+                get_object_callback=lambda: self._get_release(release),
+                change_field='name',
+                get_what_callback=self._get_what,
+                changed_by=changed_by,
+                response_message='Excellent!',
+                transaction=transaction,
+                obj_not_found_msg='bad release')
         except BlobValidationError as e:
             self.log.warning("Bad input: %s", e.args)
-            return Response(status=400, response=json.dumps({"data": e.errors}))
+            return Response(status=400,
+                            response=json.dumps({"data": e.errors}))
         except ValueError as e:
             self.log.warning("Bad input: %s", e.args)
             return Response(status=400, response=json.dumps({"data": e.args}))
-
-        return Response("Excellent!")
 
 
 class ReleasesAPIView(AdminView):
@@ -608,11 +589,43 @@ class ReleaseScheduledChangeHistoryView(ScheduledChangeHistoryView):
         return super(ReleaseScheduledChangeHistoryView, self)._post(sc_id, transaction, changed_by)
 
 
-class ReleaseFieldView(FieldView):
+class ReleaseFieldView(AdminView):
     """/diff/:id/:field"""
-
     def __init__(self):
-        super(ReleaseFieldView, self).__init__(dbo.releases)
+        self.table = dbo.releases
+
+    def get_value(self, change_id, field):
+        revision = self.table.history.getChange(change_id=change_id)
+        if not revision:
+            raise ValueError('Bad change_id')
+        if field not in revision:
+            raise KeyError('Bad field')
+        return revision[field]
+
+    def format_value(self, value):
+        if isinstance(value, dict):
+            try:
+                value = json.dumps(value, indent=2, sort_keys=True)
+            except ValueError:
+                pass
+        elif value is None:
+            value = 'NULL'
+        elif isinstance(value, int):
+            value = unicode(str(value), 'utf8')
+        else:
+            value = unicode(value, 'utf8')
+        return value
+
+    def get(self, change_id, field):
+        try:
+            value = self.get_value(change_id, field)
+        except KeyError as msg:
+            self.log.warning("Bad input: %s", field)
+            return Response(status=400, response=str(msg))
+        except ValueError as msg:
+            return Response(status=404, response=str(msg))
+        value = self.format_value(value)
+        return Response(value, content_type='text/plain')
 
 
 class ReleaseDiffView(ReleaseFieldView):


### PR DESCRIPTION
-Make the FieldView and DiffView subclassable and available only in release contexts;
-Refactoring the HistoryViews to be needed less reimplementations for each table.

Just opening the PR to validate the ReleaseHistoryView, RuleHistoryAPIView and ScheduledChangeHistoryView refactory approach.
So far, only the get method was refactored.