### PR TITLE
Add support for creating rule scheduled changes

### DIFF
--- a/auslib/admin/views/rules.py
+++ b/auslib/admin/views/rules.py
@@ -284,8 +284,10 @@ class RuleScheduledChangesView(ScheduledChangesView):
 
     @requirelogin
     def _post(self, transaction, changed_by):
-
-        change_type = request.json.get("change_type")
+        if request.json:
+            change_type = request.json.get("change_type")
+        else:
+            change_type = request.values.get("change_type")
 
         if change_type == "update":
             form = ScheduledChangeExistingRuleForm()

--- a/client/balrogclient/__init__.py
+++ b/client/balrogclient/__init__.py
@@ -1,3 +1,3 @@
-from balrogclient.api import is_csrf_token_expired, SingleLocale, Release, Rule
+from balrogclient.api import is_csrf_token_expired, SingleLocale, Release, Rule, ScheduledRuleChange
 
-__all__ = [ 'is_csrf_token_expired', 'SingleLocale', 'Release', 'Rule' ]
+__all__ = [ 'is_csrf_token_expired', 'SingleLocale', 'Release', 'Rule', 'ScheduledRuleChange' ]

--- a/client/balrogclient/api.py
+++ b/client/balrogclient/api.py
@@ -236,3 +236,18 @@ class Rule(API):
     def update_rule(self, **rule_data):
         """wrapper for self.request"""
         return self.request(method='POST', data=rule_data)
+
+
+class ScheduledRuleChange(API):
+    """Update Balrog rules"""
+    url_template = '/scheduled_changes/rules'
+    prerequest_url_template = '/scheduled_changes/rules'
+
+    def __init__(self, rule_id, **kwargs):
+        super(ScheduledRuleChange, self).__init__(**kwargs)
+        self.rule_id = rule_id
+        self.url_template_vars = dict(rule_id=rule_id)
+
+    def add_scheduled_rule_change(self, **rule_data):
+        """wrapper for self.request"""
+        return self.request(method='POST', data=rule_data)

--- a/client/balrogclient/api.py
+++ b/client/balrogclient/api.py
@@ -241,7 +241,7 @@ class Rule(API):
 class ScheduledRuleChange(API):
     """Update Balrog rules"""
     url_template = '/scheduled_changes/rules'
-    prerequest_url_template = '/scheduled_changes/rules'
+    prerequest_url_template = '/rules/%(rule_id)s'
 
     def __init__(self, rule_id, **kwargs):
         super(ScheduledRuleChange, self).__init__(**kwargs)


### PR DESCRIPTION
Pretty simple, mostly a copy of the existing Rule class. I also discovered that the current backend method doesn't support non-JSON arguments when peeking to find change_type, so I fixed that as well.

@srfraser - are you comfortable reviewing this?