### PR TITLE
bug 1369781: Update the client to send data over the wire as JSON.

### DIFF
--- a/client/balrogclient/api.py
+++ b/client/balrogclient/api.py
@@ -119,10 +119,11 @@ class API(object):
         else:
             logging.debug('Data sent: %s', data)
         headers = {'Accept-Encoding': 'application/json',
-                   'Accept': 'application/json'}
+                   'Accept': 'application/json',
+                   'Content-Type': 'application/json'}
         before = time.time()
         req = self.session.request(
-            method=method, url=url, data=data, timeout=self.timeout,
+            method=method, url=url, data=json.dumps(data), timeout=self.timeout,
             verify=self.verify, auth=self.auth, headers=headers)
         try:
             if self.raise_exceptions:

--- a/client/setup.py
+++ b/client/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="balrogclient",
-    version="0.0.2",
+    version="0.0.3",
     description="Balrog Admin API Client",
     author="Release Engineers",
     author_email="release@mozilla.com",


### PR DESCRIPTION
This is for https://bugzilla.mozilla.org/show_bug.cgi?id=1369781. We discovered as part of the swaggerification of the admin API that these submission tools still submit as form data, and that swagger will not allow us to accept both form data and JSON (as we have been doing up until now).

I tested this locally by re-running all of the balrog submission scripts I could find with the new swagger endpoints. Everything appeared to work.