### PR TITLE
Fix bug 1355057 - balrog throws ISE 500 instead of 400 when duplicate alias name is present when posting a new Rule.

### DIFF
--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -222,6 +222,17 @@ class TestRulesAPI_JSON(ViewTest):
                                               product='Firefox', channel='nightly', update_type='minor'))
         self.assertEquals(ret.status_code, 400, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
 
+    def testDuplicateAlias(self):
+        ret = self._post('/rules', data=dict(backgroundRate=31, mapping='c',
+                                             priority=33, product='Firefox',
+                                             update_type='minor', channel='nightly', alias='test'))
+        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+
+        ret = self._post('/rules', data=dict(backgroundRate=31, mapping='c',
+                                             priority=33, product='Firefox',
+                                             update_type='minor', channel='nightly', alias='test'))
+        self.assertEquals(ret.status_code, 400, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+
 
 class TestSingleRuleView_JSON(ViewTest):
 

--- a/auslib/web/admin/views/rules.py
+++ b/auslib/web/admin/views/rules.py
@@ -85,6 +85,12 @@ class RulesAPIView(AdminView):
 
         # Solves Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1361158
         what.pop("csrf_token", None)
+
+        alias = what.get('alias', None)
+        if alias:
+            if dbo.rules.getRule(alias):
+                return problem(400, 'Bad Request', 'Rule with alias exists.')
+
         rule_id = dbo.rules.insert(changed_by=changed_by, transaction=transaction, **what)
         return Response(status=200, response=str(rule_id))
 


### PR DESCRIPTION
@mozbhearsum Added a [check](https://github.com/harikishen/balrog/blob/ticket_1355057/auslib/web/admin/views/rules.py#L89-L92) for existing rules with same alias in [rules.py](https://github.com/harikishen/balrog/blob/ticket_1355057/auslib/web/admin/views/rules.py) `_post()`.