### PR TITLE
Install netcat in dev Dockerfile to fix healthchecks.

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,7 +14,7 @@ MAINTAINER bhearsum@mozilla.com
 # libfontconfig1 is required by phantomjs
 RUN apt-get -q update \
     && apt-get -q --yes install netcat libpcre3 libpcre3-dev nodejs nodejs-legacy npm libmysqlclient-dev mysql-client \
-                                libfontconfig1 \
+                                libfontconfig1 netcat \
     && apt-get clean
 
 WORKDIR /app


### PR DESCRIPTION
Turns out that the balrogadmin healthcheck was failing at least some of the time because "nc" wasn't available on the image.