### PR TITLE
Bg1276289 reenable coveralls

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -73,6 +73,13 @@ elif [ $1 == "test" ]; then
 
         if [[ $backend_rc == 0 && $frontend_rc == 0 ]]; then
             echo "All tests pass!!!"
+            if [[ $GITHUB_HEAD_REPO_URL == "https://github.com/mozilla/balrog.git" ]];
+            then
+              password_url="taskcluster/secrets/v1/secret/repo:github.com/mozilla/balrog:coveralls"
+              repo_token=$(curl ${password_url} | python -c 'import json, sys; a = json.load(sys.stdin); print a["secret"]["repo_token"]')
+              echo 'repo_token:' $repo_token >> .coveralls.yml
+              coveralls
+            fi
             exit 0
         else
             echo "FAIL FAIL FAIL FAIL FAIL FAIL FAIL FAIL. Some tests failed, see above for details."

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -79,6 +79,7 @@ elif [ $1 == "test" ]; then
               repo_token=$(curl ${password_url} | python -c 'import json, sys; a = json.load(sys.stdin); print a["secret"]["repo_token"]')
               echo 'repo_token:' $repo_token >> .coveralls.yml
               coveralls
+              echo "Coverage successfully sent to coveralls.io"
             fi
             exit 0
         else


### PR DESCRIPTION
## What Does this PR do?

Currently, coverage results are not sent to [coveralls](https://coveralls.io). This PR re-enables it by writing a script to manually send coverage data after successful test completion.

## Description of tasks to be completed

First, coveralls is to be added to the requirements.txt so as to install it when building the docker image for testing, then the repo token is gotten via the curl command from a secret url and saved to .coveralls.yml so coveralls can get it. After all this the `coveralls` command is then run.

## Bug Reference
https://bugzilla.mozilla.org/show_bug.cgi?id=1276289