### PR TITLE
Fix bug #1346212 - Cannot revert a rule change: Cannot revert a rule change: https://aus4-admin.mozilla.org/api/rules/undefined/revisions

### DIFF
--- a/ui/app/js/controllers/rule_revert_controller.js
+++ b/ui/app/js/controllers/rule_revert_controller.js
@@ -10,12 +10,13 @@ function ($scope, $modalInstance, CSRF, Rules, revision) {
     .then(function(csrf_token) {
       Rules.revertRule($scope.rule.rule_id, $scope.rule.change_id, csrf_token)
       .success(function(response) {
-        $scope.saving = false;
         $modalInstance.close();
       })
       .error(function() {
-        $scope.saving = false;
         console.error(arguments);
+      })
+      .finally(function() {
+        $scope.saving = false;
       });
     });
   };

--- a/ui/app/js/controllers/rule_revert_controller.js
+++ b/ui/app/js/controllers/rule_revert_controller.js
@@ -8,7 +8,7 @@ function ($scope, $modalInstance, CSRF, Rules, revision) {
     $scope.saving = true;
     CSRF.getToken()
     .then(function(csrf_token) {
-      Rules.revertRule($scope.rule.id, $scope.rule.change_id, csrf_token)
+      Rules.revertRule($scope.rule.rule_id, $scope.rule.change_id, csrf_token)
       .success(function(response) {
         $scope.saving = false;
         $modalInstance.close();

--- a/ui/spec/controllers/rule_revert_controller_spec.js
+++ b/ui/spec/controllers/rule_revert_controller_spec.js
@@ -53,7 +53,7 @@ describe("controller: RuleRevertCtrl", function() {
         "headerArchitecture": null,
         "distribution": null,
         "buildTarget": null,
-        "id": 19,
+        "rule_id": 19,
         "channel": null,
         "update_type": "minor",
         "whitelist": null
@@ -79,7 +79,7 @@ describe("controller: RuleRevertCtrl", function() {
         "headerArchitecture": null,
         "distribution": null,
         "buildTarget": null,
-        "id": 19,
+        "rule_id": 19,
         "channel": null,
         "update_type": "minor",
         "whitelist": null


### PR DESCRIPTION
@mozbhearsum The issue was with the parameter being passed to [Rules.revertRule()](https://github.com/harikishen/balrog/blob/ticket_1346212/ui/app/js/services/rules_service.js#L36-L40). I replaced the parameter `$scope.rule.id` with `$scope.rule.rule_id` in [rule_revert_controller.js](https://github.com/harikishen/balrog/blob/ticket_1346212/ui/app/js/controllers/rule_revert_controller.js#L11).