### PR TITLE
Fix bug 1353241 - 'View diff' for first revision doesn't work

### DIFF
--- a/auslib/test/admin/views/test_history.py
+++ b/auslib/test/admin/views/test_history.py
@@ -121,7 +121,7 @@ class TestHistoryView(ViewTest):
         }"""
 
         ret = self._put('/releases/ddd1', data=dict(blob=blob, name='ddd1',
-                                                  product='d', data_version=1))
+                        product='d', data_version=1))
         self.assertStatusCode(ret, 201)
         ret = self._post(
             '/releases/ddd1',

--- a/auslib/test/admin/views/test_history.py
+++ b/auslib/test/admin/views/test_history.py
@@ -96,6 +96,39 @@ class TestHistoryView(ViewTest):
         self.assertTrue('"fakePartials": true' in ret.data)
         self.assertTrue('"fakePartials": false' in ret.data)
 
+    def testFieldViewDiffFirstRelease(self):
+        # Add first release
+        blob = """
+        {
+            "name": "ddd1",
+            "schema_version": 1,
+            "detailsUrl": "blah",
+            "fakePartials": true,
+            "hashFunction": "sha512",
+            "platforms": {
+                "p": {
+                    "locales": {
+                        "dd": {
+                            "complete": {
+                                "filesize": 1234,
+                                "from": "*",
+                                "hashValue": "abc"
+                            }
+                        }
+                    }
+                }
+            }
+        }"""
+
+        ret = self._put('/releases/ddd1', data=dict(blob=blob, name='ddd1',
+                                                  product='d', data_version=1))
+        self.assertStatusCode(ret, 201)
+        ret = self._post(
+            '/releases/ddd1',
+            data=dict(data=blob, product='d', data_version=1)
+        )
+        self.assertStatusCode(ret, 200)
+
     def testFieldViewDiffRelease(self):
 
         # Add release history for d

--- a/auslib/test/admin/views/test_history.py
+++ b/auslib/test/admin/views/test_history.py
@@ -123,10 +123,12 @@ class TestHistoryView(ViewTest):
         ret = self._put('/releases/ddd1', data=dict(blob=blob, name='ddd1',
                         product='d', data_version=1))
         self.assertStatusCode(ret, 201)
-        ret = self._post(
-            '/releases/ddd1',
-            data=dict(data=blob, product='d', data_version=1)
-        )
+        table = dbo.releases.history
+        row, = table.select(order_by=[table.change_id.desc()], limit=1)
+        change_id = row['change_id']
+
+        url = '/history/diff/release/%d/data' % change_id
+        ret = self.client.get(url)
         self.assertStatusCode(ret, 200)
 
     def testFieldViewDiffRelease(self):

--- a/auslib/test/admin/views/test_history.py
+++ b/auslib/test/admin/views/test_history.py
@@ -124,7 +124,7 @@ class TestHistoryView(ViewTest):
                         product='d', data_version=1))
         self.assertStatusCode(ret, 201)
         table = dbo.releases.history
-        row, = table.select(order_by=[table.change_id.desc()], limit=1)
+        row, = table.select(order_by=[table.change_id.asc()], limit=1)
         change_id = row['change_id']
 
         url = '/history/diff/release/%d/data' % change_id

--- a/auslib/web/admin/views/releases.py
+++ b/auslib/web/admin/views/releases.py
@@ -621,19 +621,20 @@ class ReleaseDiffView(ReleaseFieldView):
     """/diff/:id/:field"""
 
     def get_prev_id(self, value, change_id):
-        release_name = value['name']
-        table = self.table.history
-        old_revision = table.select(
-            where=[
-                table.name == release_name,
-                table.change_id < change_id,
-                table.data_version != null()
-            ],
-            limit=1,
-            order_by=[table.timestamp.desc()],
-        )
-        if len(old_revision) > 0:
-            return old_revision[0]['change_id']
+        if value:
+            release_name = value['name']
+            table = self.table.history
+            old_revision = table.select(
+                where=[
+                    table.name == release_name,
+                    table.change_id < change_id,
+                    table.data_version != null()
+                ],
+                limit=1,
+                order_by=[table.timestamp.desc()],
+            )
+            if len(old_revision) > 0:
+                return old_revision[0]['change_id']
 
     def get(self, change_id, field):
         try:

--- a/auslib/web/admin/views/releases.py
+++ b/auslib/web/admin/views/releases.py
@@ -632,8 +632,8 @@ class ReleaseDiffView(ReleaseFieldView):
             limit=1,
             order_by=[table.timestamp.desc()],
         )
-
-        return old_revision[0]['change_id']
+        if len(old_revision) > 0:
+            return old_revision[0]['change_id']
 
     def get(self, change_id, field):
         try:
@@ -641,8 +641,13 @@ class ReleaseDiffView(ReleaseFieldView):
             data_version = self.get_value(change_id, "data_version")
 
             prev_id = self.get_prev_id(value, change_id)
-            previous = self.get_value(prev_id, field)
-            prev_data_version = self.get_value(prev_id, "data_version")
+            if prev_id:
+                previous = self.get_value(prev_id, field)
+                prev_data_version = self.get_value(prev_id, "data_version")
+            else:
+                previous = ""
+                prev_data_version = ""
+
         except (KeyError, TypeError, IndexError) as msg:
             return problem(400, "Bad Request", str(msg))
         except ValueError as msg:


### PR DESCRIPTION
Added a check for first data_version in releases.py