### PR TITLE
[Bug #1325442] Remove update/delete button on completed scheduled changes for the UI

### DIFF
--- a/ui/app/templates/permission_scheduled_changes.html
+++ b/ui/app/templates/permission_scheduled_changes.html
@@ -50,8 +50,8 @@
                 ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
             Revoke your Signoff
         </button>
-        <button class="btn btn-default btn-xs" ng-click="openScheduledUpdateModal(sc)">Update</button>
-        <button class="btn btn-default btn-xs" ng-click="openDeleteModal(sc)">Delete</button>
+        <button ng-show="!sc.complete" class="btn btn-default btn-xs" ng-click="openScheduledUpdateModal(sc)">Update</button>
+        <button ng-show="!sc.complete" class="btn btn-default btn-xs" ng-click="openDeleteModal(sc)">Delete</button>
       </div>
 
 
@@ -112,4 +112,3 @@
       ></pagination>
     </div>
   </div>
-

--- a/ui/app/templates/release_scheduled_changes.html
+++ b/ui/app/templates/release_scheduled_changes.html
@@ -59,8 +59,8 @@
                 ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
             Revoke your Signoff
         </button>
-        <button ng-show="!scheduled_changes_count" class="btn btn-default btn-xs" ng-click="openUpdateModal(sc)">Update</button>
-        <button ng-show="!scheduled_changes_count" class="btn btn-default btn-xs" ng-click="openDeleteModal(sc)">Delete</button>
+        <button ng-show="!scheduled_changes_count && !sc.complete" class="btn btn-default btn-xs" ng-click="openUpdateModal(sc)">Update</button>
+        <button ng-show="!scheduled_changes_count && !sc.complete" class="btn btn-default btn-xs" ng-click="openDeleteModal(sc)">Delete</button>
         <a ng-show="!scheduled_changes_count" class="btn btn-default btn-xs" ng-href="/scheduled_changes/releases/{{ sc.sc_id }}">History</a>
       </div>
 

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -62,8 +62,8 @@
                 ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
             Revoke your Signoff
         </button>
-        <button ng-show="!scheduled_changes_rules_count" class="btn btn-default btn-xs" ng-click="openUpdateModal(sc)">Update</button>
-        <button ng-show="!scheduled_changes_rules_count" class="btn btn-default btn-xs" ng-click="openDeleteModal(sc)">Delete</button>
+        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-default btn-xs" ng-click="openUpdateModal(sc)">Update</button>
+        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-default btn-xs" ng-click="openDeleteModal(sc)">Delete</button>
         <a ng-show="!scheduled_changes_rules_count" class="btn btn-default btn-xs" ng-href="/scheduled_changes/rules/{{ sc.sc_id }}">History</a>
       </div>
 


### PR DESCRIPTION
## What does this PR do?
It removes the update and delete buttons on completed scheduled changes (for Rules, Permissions and Releases).

## Description of tasks to be completed
Set the condition for the `ng-show` attribute of the update/delete button to be False on completed scheduled changes.

## Screenshot

# Before the update/delete button was removed
<img width="1192" alt="screen shot 2017-03-29 at 3 32 35 pm" src="https://cloud.githubusercontent.com/assets/25608603/24460111/34ce02c2-1495-11e7-95ca-3c0b65bcdbe7.png">

# After the update/delete button was removed
<img width="1202" alt="screen shot 2017-03-29 at 3 31 40 pm" src="https://cloud.githubusercontent.com/assets/25608603/24460128/3e177d04-1495-11e7-9c91-8c6df3a9a9a2.png">
