### PR TITLE
Add a docker tag for git commit

### DIFF
--- a/agent/scripts/push-dockerimage.sh
+++ b/agent/scripts/push-dockerimage.sh
@@ -30,17 +30,20 @@ branch_tag="${branch}"
 if [ "$branch" == "master" ]; then
     branch_tag="latest"
 fi
-date_tag="${branch}-${date}"
+date_tag="${branch}-${date}"commit_tag="${branch}-${commit}"
 
 echo "Building Docker image"
 docker build -t mozilla/balrogagent:${branch_tag} .
 echo "Tagging Docker image with date tag"
 docker tag mozilla/balrogagent:${branch_tag} "mozilla/balrogagent:${date_tag}"
+echo "Tagging Docker image with git commit tag"
+docker tag mozilla/balrogagent:${branch_tag} "mozilla/balrogagent:${commit_tag}"
 echo "Logging into Dockerhub"
 docker login -e $dockerhub_email -u $dockerhub_username -p $dockerhub_password
 echo "Pushing Docker image"
 docker push mozilla/balrogagent:${branch_tag}
 docker push mozilla/balrogagent:${date_tag}
+docker push mozilla/balrogagent:${commit_tag}
 
 sha256=$(docker images --no-trunc mozilla/balrogagent | grep "${date_tag}" | awk '/^mozilla/ {print $3}')
 echo "SHA256 is ${sha256}, creating artifact for it"

--- a/agent/scripts/push-dockerimage.sh
+++ b/agent/scripts/push-dockerimage.sh
@@ -30,7 +30,8 @@ branch_tag="${branch}"
 if [ "$branch" == "master" ]; then
     branch_tag="latest"
 fi
-date_tag="${branch}-${date}"commit_tag="${branch}-${commit}"
+date_tag="${branch}-${date}"
+commit_tag="${branch}-${commit}"
 
 echo "Building Docker image"
 docker build -t mozilla/balrogagent:${branch_tag} .

--- a/scripts/push-dockerimage.sh
+++ b/scripts/push-dockerimage.sh
@@ -35,16 +35,20 @@ if [ "$branch" == "master" ]; then
     branch_tag="latest"
 fi
 date_tag="${branch}-${date}"
+commit_tag="${branch}-${commit}"
 
 echo "Building Docker image"
 docker build -t mozilla/balrog:${branch_tag} .
 echo "Tagging Docker image with date tag"
 docker tag mozilla/balrog:${branch_tag} "mozilla/balrog:${date_tag}"
+echo "Tagging Docker image with git commit tag"
+docker tag mozilla/balrog:${branch_tag} "mozilla/balrog:${commit_tag}"
 echo "Logging into Dockerhub"
 docker login -e $dockerhub_email -u $dockerhub_username -p $dockerhub_password
 echo "Pushing Docker image"
 docker push mozilla/balrog:${branch_tag}
 docker push mozilla/balrog:${date_tag}
+docker push mozilla/balrog:${commit_tag}
 
 sha256=$(docker images --no-trunc mozilla/balrog | grep "${date_tag}" | awk '/^mozilla/ {print $3}')
 echo "SHA256 is ${sha256}, creating artifact for it"


### PR DESCRIPTION
This is the tag that would be automatically deployed. I investigated automatically deploying the current date stamped tags, but because the balrog and balrogagent tags may differ slightly, this will make sure that a consistent version is deployed automatically.

@bhearsum 