### PR TITLE
Bug 1304555:Remove Product/Channel filter from Rules history pages

### DIFF
--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -47,14 +47,14 @@
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.backgroundRate}">
           <label for="id_rate">Rate</label>
-          <input type="number" class="form-control" id="id_rate" ng-model="rule.backgroundRate">
+          <input type="text" class="form-control" id="id_rate" ng-model="rule.backgroundRate">
           <p class="help-block" ng-show="errors.backgroundRate">{{ errors.backgroundRate.join(', ') }}</p>
         </div>
       </div>
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.priority}">
           <label for="id_priority">Priority</label>
-          <input type="number" class="form-control" id="id_priority" ng-model="rule.priority">
+          <input type="text" class="form-control" id="id_priority" ng-model="rule.priority">
           <p class="help-block" ng-show="errors.priority">{{ errors.priority.join(', ') }}</p>
         </div>
       </div>

--- a/ui/app/templates/rules.html
+++ b/ui/app/templates/rules.html
@@ -31,7 +31,7 @@
     </div>
   </div>
   <div class="col-sm-5 text-right">
-    <div class="row">
+    <div class="row" ng-if="!rule_id">
       <label>Product/Channel filter:</label>
       <select ng-model="pr_ch_filter" name="pr_ch_filter"
         ng-options="pr_ch_pair for pr_ch_pair in pr_ch_options track by pr_ch_pair">


### PR DESCRIPTION
Product/Channel filter is shown in all pages where rule_id is not available and ng-if evaluates to true. rule_id is available in the history page, hence ng-if evaluates to false and the filter is removed from the DOM. 