### PR TITLE
Fix required_signoffs returned in API

### DIFF
--- a/auslib/admin/views/scheduled_changes.py
+++ b/auslib/admin/views/scheduled_changes.py
@@ -29,7 +29,7 @@ class ScheduledChangesView(AdminView):
         for row in rows:
             scheduled_change = {"signoffs": {}, "required_signoffs": {}}
             base_row = {}
-            pk = {}
+            base_pk = {}
 
             for k, v in row.iteritems():
                 if k == "data_version":
@@ -39,7 +39,7 @@ class ScheduledChangesView(AdminView):
                         k = k.replace("base_", "")
                         base_row[k] = v
                         if getattr(self.table, k).primary_key:
-                            pk[k] = v
+                            base_pk[k] = v
                     scheduled_change[k] = v
 
             for signoff in self.sc_table.signoffs.select({"sc_id": row["sc_id"]}):
@@ -51,7 +51,7 @@ class ScheduledChangesView(AdminView):
                 # We don't need to consider the existing version of a row for
                 # inserts, because it doesn't exist yet!
                 if row["change_type"] != "insert":
-                    affected_rows.append(self.table.select(where=pk)[0])
+                    affected_rows.append(self.table.select(where=base_pk)[0])
                 # We don't need to consider the future version of the row when
                 # looking for required signoffs, because it won't exist when
                 # enacted.

--- a/auslib/admin/views/scheduled_changes.py
+++ b/auslib/admin/views/scheduled_changes.py
@@ -56,7 +56,7 @@ class ScheduledChangesView(AdminView):
                 # looking for required signoffs, because it won't exist when
                 # enacted.
                 if row["change_type"] != "delete":
-                  affected_rows.append(base_row)
+                    affected_rows.append(base_row)
                 for rs in self.table.getPotentialRequiredSignoffs(affected_rows):
                     signoffs_required = max(scheduled_change["required_signoffs"].get(rs["role"], 0), rs["signoffs_required"])
                     scheduled_change["required_signoffs"][rs["role"]] = signoffs_required

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1462,7 +1462,7 @@ class Rules(AUSTable):
     def getPotentialRequiredSignoffs(self, affected_rows, transaction=None):
         potential_required_signoffs = []
         # The new row may change the product or channel, so we must look for
-        # Signoff for both.
+        # Signoffs for both.
         for row in affected_rows:
             if not row:
                 continue

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -58,11 +58,11 @@ class ViewTest(unittest.TestCase):
         dbo.productRequiredSignoffs.t.insert().execute(product="fake", channel="a", role="releng", signoffs_required=1, data_version=1)
         dbo.productRequiredSignoffs.t.insert().execute(product="fake", channel="e", role="releng", signoffs_required=1, data_version=1)
         dbo.productRequiredSignoffs.t.insert().execute(product="fake", channel="j", role="releng", signoffs_required=1, data_version=1)
-        dbo.productRequiredSignoffs.t.insert().execute(product="fake", channel="k", role="releng", signoffs_required=1, data_version=2)
-        dbo.productRequiredSignoffs.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=10, product="fake", channel="k", role="releng")
-        dbo.productRequiredSignoffs.history.t.insert().execute(change_id=2, changed_by="bill", timestamp=11, product="fake", channel="k", role="releng",
+        dbo.productRequiredSignoffs.t.insert().execute(product="fake", channel="k", role="relman", signoffs_required=1, data_version=2)
+        dbo.productRequiredSignoffs.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=10, product="fake", channel="k", role="relman")
+        dbo.productRequiredSignoffs.history.t.insert().execute(change_id=2, changed_by="bill", timestamp=11, product="fake", channel="k", role="relman",
                                                                signoffs_required=2, data_version=1)
-        dbo.productRequiredSignoffs.history.t.insert().execute(change_id=3, changed_by="bill", timestamp=25, product="fake", channel="k", role="releng",
+        dbo.productRequiredSignoffs.history.t.insert().execute(change_id=3, changed_by="bill", timestamp=25, product="fake", channel="k", role="relman",
                                                                signoffs_required=1, data_version=2)
         dbo.permissionsRequiredSignoffs.t.insert().execute(product="fake", role="releng", signoffs_required=1, data_version=1)
         dbo.permissionsRequiredSignoffs.t.insert().execute(product="bar", role="releng", signoffs_required=1, data_version=1)
@@ -122,6 +122,7 @@ class ViewTest(unittest.TestCase):
             rule_id=5, priority=80, buildTarget='d', version='3.3', backgroundRate=0, mapping='c', update_type='minor',
             product="a", channel="a", data_version=1
         )
+        dbo.rules.t.insert().execute(rule_id=6, product='fake', priority=40, backgroundRate=50, mapping='a', update_type='minor', channel="e", data_version=1)
         self.client = app.test_client()
 
     def tearDown(self):

--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -336,6 +336,10 @@ class TestPermissionsScheduledChanges(ViewTest):
         )
         dbo.permissions.scheduled_changes.signoffs.t.insert().execute(sc_id=4, username="bill", role="releng")
         dbo.permissions.scheduled_changes.signoffs.t.insert().execute(sc_id=4, username="mary", role="relman")
+        # TODO: need tests that verify the new required signoffs code in scheduled_changes.py
+        # probably one that schedules a delete that requires signoff
+        # and one that schedules an insert that requires signoff
+        # and one that schedules an update where the current version requires signoff, but future version won't
 
     def testGetScheduledChanges(self):
         ret = self._get("/scheduled_changes/permissions")

--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -336,15 +336,41 @@ class TestPermissionsScheduledChanges(ViewTest):
         )
         dbo.permissions.scheduled_changes.signoffs.t.insert().execute(sc_id=4, username="bill", role="releng")
         dbo.permissions.scheduled_changes.signoffs.t.insert().execute(sc_id=4, username="mary", role="relman")
