### PR TITLE
Add sm

### DIFF
--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -4,11 +4,12 @@ import os
 from auslib.log import configure_logging
 
 
-SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "b2gbld", "stage-ffxbld", "stage-tbirdbld", "stage-b2gbld"]
+SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "seabld", "stage-ffxbld",
+                   "stage-tbirdbld", "stage-seabld"]
 DOMAIN_WHITELIST = {
-    "download.mozilla.org": ("Firefox", "Fennec", "Thunderbird"),
-    "archive.mozilla.org": ("Firefox", "Fennec", "Thunderbird"),
-    "download.cdn.mozilla.net": ("Firefox", "Fennec"),
+    "download.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),
+    "archive.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),
+    "download.cdn.mozilla.net": ("Firefox", "Fennec", "SeaMonkey"),
     "mozilla-nightly-updates.s3.amazonaws.com": ("Firefox",),
     "ciscobinary.openh264.org": ("OpenH264",),
     "cdmdownload.adobe.com": ("CDM",),

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -4,8 +4,8 @@ import os
 from auslib.log import configure_logging
 
 
-SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "b2gbld", "seabld", "stage-ffxbld",
-                   "stage-tbirdbld", "stage-b2gbld", "stage-seabld"]
+SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "seabld", "stage-ffxbld",
+                   "stage-tbirdbld", "stage-seabld"]
 SPECIAL_FORCE_HOSTS = ["http://download.mozilla.org"]
 DOMAIN_WHITELIST = {
     "download.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -4,12 +4,13 @@ import os
 from auslib.log import configure_logging
 
 
-SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "b2gbld", "stage-ffxbld", "stage-tbirdbld", "stage-b2gbld"]
+SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "b2gbld", "seabld", "stage-ffxbld",
+                   "stage-tbirdbld", "stage-b2gbld", "stage-seabld"]
 SPECIAL_FORCE_HOSTS = ["http://download.mozilla.org"]
 DOMAIN_WHITELIST = {
-    "download.mozilla.org": ("Firefox", "Fennec", "Thunderbird"),
-    "archive.mozilla.org": ("Firefox", "Fennec", "Thunderbird"),
-    "download.cdn.mozilla.net": ("Firefox", "Fennec"),
+    "download.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),
+    "archive.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),
+    "download.cdn.mozilla.net": ("Firefox", "Fennec", "SeaMonkey"),
     "mozilla-nightly-updates.s3.amazonaws.com": ("Firefox",),
     "ciscobinary.openh264.org": ("OpenH264",),
     "cdmdownload.adobe.com": ("CDM",),


### PR DESCRIPTION
The SeaMonkey project is migrating to Balrog and will need seabld/stage-seabld and SeaMonkey whitelisted.