### PR TITLE
Bug 1302164 - add contribute.json

### DIFF
--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -4,6 +4,7 @@ import os
 from tempfile import mkstemp
 import unittest
 from xml.dom import minidom
+import json
 
 from auslib.blobs.base import createBlob
 from auslib.global_state import dbo
@@ -737,6 +738,12 @@ class ClientTest(ClientTestBase):
         self.assertEqual(ret.status_code, 200)
         self.assertEqual(ret.mimetype, 'text/plain')
         self.assertTrue('User-agent' in ret.data)
+
+    def testContributeJsonExists(self):
+        ret = self.client.get('/contribute.json')
+        self.assertEqual(ret.status_code, 200)
+        self.assertTrue(json.loads(ret.data))
+        self.assertEqual(ret.mimetype, 'application/json')
 
     def testBadAvastURLsFromBug1125231(self):
         # Some versions of Avast have a bug in them that prepends "x86 "

--- a/auslib/web/base.py
+++ b/auslib/web/base.py
@@ -72,6 +72,11 @@ def robots():
     return send_from_directory(app.static_folder, "robots.txt")
 
 
+@app.route('/contribute.json')
+def contributejson():
+    return send_from_directory(app.static_folder, "contribute.json")
+
+
 @app.route('/update/1/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/update.xml')
 @app.route('/update/2/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/update.xml')
 @app.route('/update/3/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/update.xml')

--- a/auslib/web/static/contribute.json
+++ b/auslib/web/static/contribute.json
@@ -1,0 +1,22 @@
+{
+    "name": "Balrog",
+    "description": "Next generation update service for Mozilla products.",
+    "repository": {
+        "url": "https://github.com/mozilla/balrog",
+        "license": "MPL-2.0"
+    },
+    "participate": {
+        "home": "https://mozilla-balrog.readthedocs.io/en/latest/contribute.html",
+        "docs": "https://mozilla-balrog.readthedocs.io/en/latest/",
+        "irc": "irc://irc.mozilla.org/#balrog"
+    },
+    "bugs": {
+        "list": "https://bugzilla.mozilla.org/buglist.cgi?list_id=13406852&emailtype1=exact&status_whiteboard_type=allwordssubstr&emailassigned_to1=1&status_whiteboard=%5Bready%5D&email1=nobody%40mozilla.org&resolution=---&query_format=advanced&component=Balrog%3A%20Backend&component=Balrog%3A%20Frontend"
+    },
+    "urls": {
+        "prod": "https://aus5.mozilla.org/"
+    },
+    "keywords": [
+        "python"
+    ]
+}


### PR DESCRIPTION
In order for Balrog to have a high rating on Observatory (https://observatory.mozilla.org) the contribute.json file must be served at /contribute.json.

Add new contribute.json file with up to date information (passes validation on https://contributejson.org) and update tests to check for its validity.

This fixes the missing part in [Bug 1302164](https://bugzilla.mozilla.org/show_bug.cgi?id=1302164) - balrog shoud get an A from mozilla observatory