-        # TODO: need tests that verify the new required signoffs code in scheduled_changes.py
-        # probably one that schedules a delete that requires signoff
-        # and one that schedules an insert that requires signoff
-        # and one that schedules an update where the current version requires signoff, but future version won't
+
+        dbo.permissions.scheduled_changes.t.insert().execute(
+            sc_id=5, scheduled_by="bill", change_type="insert", data_version=1, base_permission="rule", base_username="joe",
+            base_options={"products": ["fake"]},
+        )
+        dbo.permissions.scheduled_changes.history.t.insert().execute(change_id=10, changed_by="bill", timestamp=204, sc_id=5)
+        dbo.permissions.scheduled_changes.history.t.insert().execute(
+            change_id=11, changed_by="bill", timestamp=205, sc_id=5, scheduled_by="bill", change_type="insert", data_version=1,
+            base_permission="rule", base_username="joe", base_options={"products": ["fake"]},
+        )
+        dbo.permissions.scheduled_changes.conditions.t.insert().execute(sc_id=5, when=98000000, data_version=1)
+        dbo.permissions.scheduled_changes.conditions.history.t.insert().execute(change_id=10, changed_by="bill", timestamp=204, sc_id=5)
+        dbo.permissions.scheduled_changes.conditions.history.t.insert().execute(
+            change_id=11, changed_by="bill", timestamp=205, sc_id=5, when=98000000, data_version=1
+        )
+
+        dbo.permissions.scheduled_changes.t.insert().execute(
+            sc_id=6, scheduled_by="bill", change_type="update", data_version=1, base_permission="release", base_username="bob",
+            base_options={"products": ["a", "b"]}, base_data_version=1
+        )
+        dbo.permissions.scheduled_changes.history.t.insert().execute(change_id=12, changed_by="bill", timestamp=404, sc_id=6)
+        dbo.permissions.scheduled_changes.history.t.insert().execute(
+            change_id=13, changed_by="bill", timestamp=405, sc_id=6, scheduled_by="bill", change_type="update", data_version=1,
+            base_permission="release", base_username="bob", base_options={"products": ["a", "b"]}, base_data_version=1
+        )
+        dbo.permissions.scheduled_changes.conditions.t.insert().execute(sc_id=6, when=38000000, data_version=1)
+        dbo.permissions.scheduled_changes.conditions.history.t.insert().execute(change_id=12, changed_by="bill", timestamp=404, sc_id=6)
+        dbo.permissions.scheduled_changes.conditions.history.t.insert().execute(
+            change_id=13, changed_by="bill", timestamp=405, sc_id=6, when=38000000, data_version=1
+        )
 
     def testGetScheduledChanges(self):
         ret = self._get("/scheduled_changes/permissions")
         expected = {
-            "count": 3,
+            "count": 5,
             "scheduled_changes": [
                 {
                     "sc_id": 1, "when": 10000000, "scheduled_by": "bill", "change_type": "insert", "complete": False, "sc_data_version": 1,
@@ -361,6 +387,16 @@ class TestPermissionsScheduledChanges(ViewTest):
                     "permission": "scheduled_change", "username": "mary", "options": None, "data_version": 1,
                     "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1, "relman": 1},
                 },
+                {
+                    "sc_id": 5, "when": 98000000, "scheduled_by": "bill", "change_type": "insert", "complete": False, "sc_data_version": 1,
+                    "permission": "rule", "username": "joe", "options": {"products": ["fake"]}, "data_version": None,
+                    "signoffs": {}, "required_signoffs": {"releng": 1},
+                },
+                {
+                    "sc_id": 6, "when": 38000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
+                    "permission": "release", "username": "bob", "options": {"products": ["a", "b"]}, "data_version": 1,
+                    "signoffs": {}, "required_signoffs": {"releng": 1},
+                },
             ],
         }
         self.assertEquals(json.loads(ret.data), expected)
@@ -368,7 +404,7 @@ class TestPermissionsScheduledChanges(ViewTest):
     def testGetScheduledChangesWithCompleted(self):
         ret = self._get("/scheduled_changes/permissions", qs={"all": 1})
         expected = {
-            "count": 4,
+            "count": 6,
             "scheduled_changes": [
                 {
                     "sc_id": 1, "when": 10000000, "scheduled_by": "bill", "change_type": "insert", "complete": False, "sc_data_version": 1,
@@ -390,6 +426,16 @@ class TestPermissionsScheduledChanges(ViewTest):
                     "permission": "scheduled_change", "username": "mary", "options": None, "data_version": 1,
                     "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1, "relman": 1},
                 },
+                {
+                    "sc_id": 5, "when": 98000000, "scheduled_by": "bill", "change_type": "insert", "complete": False, "sc_data_version": 1,
+                    "permission": "rule", "username": "joe", "options": {"products": ["fake"]}, "data_version": None,
+                    "signoffs": {}, "required_signoffs": {"releng": 1},
+                },
+                {
+                    "sc_id": 6, "when": 38000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
+                    "permission": "release", "username": "bob", "options": {"products": ["a", "b"]}, "data_version": 1,
+                    "signoffs": {}, "required_signoffs": {"releng": 1},
+                },
             ],
         }
         self.assertEquals(json.loads(ret.data), expected)
@@ -401,18 +447,18 @@ class TestPermissionsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/permissions", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 5})
-        r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 5).execute().fetchall()
+        self.assertEquals(json.loads(ret.data), {"sc_id": 7})
+        r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 7).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
-            "sc_id": 5, "scheduled_by": "bill", "change_type": "update", "complete": False, "data_version": 1,
+            "sc_id": 7, "scheduled_by": "bill", "change_type": "update", "complete": False, "data_version": 1,
             "base_permission": "rule", "base_username": "bob", "base_options": None, "base_data_version": 1,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.permissions.scheduled_changes.conditions.t.select().where(dbo.permissions.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.permissions.scheduled_changes.conditions.t.select().where(dbo.permissions.scheduled_changes.conditions.sc_id == 7).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 5, "data_version": 1, "when": 400000000}
+        cond_expected = {"sc_id": 7, "data_version": 1, "when": 400000000}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
@@ -422,18 +468,18 @@ class TestPermissionsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/permissions", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 5})
-        r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 5).execute().fetchall()
+        self.assertEquals(json.loads(ret.data), {"sc_id": 7})
+        r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 7).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
-            "sc_id": 5, "scheduled_by": "bill", "change_type": "insert", "complete": False, "data_version": 1,
+            "sc_id": 7, "scheduled_by": "bill", "change_type": "insert", "complete": False, "data_version": 1,
             "base_permission": "release", "base_username": "jill", "base_options": {"products": ["a"]}, "base_data_version": None,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.permissions.scheduled_changes.conditions.t.select().where(dbo.permissions.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.permissions.scheduled_changes.conditions.t.select().where(dbo.permissions.scheduled_changes.conditions.sc_id == 7).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 5, "data_version": 1, "when": 400000000}
