### PR TITLE
Fix bug 1369078 - Not sending data_version and rule_id for Duplicate rules

### DIFF
--- a/ui/app/js/controllers/rules_controller.js
+++ b/ui/app/js/controllers/rules_controller.js
@@ -271,8 +271,8 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         },
         rule: function() {
           var copy = angular.copy(rule);
-          copy.data_version = '';
-          copy.rule_id = '';
+          delete copy.data_version;
+          delete copy.rule_id;
           copy._duplicate = true;
           return copy;
         },


### PR DESCRIPTION
I've modified [rule_controller.js](https://github.com/harikishen/balrog/blob/ticket_1369078/ui/app/js/controllers/rules_controller.js#L274-L275) to not include `data_version` and `rule_id` in the copy of `rule` which is passed to `addRule()`