### PR TITLE
[Bug #1304026] Make the order of enacting changes predictable

### DIFF
--- a/agent/balrogagent/cmd.py
+++ b/agent/balrogagent/cmd.py
@@ -27,6 +27,7 @@ async def run_agent(loop, balrog_api_root, balrog_username, balrog_password, tel
                                             "/scheduled_changes/%s" % endpoint,
                                             auth=auth, loop=loop)
                 sc = (await resp.json())["scheduled_changes"]
+                sc = sorted(sc, key=lambda k: (k["priority"], k["when"]), reverse=True)
                 resp.close()
                 logging.debug("Found %s", len(sc))
                 for change in sc:

--- a/agent/balrogagent/test/test_cmd.py
+++ b/agent/balrogagent/test/test_cmd.py
@@ -220,3 +220,77 @@ class TestRunAgent(asynctest.TestCase):
         self.assertEquals(telemetry_is_ready.call_count, 0)
         self.assertEquals(time_is_ready.call_count, 1)
         self.assertEquals(request.call_count, 5)
+
+    @asynctest.patch("time.time")
+    async def testRightEnactOrderForMultipleChangesOneEndpoint(self, time, time_is_ready, telemetry_is_ready, request):
+        time.return_value = 999999999
+        time_is_ready.return_value = True
+        sc = {'releases': [{"priority": 1, "sc_id": 4, "when": 234, "telemetry_uptake": None,
+                            "telemetry_product": None, "telemetry_channel": None},
+                           {"priority": 2, "sc_id": 5, "when": 234, "telemetry_uptake": None,
+                            "telemetry_product": None, "telemetry_channel": None},
+                           {"priority": 1, "sc_id": 6, "when": 378, "telemetry_uptake": None,
+                            "telemetry_product": None, "telemetry_channel": None},
+                           {"priority": 2, "sc_id": 7, "when": 187, "telemetry_uptake": None,
+                            "telemetry_product": None, "telemetry_channel": None},
+                           {"priority": 2, "sc_id": 8, "when": 1000, "telemetry_uptake": None,
+                            "telemetry_product": None, "telemetry_channel": None},
+                           {"priority": 4, "sc_id": 9, "when": 74, "telemetry_uptake": None,
+                            "telemetry_product": None, "telemetry_channel": None},
+                           {"priority": 3, "sc_id": 10, "when": 543, "telemetry_uptake": None,
+                            "telemetry_product": None, "telemetry_channel": None}
+                           ]}
+        await self._runAgent(sc, request)
+        self.assertEquals(telemetry_is_ready.call_count, 0)
+        self.assertEquals(time_is_ready.call_count, 7)
+        self.assertEquals(request.call_count, 12)
+        called_endpoints = [call[0][1] for call in request.call_args_list]
+        called_endpoints = called_endpoints[2:9]  # the list slice returns only the enacted endpoints
+        self.assertEquals(called_endpoints.index('/scheduled_changes/releases/4/enact'), 6)
+        self.assertEquals(called_endpoints.index('/scheduled_changes/releases/5/enact'), 3)
+        self.assertEquals(called_endpoints.index('/scheduled_changes/releases/6/enact'), 5)
+        self.assertEquals(called_endpoints.index('/scheduled_changes/releases/7/enact'), 4)
+        self.assertEquals(called_endpoints.index('/scheduled_changes/releases/8/enact'), 2)
+        self.assertEquals(called_endpoints.index('/scheduled_changes/releases/9/enact'), 0)
+        self.assertEquals(called_endpoints.index('/scheduled_changes/releases/10/enact'), 1)
+
+    @asynctest.patch("time.time")
+    async def testRightEnactOrderForMultipleEndpointsAtOnce(self, time, time_is_ready, telemetry_is_ready, request):
+        time.return_value = 999999999
+        time_is_ready.return_value = True
+        sc = {'releases': [{"priority": 1, "sc_id": 4, "when": 234, "telemetry_uptake": None,
+                            "telemetry_product": None, "telemetry_channel": None},
+                           {"priority": 2, "sc_id": 5, "when": 234, "telemetry_uptake": None,
+                            "telemetry_product": None, "telemetry_channel": None},
+                           {"priority": 1, "sc_id": 6, "when": 378, "telemetry_uptake": None,
+                            "telemetry_product": None, "telemetry_channel": None},
+                           {"priority": 2, "sc_id": 7, "when": 187, "telemetry_uptake": None,
+                            "telemetry_product": None, "telemetry_channel": None}],
+              'rules': [{"priority": 100, "sc_id": 1, "when": 23400, "telemetry_uptake": None,
+                         "telemetry_product": None, "telemetry_channel": None},
+                        {"priority": 300, "sc_id": 2, "when": 7000, "telemetry_uptake": None,
+                         "telemetry_product": None, "telemetry_channel": None},
+                        {"priority": 50, "sc_id": 3, "when": 329, "telemetry_uptake": None,
+                         "telemetry_product": None, "telemetry_channel": None}],
+              'permissions': [{"priority": 600, "sc_id": 8, "when": 45400, "telemetry_uptake": None,
+                               "telemetry_product": None, "telemetry_channel": None},
+                              {"priority": 600, "sc_id": 9, "when": 98000, "telemetry_uptake": None,
+                               "telemetry_product": None, "telemetry_channel": None},
+                              {"priority": 600, "sc_id": 10, "when": 5000, "telemetry_uptake": None,
+                               "telemetry_product": None, "telemetry_channel": None}]
+
+              }
+        await self._runAgent(sc, request)
+        self.assertEquals(telemetry_is_ready.call_count, 0)
+        self.assertEquals(time_is_ready.call_count, 10)
+        self.assertEquals(request.call_count, 15)
+        called_endpoints = [call[0][1] for call in request.call_args_list]
+        self.assertLess(called_endpoints.index('/scheduled_changes/rules'), called_endpoints.index('/scheduled_changes/releases'))
+        self.assertLess(called_endpoints.index('/scheduled_changes/releases'), called_endpoints.index('/scheduled_changes/permissions'))
+        self.assertLess(called_endpoints.index('/scheduled_changes/releases/5/enact'), called_endpoints.index('/scheduled_changes/releases/7/enact'))
+        self.assertLess(called_endpoints.index('/scheduled_changes/releases/7/enact'), called_endpoints.index('/scheduled_changes/releases/6/enact'))
+        self.assertLess(called_endpoints.index('/scheduled_changes/releases/6/enact'), called_endpoints.index('/scheduled_changes/releases/4/enact'))
+        self.assertLess(called_endpoints.index('/scheduled_changes/rules/2/enact'), called_endpoints.index('/scheduled_changes/rules/1/enact'))
+        self.assertLess(called_endpoints.index('/scheduled_changes/rules/1/enact'), called_endpoints.index('/scheduled_changes/rules/3/enact'))
+        self.assertLess(called_endpoints.index('/scheduled_changes/permissions/9/enact'), called_endpoints.index('/scheduled_changes/permissions/8/enact'))
+        self.assertLess(called_endpoints.index('/scheduled_changes/permissions/8/enact'), called_endpoints.index('/scheduled_changes/permissions/10/enact'))

--- a/agent/balrogagent/test/test_cmd.py
+++ b/agent/balrogagent/test/test_cmd.py
@@ -45,7 +45,7 @@ class TestRunAgent(asynctest.TestCase):
     async def testTimeBasedNotReadyRules(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 0
         time_is_ready.return_value = False
-        sc = {'rules': [{"sc_id": 4, "when": 23456789, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
+        sc = {'rules': [{"priority": None, "sc_id": 4, "when": 23456789, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
         await self._runAgent(sc, request)
         self.assertEquals(telemetry_is_ready.call_count, 0)
         self.assertEquals(time_is_ready.call_count, 1)
@@ -55,7 +55,7 @@ class TestRunAgent(asynctest.TestCase):
     async def testTimeBasedNotReadyReleases(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 0
         time_is_ready.return_value = False
-        sc = {'releases': [{"sc_id": 4, "when": 23456789, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
+        sc = {'releases': [{"priority": None, "sc_id": 4, "when": 23456789, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
         await self._runAgent(sc, request)
         self.assertEquals(telemetry_is_ready.call_count, 0)
         self.assertEquals(time_is_ready.call_count, 1)
@@ -65,7 +65,7 @@ class TestRunAgent(asynctest.TestCase):
     async def testTimeBasedNotReadyPermissions(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 0
         time_is_ready.return_value = False
-        sc = {'permissions': [{"sc_id": 4, "when": 23456789, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
+        sc = {'permissions': [{"priority": None, "sc_id": 4, "when": 23456789, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
         await self._runAgent(sc, request)
         self.assertEquals(telemetry_is_ready.call_count, 0)
         self.assertEquals(time_is_ready.call_count, 1)
@@ -75,11 +75,11 @@ class TestRunAgent(asynctest.TestCase):
     async def testTimeBasedIsNotReadyRequiredSignoffs(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 0
         time_is_ready.return_value = False
-        sc = {'required_signoffs/product': [{"sc_id": 4, "when": 23456789,
+        sc = {'required_signoffs/product': [{"priority": None, "sc_id": 4, "when": 23456789,
                                              "telemetry_uptake": None,
                                              "telemetry_product": None,
                                              "telemetry_channel": None}],
-              'required_signoffs/permissions': [{"sc_id": 4, "when": 23456789,
+              'required_signoffs/permissions': [{"priority": None, "sc_id": 4, "when": 23456789,
                                                  "telemetry_uptake": None,
                                                  "telemetry_product": None,
                                                  "telemetry_channel": None}]}
@@ -92,7 +92,7 @@ class TestRunAgent(asynctest.TestCase):
     async def testTimeBasedIsReadyRules(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 999999999
         time_is_ready.return_value = True
-        sc = {'rules': [{"sc_id": 4, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
+        sc = {'rules': [{"priority": None, "sc_id": 4, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
         await self._runAgent(sc, request)
         self.assertEquals(telemetry_is_ready.call_count, 0)
         self.assertEquals(time_is_ready.call_count, 1)
@@ -102,7 +102,7 @@ class TestRunAgent(asynctest.TestCase):
     async def testTimeBasedIsReadyReleases(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 999999999
         time_is_ready.return_value = True
-        sc = {'releases': [{"sc_id": 4, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
+        sc = {'releases': [{"priority": None, "sc_id": 4, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
         await self._runAgent(sc, request)
         self.assertEquals(telemetry_is_ready.call_count, 0)
         self.assertEquals(time_is_ready.call_count, 1)
@@ -112,7 +112,7 @@ class TestRunAgent(asynctest.TestCase):
     async def testTimeBasedIsReadyPermissions(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 999999999
         time_is_ready.return_value = True
-        sc = {'permissions': [{"sc_id": 4, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
+        sc = {'permissions': [{"priority": None, "sc_id": 4, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
         await self._runAgent(sc, request)
         self.assertEquals(telemetry_is_ready.call_count, 0)
         self.assertEquals(time_is_ready.call_count, 1)
@@ -122,11 +122,11 @@ class TestRunAgent(asynctest.TestCase):
     async def testTimeBasedIsReadyRequiredSignoffs(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 999999999
         time_is_ready.return_value = True
-        sc = {'required_signoffs/product': [{"sc_id": 4, "when": 234,
+        sc = {'required_signoffs/product': [{"priority": None, "sc_id": 4, "when": 234,
                                              "telemetry_uptake": None,
                                              "telemetry_product": None,
                                              "telemetry_channel": None}],
-              'required_signoffs/permissions': [{"sc_id": 4, "when": 234,
+              'required_signoffs/permissions': [{"priority": None, "sc_id": 4, "when": 234,
                                                  "telemetry_uptake": None,
                                                  "telemetry_product": None,
                                                  "telemetry_channel": None}]}
@@ -139,7 +139,7 @@ class TestRunAgent(asynctest.TestCase):
     async def testTelemetryBasedNotReady(self, get_telemetry_uptake, time_is_ready, telemetry_is_ready, request):
         telemetry_is_ready.return_value = False
         get_telemetry_uptake.return_value = 0
-        sc = {'rules': [{"sc_id": 4, "when": None, "telemetry_uptake": 1000, "telemetry_product": "foo", "telemetry_channel": "bar"}]}
+        sc = {'rules': [{"priority": None, "sc_id": 4, "when": None, "telemetry_uptake": 1000, "telemetry_product": "foo", "telemetry_channel": "bar"}]}
         await self._runAgent(sc, request)
         self.assertEquals(telemetry_is_ready.call_count, 1)
         self.assertEquals(time_is_ready.call_count, 0)
@@ -149,7 +149,7 @@ class TestRunAgent(asynctest.TestCase):
     async def testTelemetryBasedIsReady(self, get_telemetry_uptake, time_is_ready, telemetry_is_ready, request):
         telemetry_is_ready.return_value = True
         get_telemetry_uptake.return_value = 20000
-        sc = {'rules': [{"sc_id": 4, "when": None, "telemetry_uptake": 1000, "telemetry_product": "foo", "telemetry_channel": "bar"}]}
+        sc = {'rules': [{"priority": None, "sc_id": 4, "when": None, "telemetry_uptake": 1000, "telemetry_product": "foo", "telemetry_channel": "bar"}]}
         await self._runAgent(sc, request)
         self.assertEquals(telemetry_is_ready.call_count, 1)
         self.assertEquals(time_is_ready.call_count, 0)
@@ -159,9 +159,9 @@ class TestRunAgent(asynctest.TestCase):
     async def testMultipleEndpointsAtOnce(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 999999999
         time_is_ready.return_value = True
-        sc = {'releases': [{"sc_id": 4, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}],
-              'rules': [{"sc_id": 5, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}],
-              'permissions': [{"sc_id": 6, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
+        sc = {'releases': [{"priority": None, "sc_id": 4, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}],
+              'rules': [{"priority": None, "sc_id": 5, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}],
+              'permissions': [{"priority": None, "sc_id": 6, "when": 234, "telemetry_uptake": None, "telemetry_product": None, "telemetry_channel": None}]}
         await self._runAgent(sc, request)
         self.assertEquals(telemetry_is_ready.call_count, 0)
         self.assertEquals(time_is_ready.call_count, 3)
@@ -171,11 +171,11 @@ class TestRunAgent(asynctest.TestCase):
     async def testMultipleChangesOneEndpoint(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 999999999
         time_is_ready.return_value = True
-        sc = {'releases': [{"sc_id": 4, "when": 234, "telemetry_uptake": None,
+        sc = {'releases': [{"priority": None, "sc_id": 4, "when": 234, "telemetry_uptake": None,
                             "telemetry_product": None, "telemetry_channel": None},
-                           {"sc_id": 5, "when": 234, "telemetry_uptake": None,
+                           {"priority": None, "sc_id": 5, "when": 234, "telemetry_uptake": None,
                             "telemetry_product": None, "telemetry_channel": None},
-                           {"sc_id": 6, "when": 234, "telemetry_uptake": None,
+                           {"priority": None, "sc_id": 6, "when": 234, "telemetry_uptake": None,
                             "telemetry_product": None, "telemetry_channel": None}]}
         await self._runAgent(sc, request)
         self.assertEquals(telemetry_is_ready.call_count, 0)
@@ -193,7 +193,7 @@ class TestRunAgent(asynctest.TestCase):
     async def testSignoffsPresent(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 999999999
         time_is_ready.return_value = True
-        sc = {'permissions': [{"sc_id": 4,
+        sc = {'permissions': [{"priority": None, "sc_id": 4,
                                "when": 234,
                                "telemetry_uptake": None,
                                "telemetry_product": None,
@@ -209,7 +209,7 @@ class TestRunAgent(asynctest.TestCase):
     async def testSignoffsAbsent(self, time, time_is_ready, telemetry_is_ready, request):
         time.return_value = 999999999
         time_is_ready.return_value = True
-        sc = {'permissions': [{"sc_id": 4,
+        sc = {'permissions': [{"priority": None, "sc_id": 4,
                                "when": 234,
                                "telemetry_uptake": None,
                                "telemetry_product": None,


### PR DESCRIPTION
## What does this PR do?
Make the order in which scheduled changes are enacted predictable.

## Description of tasks to be completed
1.  Add function to sort the scheduled changes based on priority and time. 