### PR TITLE
Bug 1333875 - don't update "scheduled_by" field when merging in updat…

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1232,7 +1232,8 @@ class ScheduledChangeTable(AUSTable):
                     raise UpdateMergeError("Cannot safely merge change to '%s' with scheduled change '%s'", col, sc["sc_id"])
 
             # If we get here, the change is safely mergeable
-            self.update(where=[self.sc_id == sc["sc_id"]], what=what, changed_by=changed_by, old_data_version=sc["data_version"], transaction=transaction)
+            self.update(where=[self.sc_id == sc["sc_id"]], what=what, changed_by=sc["scheduled_by"],
+                        old_data_version=sc["data_version"], transaction=transaction)
             self.log.debug("Merged %s into scheduled change '%s'", what, sc["sc_id"])
 
 

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1332,6 +1332,12 @@ class TestScheduledChangesTable(unittest.TestCase, ScheduledChangesTableMixin, M
         self.assertRaises(UpdateMergeError, self.sc_table.mergeUpdate, old_row, what, changed_by="bob")
 
     @mock.patch("time.time", mock.MagicMock(return_value=200))
+    def testMergeUpateScheduledby(self):
+        self.table.update([self.table.fooid == 2], what={"bar": "bar1"}, changed_by="mary", old_data_version=2)
+        new_row =self.sc_table.select(where=[self.sc_table.sc_id == 4])[0]
+        self.assertEquals(new_row["scheduled_by"], "bob")
+
+    @mock.patch("time.time", mock.MagicMock(return_value=200))
     def testMergeUpdateForDeleteScheduledChange(self):
         old_row = self.table.select(where=[self.table.fooid == 4])[0]
         what = {"fooid": 4, "bar": "abc", "data_version": 2}

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1332,7 +1332,7 @@ class TestScheduledChangesTable(unittest.TestCase, ScheduledChangesTableMixin, M
         self.assertRaises(UpdateMergeError, self.sc_table.mergeUpdate, old_row, what, changed_by="bob")
 
     @mock.patch("time.time", mock.MagicMock(return_value=200))
-    def testMergeUpateScheduledby(self):
+    def testMergeDontChangeScheduledby(self):
         self.table.update([self.table.fooid == 2], what={"bar": "bar1"}, changed_by="mary", old_data_version=2)
         new_row = self.sc_table.select(where=[self.sc_table.sc_id == 4])[0]
         self.assertEquals(new_row["scheduled_by"], "bob")

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1334,7 +1334,7 @@ class TestScheduledChangesTable(unittest.TestCase, ScheduledChangesTableMixin, M
     @mock.patch("time.time", mock.MagicMock(return_value=200))
     def testMergeUpateScheduledby(self):
         self.table.update([self.table.fooid == 2], what={"bar": "bar1"}, changed_by="mary", old_data_version=2)
-        new_row =self.sc_table.select(where=[self.sc_table.sc_id == 4])[0]
+        new_row = self.sc_table.select(where=[self.sc_table.sc_id == 4])[0]
         self.assertEquals(new_row["scheduled_by"], "bob")
 
     @mock.patch("time.time", mock.MagicMock(return_value=200))


### PR DESCRIPTION
Fixed the bug by using `scheduled_by` of `sc_table` instead of `changed_by`.

I was playing around after the fix and when I found out that even if I `update` in [http://localhost:8080/rules/scheduled_changes](http://localhost:8080/rules/scheduled_changes), it still didn't update `scheduled_by`. 
Is this what is expected of the fix?

