### PR TITLE
Bug 1333874:  mergeUpdate is broken when a base table row updates a v…

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1215,6 +1215,10 @@ class ScheduledChangeTable(AUSTable):
         (meaning: the scheduled change and the new version of the row modify
         the same columns), an UpdateMergeError is raised."""
 
+        # Filter the update to only include fields that are different than
+        # what's in the base (old_row).
+        what = {k: v for k, v in what.items() if v != old_row.get(k)}
+
         # pyflakes thinks this should be "is False", but that's not how SQLAlchemy
         # works, so we need to shut it up.
         # http://stackoverflow.com/questions/18998010/flake8-complains-on-boolean-comparison-in-filter-clause
@@ -1235,7 +1239,7 @@ class ScheduledChangeTable(AUSTable):
                 # be modifying the row when enacted. If the update to the row
                 # ("what") is also modifying the same column, this is a conflict
                 # that the server cannot resolve.
-                if sc["base_%s" % col] != old_row.get(col) and old_row.get(col) != what.get(col):
+                if sc["base_%s" % col] != old_row.get(col) and what.get(col) != old_row.get(col):
                     raise UpdateMergeError("Cannot safely merge change to '%s' with scheduled change '%s'", col, sc["sc_id"])
 
             # If we get here, the change is safely mergeable

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1235,7 +1235,7 @@ class ScheduledChangeTable(AUSTable):
                 # be modifying the row when enacted. If the update to the row
                 # ("what") is also modifying the same column, this is a conflict
                 # that the server cannot resolve.
-                if sc["base_%s" % col] != old_row.get(col) and sc["base_%s" % col] != what.get(col):
+                if sc["base_%s" % col] != old_row.get(col) and old_row.get(col) != what.get(col):
                     raise UpdateMergeError("Cannot safely merge change to '%s' with scheduled change '%s'", col, sc["sc_id"])
 
             # If we get here, the change is safely mergeable

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1346,6 +1346,14 @@ class TestScheduledChangesTable(unittest.TestCase, ScheduledChangesTableMixin, M
         self.assertEquals(new_row["base_data_version"], 2)
         self.assertEquals(new_row["base_bar"], "abc")
 
+    @mock.patch("time.time", mock.MagicMock(return_value=200))
+    def testMergeUpdateWithConflictWhenSameValAndCol(self):
+        # This is from bug #1333874 - if an update and scheduled change update
+        # the same column with the same value, mergeUpdate should throw an exception.
+        old_row = self.table.select(where=[self.table.fooid == 1])[0]
+        what = {"fooid": 1, "bar": "barbar", "data_version": 1}
+        self.assertRaises(UpdateMergeError, self.sc_table.mergeUpdate, old_row, what, changed_by="bob")
+
 
 class TestScheduledChangesWithConfigurableConditions(unittest.TestCase, MemoryDatabaseMixin):
 


### PR DESCRIPTION
…alue to the same value in the scheduled change

Bug: [1333874](https://bugzilla.mozilla.org/show_bug.cgi?id=1333874)

I changed the condition to check the base object against the update and I added a test to check against this case. I'll test this out manually today or tomorrow so we can get this merged soon :). 