### PR TITLE
create docker images with version tags

### DIFF
--- a/scripts/push-dockerimage.sh
+++ b/scripts/push-dockerimage.sh
@@ -40,11 +40,14 @@ echo "Building Docker image"
 docker build -t mozilla/balrog:${branch_tag} .
 echo "Tagging Docker image with date tag"
 docker tag mozilla/balrog:${branch_tag} "mozilla/balrog:${date_tag}"
+echo "Tagging Docker image with version tag"
+docker tag mozilla/balrog:${branch_tag} "mozilla/balrog:${version}"
 echo "Logging into Dockerhub"
 docker login -e $dockerhub_email -u $dockerhub_username -p $dockerhub_password
 echo "Pushing Docker image"
 docker push mozilla/balrog:${branch_tag}
 docker push mozilla/balrog:${date_tag}
+docker push mozilla/balrog:${version}
 
 sha256=$(docker images --no-trunc mozilla/balrog | grep "${date_tag}" | awk '/^mozilla/ {print $3}')
 echo "SHA256 is ${sha256}, creating artifact for it"


### PR DESCRIPTION
this will create docker images like mozilla/balrog:2.24 which jenkins can identify and automatically deploy to stage