### PR TITLE
Update .taskcluster.yml with new settings.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,4 +1,5 @@
 version: 0
+allowPullRequests: public
 metadata:
   name: Balrog
   description: Balrog CI Tasks
@@ -22,7 +23,9 @@ tasks:
       github:
         env: true
         events:
-          - pull_request.*
+          - pull_request.opened
+          - pull_request.synchronize
+          - pull_request.reopened
           - push
     metadata:
       name: Balrog back-end tests
@@ -47,11 +50,40 @@ tasks:
       github:
         env: true
         events:
-          - pull_request.*
+          - pull_request.opened
+          - pull_request.synchronize
+          - pull_request.reopened
           - push
     metadata:
       name: Balrog front-end tests
       description: Balrog JavaScript tests
+      owner: "{{ event.head.user.email }}"
+      source: "{{ event.head.repo.url }}"
+
+  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
+    workerType: "{{ taskcluster.docker.workerType }}"
+    payload:
+      maxRunTime: 1200
+      image: "rail/python-test-runner"
+      env:
+        NO_VOLUME_MOUNT: 1
+      command:
+        - "/bin/bash"
+        - "-c"
+        - "git clone $GITHUB_HEAD_REPO_URL && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd agent && bash run-tests.sh"
+      features:
+        dind: true
+    extra:
+      github:
+        env: true
+        events:
+          - pull_request.opened
+          - pull_request.synchronize
+          - pull_request.reopened
+          - push
+    metadata:
+      name: Balrog Agent Tests
+      description: Balrog Agent Tests
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"
 
@@ -80,31 +112,6 @@ tasks:
     metadata:
       name: Balrog Docker Image Creation
       description: Balrog Docker Image Creation
-      owner: "{{ event.head.user.email }}"
-      source: "{{ event.head.repo.url }}"
-
-  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
-    workerType: "{{ taskcluster.docker.workerType }}"
-    payload:
-      maxRunTime: 1200
-      image: "rail/python-test-runner"
-      env:
-        NO_VOLUME_MOUNT: 1
-      command:
-        - "/bin/bash"
-        - "-c"
-        - "git clone $GITHUB_HEAD_REPO_URL && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd agent && bash run-tests.sh"
-      features:
-        dind: true
-    extra:
-      github:
-        env: true
-        events:
-          - pull_request.*
-          - push
-    metadata:
-      name: Balrog Agent Tests
-      description: Balrog Agent Tests
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"
 
@@ -183,8 +190,8 @@ tasks:
         events:
           - release
     metadata:
-      name: Balrog Docker Image Creation
-      description: Balrog Docker Image Creation
+      name: Balrog Docker Image Creation (release event)
+      description: Balrog Docker Image Creation (release event)
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"
 
@@ -209,7 +216,7 @@ tasks:
         events:
           - release
     metadata:
-      name: Balrog Agent Docker Image Creation
-      description: Balrog Agent Docker Image Creation
+      name: Balrog Agent Docker Image Creation (release event)
+      description: Balrog Agent Docker Image Creation (release event)
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"


### PR DESCRIPTION
The most important part of this is the new allowPullRequests setting (see https://docs.taskcluster.net/reference/integrations/github/docs/usage). I also:
- Pared down the events we respond to - pull_request.* causes a lot of unnecessary (and hidden) jobs.
- Changed the names of the "release" event tasks - I'm still trying to verify that they work, so we can remove the "push" ones that build Docker images.
- Moved all the CI tasks to the top.