### PR TITLE
Bug 1301040 Filter state persists after switching pages

### DIFF
--- a/ui/app/js/controllers/rules_controller.js
+++ b/ui/app/js/controllers/rules_controller.js
@@ -58,7 +58,7 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         })
         .finally(function() {
           $scope.pr_ch_options.sort().unshift("All rules");
-          $scope.pr_ch_filter = $scope.pr_ch_options[0];
+          $scope.pr_ch_filter = localStorage.getItem('pr_ch_filter') || "All rules";
         });
       });
     })
@@ -76,6 +76,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
   });
 
   $scope.$watch('pr_ch_filter', function(value) {
+    if (value) {
+      localStorage.setItem("pr_ch_filter", value);
+    }
     $scope.pr_ch_selected = value.split(',');
   });
 


### PR DESCRIPTION
Filter state is now stored in localStorage under the key 'pr_ch_filter'. When page is switched, the state is persisted, and when we revert back to the page, we reload the last known filter from localStorage. Its "All rules" by default