### PR TITLE
Always treat data_version as an int

### DIFF
--- a/client/balrogclient/api.py
+++ b/client/balrogclient/api.py
@@ -90,7 +90,7 @@ class API(object):
                 # because the caller may be acting on a modified version of
                 # a specific older version of the data.
                 if 'data_version' not in data:
-                    data['data_version'] = res.headers['X-Data-Version']
+                    data['data_version'] = int(res.headers['X-Data-Version'])
                 # We may already have a non-expired CSRF token, but it's
                 # faster/easier just to set it again even if we do, since
                 # we've already made the request.
@@ -144,7 +144,7 @@ class API(object):
 
     def get_data(self):
         resp = self.request()
-        return (json.loads(resp.content), resp.headers['X-Data-Version'])
+        return (json.loads(resp.content), int(resp.headers['X-Data-Version']))
 
 
 class Release(API):

--- a/client/setup.py
+++ b/client/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="balrogclient",
-    version="0.0.3",
+    version="0.0.4",
     description="Balrog Admin API Client",
     author="Release Engineers",
     author_email="release@mozilla.com",


### PR DESCRIPTION
As part of reviewing #336 I discovered that our client tools submit data_version as a string. This happens because we always retrieve it from a header, but never cast it to an int. This patch should fix that.