### PR TITLE
Devedition changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - SMTP_TLS
       - NOTIFY_TO_ADDR
       - NOTIFY_FROM_ADDR
+      - STAGING
     healthcheck:
         test: nc -z -v balrogadmin 7070
         interval: 5s

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -5,8 +5,8 @@ from auslib.log import configure_logging
 
 SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "seabld"]
 DOMAIN_WHITELIST = {
-    "download.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),
-    "archive.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),
+    "download.mozilla.org": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
+    "archive.mozilla.org": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
     "download.cdn.mozilla.net": ("Firefox", "Fennec", "SeaMonkey"),
     "mozilla-nightly-updates.s3.amazonaws.com": ("Firefox",),
     "ciscobinary.openh264.org": ("OpenH264",),
@@ -18,7 +18,7 @@ DOMAIN_WHITELIST = {
 if os.environ.get("STAGING"):
     SYSTEM_ACCOUNTS.extend(["stage-ffxbld", "stage-tbirdbld", "stage-seabld"])
     DOMAIN_WHITELIST.update({
-        "ftp.stage.mozaws.net": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird")
+        "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird")
     })
 
 # Logging needs to be set-up before importing the application to make sure that

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -3,9 +3,7 @@ import os
 
 from auslib.log import configure_logging
 
-
-SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "seabld", "stage-ffxbld",
-                   "stage-tbirdbld", "stage-seabld"]
+SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "seabld"]
 DOMAIN_WHITELIST = {
     "download.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),
     "archive.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),
@@ -17,6 +15,11 @@ DOMAIN_WHITELIST = {
     "redirector.gvt1.com": ("Widevine",),
     "ftp.mozilla.org": ("SystemAddons",),
 }
+if os.environ.get("STAGING"):
+    SYSTEM_ACCOUNTS.extend(["stage-ffxbld", "stage-tbirdbld", "stage-seabld"])
+    DOMAIN_WHITELIST.update({
+        "ftp.stage.mozaws.net": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird")
+    })
 
 # Logging needs to be set-up before importing the application to make sure that
 # logging done from other modules uses our Logger.

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -4,8 +4,7 @@ import os
 from auslib.log import configure_logging
 
 
-SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "seabld", "stage-ffxbld",
-                   "stage-tbirdbld", "stage-seabld"]
+SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "seabld"]
 SPECIAL_FORCE_HOSTS = ["http://download.mozilla.org"]
 DOMAIN_WHITELIST = {
     "download.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),
@@ -18,6 +17,11 @@ DOMAIN_WHITELIST = {
     "redirector.gvt1.com": ("Widevine",),
     "ftp.mozilla.org": ("SystemAddons",),
 }
+if os.environ.get("STAGING"):
+    SYSTEM_ACCOUNTS.extend(["stage-ffxbld", "stage-tbirdbld", "stage-seabld"])
+    DOMAIN_WHITELIST.update({
+        "ftp.stage.mozaws.net": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird")
+    })
 
 # Logging needs to be set-up before importing the application to make sure that
 # logging done from other modules uses our Logger.

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -7,8 +7,8 @@ from auslib.log import configure_logging
 SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "seabld"]
 SPECIAL_FORCE_HOSTS = ["http://download.mozilla.org"]
 DOMAIN_WHITELIST = {
-    "download.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),
-    "archive.mozilla.org": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird"),
+    "download.mozilla.org": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
+    "archive.mozilla.org": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
     "download.cdn.mozilla.net": ("Firefox", "Fennec", "SeaMonkey"),
     "mozilla-nightly-updates.s3.amazonaws.com": ("Firefox",),
     "ciscobinary.openh264.org": ("OpenH264",),
@@ -20,7 +20,7 @@ DOMAIN_WHITELIST = {
 if os.environ.get("STAGING"):
     SYSTEM_ACCOUNTS.extend(["stage-ffxbld", "stage-tbirdbld", "stage-seabld"])
     DOMAIN_WHITELIST.update({
-        "ftp.stage.mozaws.net": ("Firefox", "Fennec", "SeaMonkey", "Thunderbird")
+        "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird")
     })
 
 # Logging needs to be set-up before importing the application to make sure that


### PR DESCRIPTION
I'm not sure if we'll end up using Balrog staging given the VPN situation but the first commit here adds in the staging equivalent of archive.mozilla.org when STAGING is set in the environment (CloudOps would have set that). Also tweaks the SYSTEM_ACCOUNTS to use that.

The second sets up Devedition as a separate product, as an extension of the approach with bouncer, and what Rail has so far on jamun (ie it's submitting with `Data sent: {'product': 'Devedition', ...` in the updates job).