+        cond_expected = {"sc_id": 7, "data_version": 1, "when": 400000000}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
@@ -443,18 +489,18 @@ class TestPermissionsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/permissions", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 5})
-        r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 5).execute().fetchall()
+        self.assertEquals(json.loads(ret.data), {"sc_id": 7})
+        r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 7).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
-            "sc_id": 5, "scheduled_by": "bill", "change_type": "delete", "complete": False, "data_version": 1,
+            "sc_id": 7, "scheduled_by": "bill", "change_type": "delete", "complete": False, "data_version": 1,
             "base_permission": "build", "base_username": "ashanti", "base_options": None, "base_data_version": 1,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.permissions.scheduled_changes.conditions.t.select().where(dbo.permissions.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.permissions.scheduled_changes.conditions.t.select().where(dbo.permissions.scheduled_changes.conditions.sc_id == 7).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 5, "data_version": 1, "when": 400000000}
+        cond_expected = {"sc_id": 7, "data_version": 1, "when": 400000000}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
@@ -663,36 +709,36 @@ class TestPermissionsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/permissions", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 5})
-        r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 5).execute().fetchall()
+        self.assertEquals(json.loads(ret.data), {"sc_id": 7})
+        r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 7).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
-            "sc_id": 5, "scheduled_by": "bill", "change_type": "insert", "complete": False, "data_version": 1,
+            "sc_id": 7, "scheduled_by": "bill", "change_type": "insert", "complete": False, "data_version": 1,
             "base_permission": "admin", "base_username": "jill", "base_options": None, "base_data_version": None,
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.permissions.scheduled_changes.conditions.t.select().where(dbo.permissions.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.permissions.scheduled_changes.conditions.t.select().where(dbo.permissions.scheduled_changes.conditions.sc_id == 7).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 5, "data_version": 1, "when": 400000000}
+        cond_expected = {"sc_id": 7, "data_version": 1, "when": 400000000}
         self.assertEquals(dict(cond[0]), cond_expected)
 
         # Signoffs, which require signoff from role in permissionsRequiredSignoffs
         # regardless of product (because a full fledged admin can mange all products).
-        ret = self._post("/scheduled_changes/permissions/5/signoffs", data=dict(role="relman"), username="bob")
+        ret = self._post("/scheduled_changes/permissions/7/signoffs", data=dict(role="relman"), username="bob")
         self.assertEquals(ret.status_code, 200, ret.data)
-        ret = self._post("/scheduled_changes/permissions/5/signoffs", data=dict(role="releng"), username="bill")
+        ret = self._post("/scheduled_changes/permissions/7/signoffs", data=dict(role="releng"), username="bill")
         self.assertEquals(ret.status_code, 200, ret.data)
 
         # Enacting!
-        ret = self._post("/scheduled_changes/permissions/5/enact")
+        ret = self._post("/scheduled_changes/permissions/7/enact")
         self.assertEquals(ret.status_code, 200, ret.data)
 
