### PR TITLE
[ Bug #1350970] Disable non-error output from docker containers in local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,6 @@ balrogui:
     - .cache:/cache
   environment:
     - WEB_PORT=8080
-    - LOG_LEVEL=WARNING
   entrypoint:
     - /bin/bash
     - /app/docker-entrypoint.sh
@@ -85,6 +84,5 @@ balrogdb:
     - MYSQL_USER=balrogadmin
     - MYSQL_PASSWORD=balrogadmin
     - MYSQL_ROOT_PASSWORD=admin
-    - LOG_LEVEL=WARNING
   volumes:
     - .cache/mysql:/var/lib/mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ balrogadmin:
     - SECRET_KEY=blahblah
     - PORT=7070
     - LOG_FORMAT=plain
-    - LOG_LEVEL=DEBUG
+    - LOG_LEVEL=WARNING
     # Grab mail information from the local environment
     - SMTP_HOST
     - SMTP_PORT
@@ -42,7 +42,7 @@ balrogpub:
     - SECRET_KEY=blahblah
     - PORT=9090
     - LOG_FORMAT=plain
-    - LOG_LEVEL=DEBUG
+    - LOG_LEVEL=WARNING
   links:
     - balrogdb
 
@@ -58,7 +58,7 @@ balrogagent:
     - BALROG_PASSWORD=balrogadmin
     - TELEMETRY_API_ROOT=abc
     - LOG_FORMAT=plain
-    - LOG_LEVEL=DEBUG
+    - LOG_LEVEL=WARNING
 
 balrogui:
   image: node:0.10
@@ -71,6 +71,7 @@ balrogui:
     - .cache:/cache
   environment:
     - WEB_PORT=8080
+    - LOG_LEVEL=WARNING
   entrypoint:
     - /bin/bash
     - /app/docker-entrypoint.sh
@@ -84,5 +85,6 @@ balrogdb:
     - MYSQL_USER=balrogadmin
     - MYSQL_PASSWORD=balrogadmin
     - MYSQL_ROOT_PASSWORD=admin
+    - LOG_LEVEL=WARNING
   volumes:
     - .cache/mysql:/var/lib/mysql


### PR DESCRIPTION
## What does this PR do?

Change and add log level for docker containers

## Description of tasks to be completed

1. Add log level for container balrog ui and balrog db
2. Change log level for container balrog admin, balrog pub, balrog agent from DEBUG to WARNING