### PR TITLE
Remove support for revision in SystemAddon superblobs.

### DIFF
--- a/auslib/blobs/schemas/superblob.yml
+++ b/auslib/blobs/schemas/superblob.yml
@@ -57,9 +57,6 @@
           description: Blob identifier number
           enum:
             - 4000
-        revision:
-          type: number
-          description: Revision number of adds collection
         blobs:
           type: array
           items:

--- a/auslib/blobs/schemas/superblob.yml
+++ b/auslib/blobs/schemas/superblob.yml
@@ -39,13 +39,17 @@
       required:
         - name
         - schema_version
-        - revision
         - blobs
       additionalProperties: false
       properties:
         name:
           type: string
           description: Human readable identifier
+          minLength: 1
+          maxLength: 100
+        product:
+          type: string
+          description: The product that the blob is associated to
           minLength: 1
           maxLength: 100
         schema_version:

--- a/auslib/blobs/superblob.py
+++ b/auslib/blobs/superblob.py
@@ -33,13 +33,7 @@ class SuperBlob(Blob):
         """
         :return: Header specific to GMP and systemaddons superblob
         """
-        if not self.get("products"):
-            revision = self['revision']
-            # In case of systemaddons superblob
-            return '    <addons revision=\"%i\">' % (revision)
-        else:
-            # In case of GMP superblob
-            return '    <addons>'
+        return '    <addons>'
 
     def getInnerFooterXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
         return '    </addons>'

--- a/auslib/test/blobs/test_superblob.py
+++ b/auslib/test/blobs/test_superblob.py
@@ -25,7 +25,6 @@ class TestSchema1Blob(unittest.TestCase):
 {
     "name": "SystemAddOnsSuperblob",
     "schema_version": 1000,
-    "revision": 123,
     "blobs": [
         "Hello-1.0",
         "Pocket-2.0"
@@ -58,7 +57,7 @@ class TestSchema1Blob(unittest.TestCase):
                                                                  self.specialForceHosts)
 
         expected_header_gmp = '    <addons>'
-        expected_header_addon = '    <addons revision="123">'
+        expected_header_addon = '    <addons>'
 
         self.assertEqual(headerXML_gmp, expected_header_gmp)
         self.assertEquals(headerXML_addon, expected_header_addon)

--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -516,7 +516,6 @@ class ClientTestBase(ClientTestCommon):
 {
     "name": "superblobaddon",
     "schema_version": 4000,
-    "revision": 123,
     "blobs": ["responseblob-a"]
 }
 """))
@@ -525,7 +524,6 @@ class ClientTestBase(ClientTestCommon):
 {
     "name": "superblobaddon",
     "schema_version": 4000,
-    "revision": 124,
     "blobs": ["responseblob-a", "responseblob-b"]
 }
 """))
@@ -862,7 +860,7 @@ class ClientTest(ClientTestBase):
         # update / 3 / gg / 3 / 1 / p / l / a / a / a / a / update.xml?force = 0
         self.assertUpdateEqual(ret, """<?xml version="1.0"?>
 <updates>
-    <addons revision="124">
+    <addons>
         <addon id="c" URL="http://a.com/e" hashFunction="SHA512" hashValue="3" size="2" version="1"/>
         <addon id="d" URL="http://a.com/c" hashFunction="SHA512" hashValue="50" size="20" version="5"/>
         <addon id="b" URL="http://a.com/b" hashFunction="sha512" hashValue="23" size="27" version="1"/>
@@ -875,7 +873,7 @@ class ClientTest(ClientTestBase):
         # update / 3 / gg / 3 / 1 / p / l / a / a / a / a / update.xml?force = 0
         self.assertUpdateEqual(ret, """<?xml version="1.0"?>
 <updates>
-    <addons revision="123">
+    <addons>
         <addon id="c" URL="http://a.com/e" hashFunction="SHA512" hashValue="3" size="2" version="1"/>
         <addon id="d" URL="http://a.com/c" hashFunction="SHA512" hashValue="50" size="20" version="5"/>
     </addons>


### PR DESCRIPTION
We're pushing forward on using multifile updates for System Addons in Balrog. While setting up some sample rules for this, I realized that the SuperBlob requires "revision" to be set - because we originally designed this feature when that was going to be a thing. I'm pretty sure we've decided not to use revision numbers at this point, so this should be safe to kill. @rhelmer - is that right?