-        r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 5).execute().fetchall()
+        r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 7).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
-            "sc_id": 5, "complete": True, "data_version": 2, "scheduled_by": "bill", "change_type": "insert", "base_permission": "admin",
+            "sc_id": 7, "complete": True, "data_version": 2, "scheduled_by": "bill", "change_type": "insert", "base_permission": "admin",
             "base_username": "jill", "base_options": None, "base_data_version": None,
         }
         self.assertEquals(db_data, expected)

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -993,7 +993,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertEquals(ret_data, json.loads("""
 {
     "releases": [
-        {"data_version": 1, "name": "a", "product": "a", "read_only": false, "rule_ids": [3, 4]},
+        {"data_version": 1, "name": "a", "product": "a", "read_only": false, "rule_ids": [3, 4, 6]},
         {"data_version": 1, "name": "ab", "product": "a", "read_only": false, "rule_ids": []}
     ]
 }
@@ -1103,6 +1103,10 @@ class TestReleasesScheduledChanges(ViewTest):
         )
         dbo.releases.scheduled_changes.signoffs.t.insert().execute(sc_id=4, username="bill", role="releng")
         dbo.releases.scheduled_changes.signoffs.t.insert().execute(sc_id=4, username="ben", role="releng")
+        # TODO: need tests that verify the new required signoffs code in scheduled_changes.py
+        # probably one that schedules a delete that requires signoff
+        # and one that schedules an insert that requires signoff
+        # and one that schedules an update where the current version requires signoff, but future version won't
 
     def testGetScheduledChanges(self):
         ret = self._get("/scheduled_changes/releases")
@@ -1665,7 +1669,7 @@ class TestRuleIdsReturned(ViewTest):
 
     def testWhitelistIncluded(self):
         rel_name = 'ab'
-        rule_id = 6
+        rule_id = 7
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)
@@ -1684,7 +1688,7 @@ class TestRuleIdsReturned(ViewTest):
 
     def testMappingIncluded(self):
         rel_name = 'ab'
-        rule_id = 6
+        rule_id = 7
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1103,10 +1103,6 @@ class TestReleasesScheduledChanges(ViewTest):
         )
         dbo.releases.scheduled_changes.signoffs.t.insert().execute(sc_id=4, username="bill", role="releng")
         dbo.releases.scheduled_changes.signoffs.t.insert().execute(sc_id=4, username="ben", role="releng")
-        # TODO: need tests that verify the new required signoffs code in scheduled_changes.py
-        # probably one that schedules a delete that requires signoff
-        # and one that schedules an insert that requires signoff
-        # and one that schedules an update where the current version requires signoff, but future version won't
 
     def testGetScheduledChanges(self):
         ret = self._get("/scheduled_changes/releases")

--- a/auslib/test/admin/views/test_required_signoffs.py
+++ b/auslib/test/admin/views/test_required_signoffs.py
@@ -15,7 +15,7 @@ class TestProductRequiredSignoffs(ViewTest):
             {"product": "fake", "channel": "a", "role": "releng", "signoffs_required": 1, "data_version": 1},
             {"product": "fake", "channel": "e", "role": "releng", "signoffs_required": 1, "data_version": 1},
             {"product": "fake", "channel": "j", "role": "releng", "signoffs_required": 1, "data_version": 1},
-            {"product": "fake", "channel": "k", "role": "releng", "signoffs_required": 1, "data_version": 2},
+            {"product": "fake", "channel": "k", "role": "relman", "signoffs_required": 1, "data_version": 2},
         ]
         self.assertEquals(got["required_signoffs"], expected)
 
@@ -59,7 +59,7 @@ class TestProductRequiredSignoffsHistoryView(ViewTest):
     maxDiff = 1000
 
     def testGetRevisions(self):
-        ret = self._get("/required_signoffs/product/revisions", qs={"product": "fake", "channel": "k", "role": "releng"})
+        ret = self._get("/required_signoffs/product/revisions", qs={"product": "fake", "channel": "k", "role": "relman"})
         self.assertStatusCode(ret, 200)
 
         got = json.loads(ret.data)
@@ -70,7 +70,7 @@ class TestProductRequiredSignoffsHistoryView(ViewTest):
                 "timestamp": 25,
                 "product": "fake",
                 "channel": "k",
-                "role": "releng",
+                "role": "relman",
                 "signoffs_required": 1,
                 "data_version": 2,
             },
@@ -80,7 +80,7 @@ class TestProductRequiredSignoffsHistoryView(ViewTest):
                 "timestamp": 11,
                 "product": "fake",
                 "channel": "k",
-                "role": "releng",
+                "role": "relman",
                 "signoffs_required": 2,
                 "data_version": 1,
             },
@@ -232,7 +232,7 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
     @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testAddScheduledChangeExistingRequiredSignoff(self):
         data = {
-            "when": 400000000, "product": "fake", "channel": "k", "role": "releng", "signoffs_required": 2, "data_version": 2, "change_type": "update",
+            "when": 400000000, "product": "fake", "channel": "k", "role": "relman", "signoffs_required": 2, "data_version": 2, "change_type": "update",
         }
         ret = self._post("/scheduled_changes/required_signoffs/product", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
@@ -242,7 +242,7 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
         db_data = dict(r[0])
         expected = {
             "sc_id": 5, "scheduled_by": "bill", "change_type": "update", "complete": False, "data_version": 1,
-            "base_product": "fake", "base_channel": "k", "base_role": "releng", "base_signoffs_required": 2, "base_data_version": 2,
+            "base_product": "fake", "base_channel": "k", "base_role": "relman", "base_signoffs_required": 2, "base_data_version": 2,
         }
         self.assertEquals(db_data, expected)
         cond = dbo.productRequiredSignoffs.scheduled_changes.conditions.t.select()\
@@ -254,7 +254,7 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
     @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testAddScheduledChangeNewRequiredSignoff(self):
         data = {
-            "when": 400000000, "product": "fake", "channel": "k", "role": "relman", "signoffs_required": 1, "change_type": "insert",
+            "when": 400000000, "product": "fake", "channel": "k", "role": "releng", "signoffs_required": 1, "change_type": "insert",
         }
         ret = self._post("/scheduled_changes/required_signoffs/product", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
@@ -264,7 +264,7 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
         db_data = dict(r[0])
         expected = {
             "sc_id": 5, "scheduled_by": "bill", "change_type": "insert", "complete": False, "data_version": 1,
-            "base_product": "fake", "base_channel": "k", "base_role": "relman", "base_signoffs_required": 1, "base_data_version": None,
+            "base_product": "fake", "base_channel": "k", "base_role": "releng", "base_signoffs_required": 1, "base_data_version": None,
         }
         self.assertEquals(db_data, expected)
         cond = dbo.productRequiredSignoffs.scheduled_changes.conditions.t.select()\
@@ -276,7 +276,7 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
     @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testAddScheduledChangeDeleteRequiredSignoff(self):
         data = {
-            "when": 400000000, "product": "fake", "channel": "k", "role": "releng", "change_type": "delete", "data_version": 2,
+            "when": 400000000, "product": "fake", "channel": "k", "role": "relman", "change_type": "delete", "data_version": 2,
         }
         ret = self._post("/scheduled_changes/required_signoffs/product", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
@@ -286,7 +286,7 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
         db_data = dict(r[0])
         expected = {
             "sc_id": 5, "scheduled_by": "bill", "change_type": "delete", "complete": False, "data_version": 1,
-            "base_product": "fake", "base_channel": "k", "base_role": "releng", "base_signoffs_required": None, "base_data_version": 2,
+            "base_product": "fake", "base_channel": "k", "base_role": "relman", "base_signoffs_required": None, "base_data_version": 2,
         }
         self.assertEquals(db_data, expected)
         cond = dbo.productRequiredSignoffs.scheduled_changes.conditions.t.select()\

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -871,12 +871,12 @@ class TestRuleScheduledChanges(ViewTest):
 
         dbo.rules.scheduled_changes.t.insert().execute(
             sc_id=7, scheduled_by="bill", data_version=1, base_priority=40, base_backgroundRate=50, base_mapping="a", base_update_type="minor",
-            base_channel="g", base_product="fake", base_rule_id=6, change_type="update",
+            base_channel="k", base_product="fake", base_rule_id=6, change_type="update",
         )
         dbo.rules.scheduled_changes.history.t.insert().execute(change_id=14, changed_by="bill", timestamp=123, sc_id=7)
         dbo.rules.scheduled_changes.history.t.insert().execute(
             change_id=15, changed_by="bill", timestamp=124, sc_id=7, scheduled_by="bill", data_version=1, base_priority=40,
-            base_backgroundRate=50, base_mapping="a", base_update_type="minor", base_channel="g", base_product="fake", base_rule_id=6,
+            base_backgroundRate=50, base_mapping="a", base_update_type="minor", base_channel="k", base_product="fake", base_rule_id=6,
             change_type="update",
         )
         dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=7, when=7500000, data_version=1)
@@ -931,10 +931,10 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
                     "backgroundRate": 50, "product": "fake", "mapping": "a", "update_type": "minor", "version": None,
-                    "buildTarget": None, "alias": None, "channel": "g", "buildID": None, "locale": None, "osVersion": None,
+                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
                     "data_version": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1},
+                    "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1},
                 },
             ],
         }
@@ -996,10 +996,10 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
                     "backgroundRate": 50, "product": "fake", "mapping": "a", "update_type": "minor", "version": None,
-                    "buildTarget": None, "alias": None, "channel": "g", "buildID": None, "locale": None, "osVersion": None,
+                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
                     "data_version": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1},
+                    "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1},
                 },
             ],
         }

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -835,6 +835,10 @@ class TestRuleScheduledChanges(ViewTest):
             change_type="update")
         dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=8, changed_by="bill", timestamp=7, sc_id=4, when=500000, data_version=2)
 
+    # TODO: need tests that verify the new required signoffs code in scheduled_changes.py
+    # probably one that schedules a delete that requires signoff
+    # and one that schedules an insert that requires signoff
+    # and one that schedules an update where the current version requires signoff, but future version won't
     def testGetScheduledChanges(self):
         ret = self._get("/scheduled_changes/rules")
         expected = {

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -778,62 +778,59 @@ class TestRuleScheduledChanges(ViewTest):
             base_product="a", base_channel="a",
         )
         dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=1, when=1000000, data_version=1)
+
         dbo.rules.scheduled_changes.t.insert().execute(
             sc_id=2, scheduled_by="bill", data_version=1, base_priority=50, base_backgroundRate=100, base_product="baz",
             base_mapping="ab", base_update_type="minor", change_type="insert",
         )
-        dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=2, when=1500000, data_version=1)
-        dbo.rules.scheduled_changes.t.insert().execute(
-            sc_id=3, scheduled_by="bill", data_version=2, base_priority=150, base_backgroundRate=100, base_channel="a",
-            base_mapping="ghi", base_update_type="minor", change_type="insert",
-        )
-        dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=3, when=2900000, data_version=2)
-        dbo.rules.scheduled_changes.signoffs.t.insert().execute(sc_id=3, username="bill", role="releng")
-        dbo.rules.scheduled_changes.t.insert().execute(
-            sc_id=4, scheduled_by="bill", data_version=2, complete=True, base_rule_id=5, base_priority=80, base_version="3.3",
-            base_buildTarget="d", base_backgroundRate=0, base_mapping="c", base_update_type="minor", base_data_version=1, change_type="update",
-        )
-
-        dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=4, when=500000, data_version=2)
-
-        dbo.rules.scheduled_changes.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=5, sc_id=3)
-        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=5, sc_id=3)
-
-        dbo.rules.scheduled_changes.history.t.insert().execute(
-            change_id=2, changed_by="bill", timestamp=6, sc_id=3, scheduled_by="bill", data_version=1, base_priority=150,
-            base_backgroundRate=100, base_channel="a", base_mapping="def", base_update_type="minor", change_type="insert"
-        )
-        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=2, changed_by="bill", timestamp=6, sc_id=3, when=2000000, data_version=1)
-
-        dbo.rules.scheduled_changes.history.t.insert().execute(
-            change_id=3, changed_by="bill", timestamp=10, sc_id=3, scheduled_by="bill", data_version=2, base_priority=150,
-            base_backgroundRate=100, base_channel="a", base_mapping="ghi", base_update_type="minor", change_type="insert"
-        )
-        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=3, changed_by="bill", timestamp=10, sc_id=3, when=2900000, data_version=2)
-
         dbo.rules.scheduled_changes.history.t.insert().execute(change_id=4, changed_by="bill", timestamp=15, sc_id=2)
-        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=4, changed_by="bill", timestamp=15, sc_id=2)
-
         dbo.rules.scheduled_changes.history.t.insert().execute(
             change_id=5, changed_by="bill", timestamp=16, sc_id=2, scheduled_by="bill", data_version=1, base_priority=50,
             base_backgroundRate=100, base_product="baz", base_mapping="ab", base_update_type="minor", change_type="insert"
         )
-        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=5, changed_by="bill", timestamp=16, sc_id=2, when=1500000, data_version=1)
-
         dbo.rules.scheduled_changes.history.t.insert().execute(change_id=6, changed_by="bill", timestamp=5, sc_id=4)
+
+        dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=2, when=1500000, data_version=1)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=4, changed_by="bill", timestamp=15, sc_id=2)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=5, changed_by="bill", timestamp=16, sc_id=2, when=1500000, data_version=1)
         dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=6, changed_by="bill", timestamp=5, sc_id=4)
 
+        dbo.rules.scheduled_changes.t.insert().execute(
+            sc_id=3, scheduled_by="bill", data_version=2, base_priority=150, base_backgroundRate=100, base_channel="a",
+            base_mapping="ghi", base_update_type="minor", change_type="insert",
+        )
+        dbo.rules.scheduled_changes.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=5, sc_id=3)
         dbo.rules.scheduled_changes.history.t.insert().execute(
-            change_id=7, changed_by="bill", timestamp=6, sc_id=4, scheduled_by="bill", data_version=1, base_priority=80,
+            change_id=2, changed_by="bill", timestamp=6, sc_id=3, scheduled_by="bill", data_version=1, base_priority=150,
+            base_backgroundRate=100, base_channel="a", base_mapping="def", base_update_type="minor", change_type="insert"
+        )
+        dbo.rules.scheduled_changes.history.t.insert().execute(
+            change_id=3, changed_by="bill", timestamp=10, sc_id=3, scheduled_by="bill", data_version=2, base_priority=150,
+            base_backgroundRate=100, base_channel="a", base_mapping="ghi", base_update_type="minor", change_type="insert"
+        )
+        dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=3, when=2900000, data_version=2)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=1, changed_by="bill", timestamp=5, sc_id=3)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=2, changed_by="bill", timestamp=6, sc_id=3, when=2000000, data_version=1)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=3, changed_by="bill", timestamp=10, sc_id=3, when=2900000, data_version=2)
+        dbo.rules.scheduled_changes.signoffs.t.insert().execute(sc_id=3, username="bill", role="releng")
+
+        dbo.rules.scheduled_changes.t.insert().execute(
+            sc_id=4, scheduled_by="bill", data_version=2, complete=True, base_rule_id=5, base_priority=80, base_version="3.3",
+            base_buildTarget="d", base_backgroundRate=0, base_mapping="c", base_update_type="minor", base_data_version=1, change_type="update",
+        )
+        dbo.rules.scheduled_changes.history.t.insert().execute(change_id=7, changed_by="bill", timestamp=5, sc_id=4)
+        dbo.rules.scheduled_changes.history.t.insert().execute(
+            change_id=8, changed_by="bill", timestamp=6, sc_id=4, scheduled_by="bill", data_version=1, base_priority=80,
             base_version="3.3", base_buildTarget="d", base_backgroundRate=0, base_mapping="c", base_update_type="minor", base_data_version=1,
             change_type="update")
-        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=7, changed_by="bill", timestamp=6, sc_id=4, when=500000, data_version=1)
-
         dbo.rules.scheduled_changes.history.t.insert().execute(
-            change_id=8, changed_by="bill", timestamp=7, sc_id=4, scheduled_by="bill", data_version=2, complete=True, base_rule_id=5,
+            change_id=9, changed_by="bill", timestamp=7, sc_id=4, scheduled_by="bill", data_version=2, complete=True, base_rule_id=5,
             base_priority=80, base_version="3.3", base_buildTarget="d", base_backgroundRate=0, base_mapping="c", base_update_type="minor", base_data_version=1,
             change_type="update")
-        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=8, changed_by="bill", timestamp=7, sc_id=4, when=500000, data_version=2)
+        dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=4, when=500000, data_version=2)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=7, changed_by="bill", timestamp=5, sc_id=4)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=8, changed_by="bill", timestamp=6, sc_id=4, when=500000, data_version=1)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=9, changed_by="bill", timestamp=7, sc_id=4, when=500000, data_version=2)
 
     # TODO: need tests that verify the new required signoffs code in scheduled_changes.py
     # probably one that schedules a delete that requires signoff
@@ -1270,7 +1267,7 @@ class TestRuleScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/rules/3/revisions", data={"change_id": 2})
         self.assertEquals(ret.status_code, 200, ret.data)
 
-        self.assertEquals(dbo.rules.scheduled_changes.history.t.count().execute().first()[0], 9)
+        self.assertEquals(dbo.rules.scheduled_changes.history.t.count().execute().first()[0], 10)
         r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 3).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
@@ -1282,7 +1279,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_whitelist": None, "base_data_version": None, "base_systemCapabilities": None, "change_type": "insert",
         }
         self.assertEquals(db_data, expected)
-        self.assertEquals(dbo.rules.scheduled_changes.conditions.history.t.count().execute().first()[0], 9)
+        self.assertEquals(dbo.rules.scheduled_changes.conditions.history.t.count().execute().first()[0], 10)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 3).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 3, "data_version": 3, "when": 2000000, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None}

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -12,18 +12,29 @@ class TestRulesAPI_JSON(ViewTest):
     def testGetRules(self):
         ret = self._get("/rules")
         got = json.loads(ret.data)
-        self.assertEquals(got["count"], 5)
+        self.assertEquals(got["count"], 6)
 
     def testGetRulesWithProductFilter(self):
         ret = self._get("/rules", qs={"product": "fake"})
         got = json.loads(ret.data)
-        expected = {
-            "rule_id": 4, "product": "fake", "priority": 80, "buildTarget": "d", "backgroundRate": 100, "mapping": "a",
-            "update_type": "minor", "channel": "a", "data_version": 1
-        }
-        self.assertEquals(got["count"], 1)
-        for k, v in expected.iteritems():
-            self.assertEquals(got["rules"][0][k], v)
+        expected = [
+            {
+                "rule_id": 4, "product": "fake", "priority": 80, "buildTarget": "d", "backgroundRate": 100, "mapping": "a",
+                "update_type": "minor", "channel": "a", "data_version": 1, "comment": None, "fallbackMapping": None,
+                "version": None, "buildID": None, "locale": None, "distribution": None, "osVersion": None,
+                "systemCapabilities": None, "distVersion": None, "headerArchitecture": None, "alias": None, "whitelist": None,
+            },
+            {
+                "rule_id": 6, "product": "fake", "priority": 40, "backgroundRate": 50, "mapping": "a", "update_type": "minor",
+                "channel": "e", "data_version": 1, "buildTarget": None, "comment": None, "fallbackMapping": None,
+                "version": None, "buildID": None, "locale": None, "distribution": None, "osVersion": None,
+                "systemCapabilities": None, "distVersion": None, "headerArchitecture": None, "alias": None, "whitelist": None,
+
+            }
+        ]
+        self.assertEquals(got["count"], 2)
+        rules = sorted(got["rules"], key=lambda r: r["rule_id"])
+        self.assertEquals(rules, expected)
 
     def testNewRulePost(self):
         ret = self._post('/rules', data=dict(backgroundRate=31, mapping='c', priority=33,
@@ -768,7 +779,7 @@ class TestSingleColumn_JSON(ViewTest):
 
 
 class TestRuleScheduledChanges(ViewTest):
-    maxDiff = 15000
+    maxDiff = 50000
 
     def setUp(self):
         super(TestRuleScheduledChanges, self).setUp()
@@ -788,12 +799,9 @@ class TestRuleScheduledChanges(ViewTest):
             change_id=5, changed_by="bill", timestamp=16, sc_id=2, scheduled_by="bill", data_version=1, base_priority=50,
             base_backgroundRate=100, base_product="baz", base_mapping="ab", base_update_type="minor", change_type="insert"
         )
-        dbo.rules.scheduled_changes.history.t.insert().execute(change_id=6, changed_by="bill", timestamp=5, sc_id=4)
-
         dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=2, when=1500000, data_version=1)
         dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=4, changed_by="bill", timestamp=15, sc_id=2)
         dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=5, changed_by="bill", timestamp=16, sc_id=2, when=1500000, data_version=1)
-        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=6, changed_by="bill", timestamp=5, sc_id=4)
 
         dbo.rules.scheduled_changes.t.insert().execute(
             sc_id=3, scheduled_by="bill", data_version=2, base_priority=150, base_backgroundRate=100, base_channel="a",
@@ -818,6 +826,7 @@ class TestRuleScheduledChanges(ViewTest):
             sc_id=4, scheduled_by="bill", data_version=2, complete=True, base_rule_id=5, base_priority=80, base_version="3.3",
             base_buildTarget="d", base_backgroundRate=0, base_mapping="c", base_update_type="minor", base_data_version=1, change_type="update",
         )
+        dbo.rules.scheduled_changes.history.t.insert().execute(change_id=6, changed_by="bill", timestamp=5, sc_id=4)
         dbo.rules.scheduled_changes.history.t.insert().execute(change_id=7, changed_by="bill", timestamp=5, sc_id=4)
         dbo.rules.scheduled_changes.history.t.insert().execute(
             change_id=8, changed_by="bill", timestamp=6, sc_id=4, scheduled_by="bill", data_version=1, base_priority=80,
@@ -828,18 +837,56 @@ class TestRuleScheduledChanges(ViewTest):
             base_priority=80, base_version="3.3", base_buildTarget="d", base_backgroundRate=0, base_mapping="c", base_update_type="minor", base_data_version=1,
             change_type="update")
         dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=4, when=500000, data_version=2)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=6, changed_by="bill", timestamp=5, sc_id=4)
         dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=7, changed_by="bill", timestamp=5, sc_id=4)
         dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=8, changed_by="bill", timestamp=6, sc_id=4, when=500000, data_version=1)
         dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=9, changed_by="bill", timestamp=7, sc_id=4, when=500000, data_version=2)
 
-    # TODO: need tests that verify the new required signoffs code in scheduled_changes.py
-    # probably one that schedules a delete that requires signoff
-    # and one that schedules an insert that requires signoff
-    # and one that schedules an update where the current version requires signoff, but future version won't
+        dbo.rules.scheduled_changes.t.insert().execute(
+            sc_id=5, scheduled_by="bill", data_version=1, complete=False, change_type="delete", base_rule_id=4, base_data_version=1
+        )
+        dbo.rules.scheduled_changes.history.t.insert().execute(change_id=10, changed_by="bill", timestamp=50, sc_id=5)
+        dbo.rules.scheduled_changes.history.t.insert().execute(
+            change_id=11, changed_by="bill", timestamp=51, sc_id=5, scheduled_by="bill", data_version=1, complete=False,
+            base_rule_id=4, base_data_version=1
+        )
+        dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=5, when=600000, data_version=1)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=10, changed_by="bill", timestamp=50, sc_id=5)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(
+            change_id=11, changed_by="bill", timestamp=50, sc_id=5, when=600000, data_version=1
+        )
+
+        dbo.rules.scheduled_changes.t.insert().execute(
+            sc_id=6, scheduled_by="bill", data_version=1, base_priority=100, base_backgroundRate=100, base_product="fake", base_channel="k",
+            base_mapping="ab", base_update_type="minor", change_type="insert",
+        )
+        dbo.rules.scheduled_changes.history.t.insert().execute(change_id=12, changed_by="bill", timestamp=75, sc_id=6)
+        dbo.rules.scheduled_changes.history.t.insert().execute(
+            change_id=13, changed_by="bill", timestamp=76, sc_id=6, scheduled_by="bill", data_version=1, base_priority=100,
+            base_backgroundRate=100, base_product="fake", base_channel="k", base_mapping="ab", base_update_type="minor", change_type="insert"
+        )
+        dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=6, when=5500000, data_version=1)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=12, changed_by="bill", timestamp=75, sc_id=6)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=13, changed_by="bill", timestamp=76, sc_id=6, when=5500000, data_version=1)
+
+        dbo.rules.scheduled_changes.t.insert().execute(
+            sc_id=7, scheduled_by="bill", data_version=1, base_priority=40, base_backgroundRate=50, base_mapping="a", base_update_type="minor",
+            base_channel="g", base_product="fake", base_rule_id=6, change_type="update",
+        )
+        dbo.rules.scheduled_changes.history.t.insert().execute(change_id=14, changed_by="bill", timestamp=123, sc_id=7)
+        dbo.rules.scheduled_changes.history.t.insert().execute(
+            change_id=15, changed_by="bill", timestamp=124, sc_id=7, scheduled_by="bill", data_version=1, base_priority=40,
+            base_backgroundRate=50, base_mapping="a", base_update_type="minor", base_channel="g", base_product="fake", base_rule_id=6,
+            change_type="update",
+        )
+        dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=7, when=7500000, data_version=1)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=14, changed_by="bill", timestamp=123, sc_id=7)
+        dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=15, changed_by="bill", timestamp=124, sc_id=7, when=7500000, data_version=1)
+
     def testGetScheduledChanges(self):
         ret = self._get("/scheduled_changes/rules")
         expected = {
-            "count": 3,
+            "count": 6,
             "scheduled_changes": [
                 {
                     "sc_id": 1, "when": 1000000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 1, "priority": 100,
@@ -865,6 +912,30 @@ class TestRuleScheduledChanges(ViewTest):
                     "data_version": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "insert", "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
                 },
+                {
+                    "sc_id": 5, "when": 600000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 4, "priority": None,
+                    "backgroundRate": None, "channel": None, "mapping": None, "update_type": None, "version": None,
+                    "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None,
+                    "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
+                    "data_version": 1, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
+                    "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1},
+                },
+                {
+                    "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
+                    "backgroundRate": 100, "product": "fake", "mapping": "ab", "update_type": "minor", "version": None,
+                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None,
+                    "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
+                    "data_version": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
+                    "change_type": "insert", "signoffs": {}, "required_signoffs": {"relman": 1},
+                },
+                {
+                    "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
+                    "backgroundRate": 50, "product": "fake", "mapping": "a", "update_type": "minor", "version": None,
+                    "buildTarget": None, "alias": None, "channel": "g", "buildID": None, "locale": None, "osVersion": None,
+                    "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
+                    "data_version": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
+                    "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1},
+                },
             ],
         }
         self.assertEquals(json.loads(ret.data), expected)
@@ -872,7 +943,7 @@ class TestRuleScheduledChanges(ViewTest):
     def testGetScheduledChangesWithCompleted(self):
         ret = self._get("/scheduled_changes/rules", qs={"all": 1})
         expected = {
-            "count": 4,
+            "count": 7,
             "scheduled_changes": [
                 {
                     "sc_id": 1, "when": 1000000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 1, "priority": 100,
@@ -906,6 +977,30 @@ class TestRuleScheduledChanges(ViewTest):
                     "whitelist": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
                 },
+                {
+                    "sc_id": 5, "when": 600000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 4, "priority": None,
+                    "backgroundRate": None, "channel": None, "mapping": None, "update_type": None, "version": None,
+                    "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None,
+                    "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
+                    "data_version": 1, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
+                    "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1},
+                },
+                {
+                    "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
+                    "backgroundRate": 100, "product": "fake", "mapping": "ab", "update_type": "minor", "version": None,
+                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None,
+                    "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
+                    "data_version": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
+                    "change_type": "insert", "signoffs": {}, "required_signoffs": {"relman": 1},
+                },
+                {
+                    "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
+                    "backgroundRate": 50, "product": "fake", "mapping": "a", "update_type": "minor", "version": None,
+                    "buildTarget": None, "alias": None, "channel": "g", "buildID": None, "locale": None, "osVersion": None,
+                    "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None, "whitelist": None,
+                    "data_version": None, "systemCapabilities": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
+                    "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1},
+                },
             ],
         }
         self.assertEquals(json.loads(ret.data), expected)
@@ -918,22 +1013,22 @@ class TestRuleScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 5})
+        self.assertEquals(json.loads(ret.data), {"sc_id": 8})
 
-        r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 5).execute().fetchall()
+        r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 8).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
             "scheduled_by": "bill", "base_rule_id": 5, "base_priority": 80, "base_buildTarget": "d", "base_version": "3.3", "base_backgroundRate": 100,
-            "base_mapping": "c", "base_update_type": "minor", "base_data_version": 1, "data_version": 1, "sc_id": 5, "complete": False, "base_alias": None,
+            "base_mapping": "c", "base_update_type": "minor", "base_data_version": 1, "data_version": 1, "sc_id": 8, "complete": False, "base_alias": None,
             "base_product": None, "base_channel": None, "base_buildID": None, "base_locale": None, "base_osVersion": None, "base_distribution": None,
             "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None, "base_whitelist": None,
             "base_systemCapabilities": None, "change_type": "update",
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 5, "data_version": 1, "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "when": None}
+        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "when": None}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     def testAddScheduledChangeExistingDeletingRule(self):
@@ -943,22 +1038,22 @@ class TestRuleScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 5})
+        self.assertEquals(json.loads(ret.data), {"sc_id": 8})
 
-        r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 5).execute().fetchall()
+        r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 8).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
             "scheduled_by": "bill", "base_rule_id": 5, "base_priority": None, "base_buildTarget": None, "base_version": None, "base_backgroundRate": None,
-            "base_mapping": None, "base_update_type": None, "base_data_version": 1, "data_version": 1, "sc_id": 5, "complete": False, "base_alias": None,
+            "base_mapping": None, "base_update_type": None, "base_data_version": 1, "data_version": 1, "sc_id": 8, "complete": False, "base_alias": None,
             "base_product": None, "base_channel": None, "base_buildID": None, "base_locale": None, "base_osVersion": None, "base_distribution": None,
             "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None, "base_whitelist": None,
             "base_systemCapabilities": None, "change_type": "delete",
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 5, "data_version": 1, "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "when": None}
+        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "when": None}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
@@ -969,22 +1064,22 @@ class TestRuleScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 5})
+        self.assertEquals(json.loads(ret.data), {"sc_id": 8})
 
-        r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 5).execute().fetchall()
+        r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 8).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
         expected = {
             "scheduled_by": "bill", "base_priority": 120, "base_backgroundRate": 100, "base_product": "blah", "base_channel": "blah",
-            "base_update_type": "minor", "base_mapping": "a", "sc_id": 5, "data_version": 1, "complete": False, "base_data_version": None,
+            "base_update_type": "minor", "base_mapping": "a", "sc_id": 8, "data_version": 1, "complete": False, "base_data_version": None,
             "base_rule_id": None, "base_buildTarget": None, "base_version": None, "base_alias": None, "base_buildID": None, "base_locale": None,
             "base_osVersion": None, "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None,
             "base_comment": None, "base_whitelist": None, "base_systemCapabilities": None, "change_type": "insert",
         }
         self.assertEquals(db_data, expected)
-        cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 5).execute().fetchall()
+        cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 5, "data_version": 1, "when": 1234567, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None}
+        cond_expected = {"sc_id": 8, "data_version": 1, "when": 1234567, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
@@ -1197,7 +1292,7 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(ret.status_code, 403, msg=ret.data)
 
     def testDeleteNonExistentScheduledChange(self):
-        ret = self._delete("/scheduled_changes/rules/5", qs=dict(data_version=1))
+        ret = self._delete("/scheduled_changes/rules/62", qs=dict(data_version=1))
         self.assertEquals(ret.status_code, 404, msg=ret.data)
 
     def testEnactScheduledChangeExistingRule(self):
@@ -1223,9 +1318,9 @@ class TestRuleScheduledChanges(ViewTest):
         sc_row = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 2).execute().fetchall()[0]
         self.assertEquals(sc_row["complete"], True)
 
-        row = dbo.rules.t.select().where(dbo.rules.rule_id == 6).execute().fetchall()[0]
+        row = dbo.rules.t.select().where(dbo.rules.rule_id == 7).execute().fetchall()[0]
         expected = {
-            "rule_id": 6, "priority": 50, "version": None, "buildTarget": None, "backgroundRate": 100, "mapping": "ab", "fallbackMapping": None,
+            "rule_id": 7, "priority": 50, "version": None, "buildTarget": None, "backgroundRate": 100, "mapping": "ab", "fallbackMapping": None,
             "update_type": "minor", "data_version": 1, "alias": None, "product": "baz", "channel": None, "buildID": None,
             "locale": None, "osVersion": None, "distribution": None, "distVersion": None, "headerArchitecture": None,
             "comment": None, "whitelist": None, "systemCapabilities": None,
@@ -1267,7 +1362,7 @@ class TestRuleScheduledChanges(ViewTest):
         ret = self._post("/scheduled_changes/rules/3/revisions", data={"change_id": 2})
         self.assertEquals(ret.status_code, 200, ret.data)
 
-        self.assertEquals(dbo.rules.scheduled_changes.history.t.count().execute().first()[0], 10)
+        self.assertEquals(dbo.rules.scheduled_changes.history.t.count().execute().first()[0], 16)
         r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 3).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
@@ -1279,7 +1374,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_whitelist": None, "base_data_version": None, "base_systemCapabilities": None, "change_type": "insert",
         }
         self.assertEquals(db_data, expected)
-        self.assertEquals(dbo.rules.scheduled_changes.conditions.history.t.count().execute().first()[0], 10)
+        self.assertEquals(dbo.rules.scheduled_changes.conditions.history.t.count().execute().first()[0], 16)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 3).execute().fetchall()
         self.assertEquals(len(cond), 1)
         cond_expected = {"sc_id": 3, "data_version": 3, "when": 2000000, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None}


### PR DESCRIPTION
While testing out https://bugzilla.mozilla.org/show_bug.cgi?id=1310227 I discovered that the Scheduled Changes API only looks at the scheduled changes table when looking for required signoffs. This means that for some updates (ones where the current version of the row requires signoff, but the scheduled version doesn't), and all deletes returned the wrong required_signoffs.

The database layer still enforces things correctly, but this caused problems for the UI. Eg: the Signoff button not showing up or showing up when not needed.

I added new tests where it made sense - both the update and delete case for Rules and Permissions. Releases are unaffected here, because changing a release doesn't impact the signoffs required (those are determined by looking at the rules table). Required Signoffs are also unaffected, because the things that influence the signoffs required are part of the key - so they're the same on the current and scheduled version of a Required Signoff.