### PR TITLE
[bg_1342231] Disable role granting for users without permissions

### DIFF
--- a/ui/app/js/controllers/user_edit_controller.js
+++ b/ui/app/js/controllers/user_edit_controller.js
@@ -8,7 +8,6 @@ function ($scope, $modalInstance, CSRF, Permissions, user, users) {
   $scope.is_edit = true;
   $scope.original_user = user;
   $scope.user = angular.copy(user);
-  $scope.showRole = true;
   $scope.permission = {
     permission: '',
     options_as_json: ''
@@ -146,7 +145,6 @@ function ($scope, $modalInstance, CSRF, Permissions, user, users) {
           permissions: {}
         };
         sweetAlert("Saved", "Permission added.", "success");
-        $scope.showRole = !$scope.showRole;
       })
       .error(function(response) {
         if (typeof response === 'object') {

--- a/ui/app/js/controllers/user_edit_controller.js
+++ b/ui/app/js/controllers/user_edit_controller.js
@@ -8,6 +8,7 @@ function ($scope, $modalInstance, CSRF, Permissions, user, users) {
   $scope.is_edit = true;
   $scope.original_user = user;
   $scope.user = angular.copy(user);
+  $scope.showRole = true;
   $scope.permission = {
     permission: '',
     options_as_json: ''
@@ -145,6 +146,7 @@ function ($scope, $modalInstance, CSRF, Permissions, user, users) {
           permissions: {}
         };
         sweetAlert("Saved", "Permission added.", "success");
+        $scope.showRole = !$scope.showRole;
       })
       .error(function(response) {
         if (typeof response === 'object') {

--- a/ui/app/templates/permissions_modal.html
+++ b/ui/app/templates/permissions_modal.html
@@ -9,8 +9,8 @@
         <li ng-class="{active: currentItemTab == 1}">
           <a href="#" ng-click="currentItemTab = 1;">Permissions</a>
         </li>
-        <li ng-class="{active: currentItemTab == 2}">
-          <a href="#" ng-click="currentItemTab = 2;" ng-hide="showRole" ng-show='user.permissions.length > 0'>Roles</a>
+        <li ng-class="{active: currentItemTab == 2}" ng-show='user.permissions.length > 0'>
+          <a href="#" ng-click="currentItemTab = 2;">Roles</a>
         </li>
       </ul>
       <div class="tab-content" ng-show="currentItemTab == 1">

--- a/ui/app/templates/permissions_modal.html
+++ b/ui/app/templates/permissions_modal.html
@@ -10,7 +10,7 @@
           <a href="#" ng-click="currentItemTab = 1;">Permissions</a>
         </li>
         <li ng-class="{active: currentItemTab == 2}">
-          <a href="#" ng-click="currentItemTab = 2;">Roles</a>
+          <a href="#" ng-click="currentItemTab = 2;" ng-hide="showRole" ng-show='user.permissions.length > 0'>Roles</a>
         </li>
       </ul>
       <div class="tab-content" ng-show="currentItemTab == 1">


### PR DESCRIPTION
## What does this PR do?

It disables role granting for users without permissions. Users without permission shouldn't be able to have roles.

## Description of tasks to be completed

First, initialized a boolean variable `showRoles` to be used as a condition to display the Roles tab in the permissions modal. After this, we then used angular directives (ng-show and ng-hide) to display the roles tab based on the boolean we set in the controller.

## Screenshot

#### Before disabling role granting for users without permissions
When a user is added or when updating a user with no permissions, we can see that the roles tab is active.
<img width="776" alt="old" src="https://cloud.githubusercontent.com/assets/25608335/24704044/dd15a3f0-19fd-11e7-8452-de049ff7c479.png">

#### After disabling role granting for users without permissions
<img width="729" alt="update1" src="https://cloud.githubusercontent.com/assets/25608335/24704129/2cb86406-19fe-11e7-9d2c-deb775a82ca0.png">

<img width="665" alt="update2" src="https://cloud.githubusercontent.com/assets/25608335/24704134/34074ab0-19fe-11e7-8138-553d4b736b10.png">

