### PR TITLE
Explicity Typecasting all 'data_version' query arguments into integer

### DIFF
--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -96,6 +96,7 @@ parameters:
     in: query
     description: data version of object.
     type: integer
+    format: int32
     minimum: 1
     required: true
 

--- a/auslib/web/admin/views/permissions.py
+++ b/auslib/web/admin/views/permissions.py
@@ -134,9 +134,9 @@ class SpecificPermissionView(AdminView):
             # won't find data where it's expecting it. Instead, we have to tell it to look at
             # the query string, which Flask puts in request.args.
 
+            old_data_version = int(connexion.request.args.get("data_version"))
             dbo.permissions.delete(where={"username": username, "permission": permission},
-                                   changed_by=changed_by, old_data_version=connexion.request.args.get("data_version"),
-                                   transaction=transaction)
+                                   changed_by=changed_by, old_data_version=old_data_version, transaction=transaction)
             return Response(status=200)
         except ValueError as e:
             self.log.warning("Bad input: %s", e.args)
@@ -243,6 +243,7 @@ class UserRoleView(AdminView):
                                                                                  "username '%s'" % (role, username)})
         # query argument i.e. data_version  is also required.
         # All input value validations already defined in swagger specification and carried out by connexion.
+        old_data_version = int(connexion.request.args.get("data_version"))
         dbo.permissions.revokeRole(username, role, changed_by=changed_by,
-                                   old_data_version=connexion.request.args.get("data_version"), transaction=transaction)
+                                   old_data_version=old_data_version, transaction=transaction)
         return Response(status=200)

--- a/auslib/web/admin/views/releases.py
+++ b/auslib/web/admin/views/releases.py
@@ -307,8 +307,9 @@ class SingleReleaseView(AdminView):
         # query argument i.e. data_version  is also required.
         # All input value validations already defined in swagger specification and carried out by connexion.
         try:
+            old_data_version = int(connexion.request.args.get("data_version"))
             dbo.releases.delete(where={"name": release["name"]}, changed_by=changed_by,
-                                old_data_version=connexion.request.args.get("data_version"),
+                                old_data_version=old_data_version,
                                 transaction=transaction)
         except ReadOnlyError as e:
                 msg = "Couldn't delete release: %s" % e

--- a/auslib/web/admin/views/rules.py
+++ b/auslib/web/admin/views/rules.py
@@ -152,8 +152,9 @@ class SingleRuleView(AdminView):
         # rule_id and data_version), we still want to create and validate the
         # form to make sure that the CSRF token is checked.
 
+        old_data_version = int(connexion.request.args.get("data_version"))
         dbo.rules.delete(where={"rule_id": id_or_alias}, changed_by=changed_by,
-                         old_data_version=connexion.request.args.get("data_version"),
+                         old_data_version=old_data_version,
                          transaction=transaction)
 
         return Response(status=200)


### PR DESCRIPTION
if unicode->int typecasting fails, [handleGeneralExceptions](https://github.com/mozilla/balrog/blob/dac48b8d073a95397342fe00e9b4e30cf1c516b6/auslib/web/admin/views/base.py#L55) automatically handles the ValueError.