### PR TITLE
Bug 1312499 - figure out how to match multiple substrings in one rule field

### DIFF
--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -2041,7 +2041,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
     def testGetRulesMatchingQueryOsVersionSubstring(self):
         rules = self.paths.getRulesMatchingQuery(
             dict(product="a", version='5.0', channel="a", buildTarget='d',
-                 buildID='', locale='', osVersion='foo 1', distribution='',
+                 buildID='', locale='', osVersion='foo 1.2.3', distribution='',
                  distVersion='', headerArchitecture='', force=False,
                  queryVersion=3,
                  ),
@@ -2059,7 +2059,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
     def testGetRulesMatchingQueryOsVersionSubstringNotAtStart(self):
         rules = self.paths.getRulesMatchingQuery(
             dict(product="a", version='5.0', channel="a", buildTarget='d',
-                 buildID='', locale='', osVersion='bbb,foo 1,ccc', distribution='',
+                 buildID='', locale='', osVersion='bbb,foo 1.2.3', distribution='',
                  distVersion='', headerArchitecture='', force=False,
                  queryVersion=3,
                  ),
@@ -2077,7 +2077,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
     def testGetRulesMatchingQueryOsVersionMultipleSubstring(self):
         rules = self.paths.getRulesMatchingQuery(
             dict(product="a", version='5.0', channel="a", buildTarget='d',
-                 buildID='', locale='', osVersion='blah 6', distribution='',
+                 buildID='', locale='', osVersion='blah 6.3.2', distribution='',
                  distVersion='', headerArchitecture='', force=False,
                  queryVersion=3,
                  ),

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1892,6 +1892,16 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
                                       product="foo", channel="foo*", data_version=1)
         self.paths.t.insert().execute(rule_id=10, priority=100, buildTarget="g", mapping="g", fallbackMapping='fallback', backgroundRate=100,
                                       update_type="z", product="foo", channel="foo", data_version=1)
+
+        self.paths.t.insert().execute(rule_id=11, priority=100, buildTarget='h', mapping='h', systemCapabilities='GenuineIntel, SSE2', update_type='z',
+                                      product='a', channel='a', data_version=1)
+        self.paths.t.insert().execute(rule_id=12, priority=100, buildTarget='i', mapping='i', systemCapabilities='GenuineIntel && SSE2', update_type='z',
+                                      product='a', channel='a', data_version=1, version='5.0')
+        self.paths.t.insert().execute(rule_id=13, priority=100, buildTarget='j', mapping='j', systemCapabilities='GenuineIntel && SSE3, SSE2', update_type='z',
+                                      product='a', channel='a', data_version=1)
+        self.paths.t.insert().execute(rule_id=14, priority=100, buildTarget='k', mapping='k', systemCapabilities='GenuineIntel, SSE', update_type='z',
+                                      product='a', channel='a', data_version=1)
+
         self.db.permissions.t.insert().execute(permission="admin", username="bill", data_version=1)
         self.db.permissions.user_roles.t.insert(username="bill", role="bar", data_version=1)
         self.db.permissions.user_roles.t.insert(username="jane", role="bar", data_version=1)
@@ -1908,27 +1918,34 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
     def testGetOrderedRules(self):
         rules = self._stripNullColumns(self.paths.getOrderedRules())
         expected = [
-            dict(rule_id=4, alias="gandalf", priority=80, backgroundRate=100, buildTarget='d', mapping='a', update_type='z',
-                 channel="a", data_version=1),
-            dict(rule_id=5, priority=80, backgroundRate=0, version='3.3', buildTarget='d', mapping='c', update_type='z',
-                 data_version=1),
-            dict(rule_id=6, alias="radagast", priority=100, buildTarget='d', mapping='a', backgroundRate=100, osVersion='foo 1', update_type='z',
-                 product="a", channel="a", data_version=1),
-            dict(rule_id=7, priority=100, buildTarget='d', mapping='a', backgroundRate=100, osVersion='foo 2,blah 6', update_type='z',
-                 product="a", channel="a", data_version=1),
-            dict(rule_id=8, priority=100, buildTarget='e', mapping='d', backgroundRate=100, locale='foo,bar-baz', update_type='z',
-                 product="a", channel="a", data_version=1),
-            dict(rule_id=9, priority=100, buildTarget="f", mapping="f", backgroundRate=100, systemCapabilities="S", update_type="z",
-                 product="foo", channel="foo*", data_version=1),
-            dict(rule_id=10, priority=100, buildTarget="g", mapping="g", fallbackMapping='fallback', backgroundRate=100, update_type="z",
-                 product="foo", channel="foo", data_version=1),
-            dict(rule_id=2, priority=100, backgroundRate=100, version='3.3', buildTarget='d', mapping='b', update_type='z',
-                 product="a", channel="a", data_version=1),
-            dict(rule_id=3, priority=100, backgroundRate=100, version='3.5', buildTarget='a', mapping='a', update_type='z',
-                 product="a", data_version=1),
-            dict(rule_id=1, priority=100, backgroundRate=100, version='3.5', buildTarget='d', mapping='c', update_type='z',
-                 product="a", channel="a", data_version=1),
+            dict(alias='gandalf', backgroundRate=100, buildTarget='d', channel='a', data_version=1, mapping='a', priority=80, rule_id=4, update_type='z'),
+            dict(backgroundRate=0, buildTarget='d', data_version=1, mapping='c', priority=80, rule_id=5, update_type='z', version='3.3'),
+            dict(alias='radagast', backgroundRate=100, buildTarget='d', channel='a', data_version=1, mapping='a', osVersion='foo 1', priority=100, product='a',
+                 rule_id=6, update_type='z'),
+            dict(backgroundRate=100, buildTarget='d', channel='a', data_version=1, mapping='a', osVersion='foo 2,blah 6', priority=100, product='a', rule_id=7,
+                 update_type='z'),
+            dict(backgroundRate=100, buildTarget='e', channel='a', data_version=1, locale='foo,bar-baz', mapping='d', priority=100, product='a', rule_id=8,
+                 update_type='z'),
+            dict(backgroundRate=100, buildTarget='f', channel='foo*', data_version=1, mapping='f', priority=100, product='foo', rule_id=9,
+                 systemCapabilities='S', update_type='z'),
+            dict(backgroundRate=100, buildTarget='g', channel='foo', data_version=1, fallbackMapping='fallback', mapping='g', priority=100, product='foo',
+                 rule_id=10, update_type='z'),
+            dict(buildTarget='h', channel='a', data_version=1, mapping='h', priority=100, product='a', rule_id=11,
+                 systemCapabilities='GenuineIntel, SSE2', update_type='z'),
+            dict(buildTarget='j', channel='a', data_version=1, mapping='j', priority=100, product='a', rule_id=13,
+                 systemCapabilities='GenuineIntel && SSE3, SSE2', update_type='z'),
+            dict(buildTarget='k', channel='a', data_version=1, mapping='k', priority=100, product='a', rule_id=14,
+                 systemCapabilities='GenuineIntel, SSE', update_type='z'),
+            dict(backgroundRate=100, buildTarget='d', channel='a', data_version=1, mapping='b', priority=100, product='a', rule_id=2,
+                 update_type='z', version='3.3'),
+            dict(backgroundRate=100, buildTarget='a', data_version=1, mapping='a', priority=100, product='a', rule_id=3,
+                 update_type='z', version='3.5'),
+            dict(backgroundRate=100, buildTarget='d', channel='a', data_version=1, mapping='c', priority=100, product='a', rule_id=1,
+                 update_type='z', version='3.5'),
+            dict(buildTarget='i', channel='a', data_version=1, mapping='i', priority=100, product='a', rule_id=12,
+                 systemCapabilities='GenuineIntel && SSE2', update_type='z', version='5.0')
         ]
+
         self.assertEquals(rules, expected)
 
     def testGetOrderedRulesWithCondition(self):
@@ -2024,7 +2041,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
     def testGetRulesMatchingQueryOsVersionSubstring(self):
         rules = self.paths.getRulesMatchingQuery(
             dict(product="a", version='5.0', channel="a", buildTarget='d',
-                 buildID='', locale='', osVersion='foo 1.2.3', distribution='',
+                 buildID='', locale='', osVersion='foo 1', distribution='',
                  distVersion='', headerArchitecture='', force=False,
                  queryVersion=3,
                  ),
@@ -2042,7 +2059,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
     def testGetRulesMatchingQueryOsVersionSubstringNotAtStart(self):
         rules = self.paths.getRulesMatchingQuery(
             dict(product="a", version='5.0', channel="a", buildTarget='d',
-                 buildID='', locale='', osVersion='bbb foo 1.2.3', distribution='',
+                 buildID='', locale='', osVersion='bbb,foo 1,ccc', distribution='',
                  distVersion='', headerArchitecture='', force=False,
                  queryVersion=3,
                  ),
@@ -2060,7 +2077,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
     def testGetRulesMatchingQueryOsVersionMultipleSubstring(self):
         rules = self.paths.getRulesMatchingQuery(
             dict(product="a", version='5.0', channel="a", buildTarget='d',
-                 buildID='', locale='', osVersion='blah 6.3.2', distribution='',
+                 buildID='', locale='', osVersion='blah 6', distribution='',
                  distVersion='', headerArchitecture='', force=False,
                  queryVersion=3,
                  ),
@@ -2102,6 +2119,149 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         )
         rules = self._stripNullColumns(rules)
         self.assertEquals(rules, [])
+
+    def testGetRulesMatchingQuerySystemCapabilitiesOrs(self):
+        match_1 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='h', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='GenuineIntel',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+        match_2 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='h', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='SSE2', version='5.0'),
+            fallbackChannel=''
+        )
+        no_match_1 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='h', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='SSE3', version='5.0'),
+            fallbackChannel=''
+        )
+        no_match_2 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='h', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='SSE', version='5.0'),
+            fallbackChannel=''
+        )
+
+        self.assertEqual(1, len(match_1))
+        self.assertEqual(1, len(match_2))
+        self.assertEqual(11, match_1[0]['rule_id'])
+        self.assertEqual(11, match_2[0]['rule_id'])
+        self.assertEquals(no_match_1, [])
+        self.assertEquals(no_match_2, [])
+
+    def testGetRulesMatchingQuerySystemCapabilitiesBooleanAnds(self):
+        match = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='i', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='GenuineIntel,SSE2',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+        no_match_1 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='i', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='AMD,SSE2',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+        no_match_2 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='i', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='GenuineIntel,SSE3',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+        no_match_3 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='i', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='GenuineIntel,SSE',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+
+        self.assertEqual(len(match), 1)
+        self.assertEqual(match[0]['rule_id'], 12)
+        self.assertEqual(no_match_1, [])
+        self.assertEqual(no_match_2, [])
+        self.assertEqual(no_match_3, [])
+
+    def testGetRulesMatchingQuerySystemCapabilitiesBooleanExact(self):
+        match = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='k', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='SSE',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+        no_match = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='k', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='SSE2',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+
+        self.assertEqual(len(match), 1)
+        self.assertEqual(match[0]['rule_id'], 14)
+        self.assertEqual(no_match, [])
+
+    def testGetRulesMatchingQuerySystemCapabilitiesBooleanMixed(self):
+        match_1 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='j', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='GenuineIntel,SSE2',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+        match_2 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='j', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='AMD,SSE2',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+        match_3 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='j', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='GenuineIntel,SSE3',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+        no_match_1 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='j', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='AMD,SSE3',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+        no_match_2 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='j', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='GenuineIntel,SSE',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+        no_match_3 = self.paths.getRulesMatchingQuery(
+            dict(product='a', channel='a', buildTarget='j', buildID='', locale='',
+                 osVersion='', distribution='', distVersion='', headerArchitecture='',
+                 force=False, queryVersion=6, systemCapabilities='AMD,SSE',
+                 version='5.0'),
+            fallbackChannel=''
+        )
+        self.assertEqual(len(match_1), 1)
+        self.assertEqual(match_1[0]['rule_id'], 13)
+        self.assertEqual(len(match_2), 1)
+        self.assertEqual(match_2[0]['rule_id'], 13)
+        self.assertEqual(len(match_3), 1)
+        self.assertEqual(match_3[0]['rule_id'], 13)
+        self.assertEqual(no_match_1, [])
+        self.assertEqual(no_match_2, [])
+        self.assertEqual(no_match_3, [])
 
     def testGetRulesMatchingQueryFallbackMapping(self):
         rules = self.paths.getRulesMatchingQuery(
@@ -2254,7 +2414,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         self.assertRaises(SignoffRequiredError, self.paths.delete, {"rule_id": 9}, changed_by="bill", old_data_version=1)
 
     def testGetNumberOfRules(self):
-        self.assertEquals(self.paths.countRules(), 10)
+        self.assertEquals(self.paths.countRules(), 14)
 
 
 class TestRulesSpecial(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):

--- a/docs/source/database.rst
+++ b/docs/source/database.rst
@@ -91,7 +91,7 @@ Following tables show columns according to different Categories:
   |                        | osVersion          | The OS Version of the application requesting an  | Simplified boolean string       | "Windows_NT 5.0" or        |
   |                        |                    | update. This field is primarily used to point    | match. '&&' ANDs terms while    | "Darwin 6, Darwin 7        |
   |                        |                    | desupported operating systems to their last      | ',' ORs them. Terms are matched | , Darwin 8"                |
-  |                        |                    | supported build.                                 | using exact strings.            |                            |
+  |                        |                    | supported build.                                 | using partial strings.          |                            |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
   |                        | Product            | The name of the application requesting an update.| Exact string match only         | "Firefox" or "B2G"         |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+

--- a/docs/source/database.rst
+++ b/docs/source/database.rst
@@ -88,17 +88,17 @@ Following tables show columns according to different Categories:
   |                        |                    | update.                                          | comma separated list of         | "en-US,en-GB,id"           |
   |                        |                    |                                                  | locales to do an exact match on |                            |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
-  |                        | osVersion          | The OS Version of the application requesting an  | Partial string match or         | "Windows_NT 5.0" or        |
-  |                        |                    | update. This field is primarily used to point    | comma separated list of         | "Darwin 6,Darwin 7         |
-  |                        |                    | desupported operating systems to their last      | partial strings to match on     | ,Darwin 8"                 |
-  |                        |                    | supported build.                                 |                                 |                            |
+  |                        | osVersion          | The OS Version of the application requesting an  | Simplified boolean string       | "Windows_NT 5.0" or        |
+  |                        |                    | update. This field is primarily used to point    | match. '&&' ANDs terms while    | "Darwin 6, Darwin 7        |
+  |                        |                    | desupported operating systems to their last      | ',' ORs them. Terms are matched | , Darwin 8"                |
+  |                        |                    | supported build.                                 | using exact strings.            |                            |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
   |                        | Product            | The name of the application requesting an update.| Exact string match only         | "Firefox" or "B2G"         |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
-  |                        | systemCapabilities | The supported hardware features of the           | Full string match or            | 	"SSE" or "MMX,SSE"        |
-  |                        |                    | application requesting an update. This field     | comma separated list of         |                            |
-  |                        |                    | is primarily used to point desupported users     | full strings to match on        |                            |
-  |                        |                    | based on their hardware. Eg: users who do not    |                                 |                            |
+  |                        | systemCapabilities | The supported hardware features of the           | Simplified boolean string       | 	"SSE" or "MMX, SSE" or    |
+  |                        |                    | application requesting an update. This field     | match. '&&' ANDs terms while    |  "GenuineIntel && MMX,SSE" |
+  |                        |                    | is primarily used to point desupported users     | ',' ORs them. Terms are matched |                            |
+  |                        |                    | based on their hardware. Eg: users who do not    | using exact strings.            |                            |
   |                        |                    | support SSE2                                     |                                 |                            |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
   |                        | Version            | The version of the application requesting an     | Exact string match or exact     | "36.0" or "36.0,36.1,36.2" |


### PR DESCRIPTION
This PR is a work in progress! I'll rebase and edit this PR message before it's ready for review and fix any tests - I just wanted to get a bit of feedback before continuing the work.

I went with rail's suggestion to the keep the comma-separated format and introduce "&&" and "!" to the syntax - which makes the whole thing a lot simpler and naturally imposes some constraints so that rules won't get out of hand. That said, I wanted to clarify two things:

1. Looking at the [bugzilla entry](https://bugzilla.mozilla.org/show_bug.cgi?id=1312499), it looks to me that we only want to introduce this simplified boolean matching to the osVersion and systemCapabilities fields - is this correct?
2. Has this functionality been implemented in the clients yet? Like, is Balrog getting any GET requests that feature extended systemCapabilities information? I'm mainly trying to pinpoint how the URL will look then - I'm currently assuming that it'll be something like `.../GenuineIntel,family6,model61,SSE3/...`. 

I'll be squaring away the tests and code in what I have so far and once I figure out the two things above, I'll add them in and make this a real PR.

Many thanks!
