### PR TITLE
Bug 1138418 : Adds sanity check for hashLength for systemaddons and app-release blob types

### DIFF
--- a/auslib/blobs/apprelease.py
+++ b/auslib/blobs/apprelease.py
@@ -1,5 +1,6 @@
 from auslib.global_state import dbo
 from auslib.AUS import isForbiddenUrl, getFallbackChannel
+from auslib.util.hashes import getHashLen
 from auslib.blobs.base import Blob
 from auslib.errors import BadDataError
 from auslib.util.versions import MozillaVersion
@@ -9,6 +10,22 @@ class ReleaseBlobBase(Blob):
 
     def __init__(self, **kwargs):
         Blob.__init__(self, **kwargs)
+
+    def validate(self, product, whitelistedDomains):
+        Blob.validate(self, product, whitelistedDomains)
+        requiredLen = getHashLen(self["hashFunction"])
+        for platform in self.get("platforms", {}).values():
+            for locale in platform.get("locales", {}).values():
+                for partial in locale.get("partials", {}):
+                    actualLen = len(partial["hashValue"])
+                    if actualLen != requiredLen:
+                        raise ValueError("The hashValue length is different from the required length of {} for {}."
+                                         .format(getHashLen(self["hashFunction"]), self["hashFunction"].lower()))
+                for complete in locale.get("completes", {}):
+                    actualLen = len(complete["hashValue"])
+                    if actualLen != requiredLen:
+                        raise ValueError("The hashValue length is different from the required length of {} for {}."
+                                         .format(getHashLen(self["hashFunction"]), self["hashFunction"].lower()))
 
     def matchesUpdateQuery(self, updateQuery):
         self.log.debug("Trying to match update query to %s" % self["name"])
@@ -300,6 +317,22 @@ class ReleaseBlobV1(ReleaseBlobBase, SingleUpdateXMLMixin, SeparatedFileUrlsMixi
         if 'schema_version' not in self.keys():
             self['schema_version'] = 1
 
+    def validate(self, product, whitelistedDomains):
+        Blob.validate(self, product, whitelistedDomains)
+        requiredLen = getHashLen(self["hashFunction"])
+        for platform in self.get("platforms", {}).values():
+            for locale in platform.get("locales", {}).values():
+                if "partial" in locale:
+                    actualLen = len(locale["partial"]["hashValue"])
+                    if actualLen != requiredLen:
+                        raise ValueError("The hashValue length is different from the required length of {} for {}."
+                                         .format(getHashLen(self["hashFunction"]), self["hashFunction"].lower()))
+                if "complete" in locale:
+                    actualLen = len(locale["complete"]["hashValue"])
+                    if actualLen != requiredLen:
+                        raise ValueError("The hashValue length is different from the required length of {} for {}."
+                                         .format(getHashLen(self["hashFunction"]), self["hashFunction"].lower()))
+
     def getAppv(self, platform, locale):
         return self.getLocaleOrTopLevelParam(platform, locale, 'appv')
 
@@ -510,6 +543,22 @@ class ReleaseBlobV2(ReleaseBlobBase, NewStyleVersionsMixin, SingleUpdateXMLMixin
         Blob.__init__(self, **kwargs)
         if 'schema_version' not in self.keys():
             self['schema_version'] = 2
+
+    def validate(self, product, whitelistedDomains):
+        Blob.validate(self, product, whitelistedDomains)
+        requiredLen = getHashLen(self["hashFunction"])
+        for platform in self.get("platforms", {}).values():
+            for locale in platform.get("locales", {}).values():
+                if "partial" in locale:
+                    actualLen = len(locale["partial"]["hashValue"])
+                    if actualLen != requiredLen:
+                        raise ValueError("The hashValue length is different from the required length of {} for {}."
+                                         .format(getHashLen(self["hashFunction"]), self["hashFunction"].lower()))
+                if "complete" in locale:
+                    actualLen = len(locale["complete"]["hashValue"])
+                    if actualLen != requiredLen:
+                        raise ValueError("The hashValue length is different from the required length of {} for {}."
+                                         .format(getHashLen(self["hashFunction"]), self["hashFunction"].lower()))
 
     # TODO: kill me when aus3.m.o is dead, and snippet tests have been
     # converted to unit tests.

--- a/auslib/blobs/systemaddons.py
+++ b/auslib/blobs/systemaddons.py
@@ -1,4 +1,5 @@
 from auslib.AUS import isForbiddenUrl
+from auslib.util.hashes import getHashLen
 from auslib.blobs.base import Blob
 from auslib.errors import BadDataError
 
@@ -10,6 +11,17 @@ class SystemAddonsBlob(Blob):
         Blob.__init__(self, **kwargs)
         if "schema_version" not in self:
             self["schema_version"] = 5000
+
+    def validate(self, product, whitelistedDomains):
+        Blob.validate(self, product, whitelistedDomains)
+        for addons in self.get("addons", {}).values():
+            for platform in addons.get("platforms", {}).values():
+                if "hashValue" in platform:
+                    actualLen = len(platform["hashValue"])
+                    requiredLen = getHashLen(self["hashFunction"])
+                    if actualLen != requiredLen:
+                        raise ValueError("The hashValue length is different from the required length of {} for {}."
+                                         .format(getHashLen(self["hashFunction"]), self["hashFunction"].lower()))
 
     def getAddonsForPlatform(self, platform):
         for v in self.get("addons", {}):

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -94,7 +94,8 @@ class ViewTest(unittest.TestCase):
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }

--- a/auslib/test/admin/views/test_history.py
+++ b/auslib/test/admin/views/test_history.py
@@ -70,7 +70,8 @@ class TestHistoryView(ViewTest):
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -112,7 +113,8 @@ class TestHistoryView(ViewTest):
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         }
                     }

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -44,7 +44,8 @@ class TestReleasesAPI_JSON(ViewTest):
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -73,7 +74,8 @@ class TestReleasesAPI_JSON(ViewTest):
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         }
                     }
@@ -94,14 +96,16 @@ class TestReleasesAPI_JSON(ViewTest):
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         },
                         "dd2": {
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         }
                      }
@@ -122,14 +126,16 @@ class TestReleasesAPI_JSON(ViewTest):
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         },
                         "dd1": {
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         }
                     }
@@ -150,21 +156,24 @@ class TestReleasesAPI_JSON(ViewTest):
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         },
                         "dd": {
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         },
                         "dd1": {
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         }
                     }
@@ -209,7 +218,8 @@ class TestReleasesAPI_JSON(ViewTest):
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         }
                     }
@@ -230,7 +240,8 @@ class TestReleasesAPI_JSON(ViewTest):
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         }
                     }
@@ -251,14 +262,16 @@ class TestReleasesAPI_JSON(ViewTest):
                             "complete": {
                                 "filesize": 12345,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         },
                         "dd1": {
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc1"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         }
                     }
@@ -298,7 +311,8 @@ class TestReleasesAPI_JSON(ViewTest):
                             "complete": {
                                 "filesize": 1234,
                                 "from": "*",
-                                "hashValue": "abc"
+                                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                             }
                         }
                     }
@@ -447,7 +461,8 @@ class TestReleasesAPI_JSON(ViewTest):
             "complete": {
                 "filesize": 435,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         })
         ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
@@ -466,7 +481,8 @@ class TestReleasesAPI_JSON(ViewTest):
                     "complete": {
                         "filesize": 435,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -480,7 +496,8 @@ class TestReleasesAPI_JSON(ViewTest):
             "complete": {
                 "filesize": 435,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         })
         ret = self._put('/releases/ab/builds/p/l', username="ashanti", data=dict(data=data, product='a', data_version=1, schema_version=1))
@@ -499,7 +516,8 @@ class TestReleasesAPI_JSON(ViewTest):
                     "complete": {
                         "filesize": 435,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -514,12 +532,14 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 400)
 
     def testLocalePutWithoutPermission(self):
-        data = '{"complete": {"filesize": 435, "from": "*", "hashValue": "abc"}}'
+        data = '{"complete": {"filesize": 435, "from": "*", "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"}}'
         ret = self._put('/releases/ab/builds/p/l', username='liu', data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 403)
 
     def testLocalePutWithoutPermissionForProduct(self):
-        data = '{"complete": {"filesize": 435, "from": "*", "hashValue": "abc"}}'
+        data = '{"complete": {"filesize": 435, "from": "*", "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"}}'
         ret = self._put('/releases/ab/builds/p/l', username='bob', data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 403)
 
@@ -528,7 +548,8 @@ class TestReleasesAPI_JSON(ViewTest):
             "complete": {
                 "filesize": 678,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         })
         # setting schema_version in the incoming blob is a hack for testing
@@ -549,7 +570,8 @@ class TestReleasesAPI_JSON(ViewTest):
                     "complete": {
                         "filesize": 678,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -563,8 +585,9 @@ class TestReleasesAPI_JSON(ViewTest):
             "partial": {
                 "filesize": 234,
                 "from": "c",
-                "hashValue": "abc",
-                "fileUrl": "http://good.com/blah",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                "fileUrl": "http://good.com/blah"
             }
         })
         ret = self._put('/releases/d/builds/p/g', data=dict(data=data, product='d', data_version=1, schema_version=1))
@@ -583,14 +606,16 @@ class TestReleasesAPI_JSON(ViewTest):
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 },
                 "g": {
                     "partial": {
                         "filesize": 234,
                         "from": "c",
-                        "hashValue": "abc",
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                         "fileUrl": "http://good.com/blah"
                     }
                 }
@@ -605,7 +630,8 @@ class TestReleasesAPI_JSON(ViewTest):
             "complete": {
                 "filesize": 678,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         })
         # setting schema_version in the incoming blob is a hack for testing
@@ -626,7 +652,8 @@ class TestReleasesAPI_JSON(ViewTest):
                     "complete": {
                         "filesize": 678,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -643,8 +670,9 @@ class TestReleasesAPI_JSON(ViewTest):
             "partial": {
                 "filesize": 123,
                 "from": "c",
-                "hashValue": "abc",
-                "fileUrl": "http://good.com/blah",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                "fileUrl": "http://good.com/blah"
             }
         })
         ret = self._put('/releases/d/builds/q/g', data=dict(data=data, product='d', data_version=1, alias='["q2"]', schema_version=1))
@@ -663,7 +691,8 @@ class TestReleasesAPI_JSON(ViewTest):
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -674,7 +703,8 @@ class TestReleasesAPI_JSON(ViewTest):
                     "partial": {
                         "filesize": 123,
                         "from": "c",
-                        "hashValue": "abc",
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                         "fileUrl": "http://good.com/blah"
                     }
                 }
@@ -692,7 +722,8 @@ class TestReleasesAPI_JSON(ViewTest):
             "partial": {
                 "filesize": 123,
                 "from": "b",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         })
         data = dict(data=data, product='a', copyTo=json.dumps(['b']), data_version=1, schema_version=1)
@@ -712,7 +743,8 @@ class TestReleasesAPI_JSON(ViewTest):
                     "partial": {
                         "filesize": 123,
                         "from": "b",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -733,7 +765,8 @@ class TestReleasesAPI_JSON(ViewTest):
                     "partial": {
                         "filesize": 123,
                         "from": "b",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -759,7 +792,8 @@ class TestReleasesAPI_JSON(ViewTest):
             "complete": {
                 "filesize": 1234,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         }
         self.assertEquals(got, expected)
@@ -770,7 +804,8 @@ class TestReleasesAPI_JSON(ViewTest):
             "complete": {
                 "filesize": 435,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         })
         inp_data = dict(csrf_token="lorem", data=data, product='d', data_version=1, schema_version=1)
@@ -783,7 +818,8 @@ class TestReleasesAPI_JSON(ViewTest):
             "complete": {
                 "filesize": 435,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         })
         ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
@@ -794,7 +830,8 @@ class TestReleasesAPI_JSON(ViewTest):
             "complete": {
                 "filesize": 435,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         })
         ret = self._put('/releases/ab/builds/p/l', username='billy',
@@ -806,7 +843,8 @@ class TestReleasesAPI_JSON(ViewTest):
             "complete": {
                 "filesize": 435,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         })
         ret = self._put('/releases/d/builds/p/d', username='billy',

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -193,6 +193,46 @@ class TestReleaseBlobV1(unittest.TestCase):
         }
         """)
 
+    def testValidateHashLength(self):
+        blob = ReleaseBlobV1()
+        blob.loadJSON("""
+        {
+            "name": "j1",
+            "schema_version": 1,
+            "hashFunction": "sha512",
+            "fileUrls": {
+                "c1": "http://a.com/%FILENAME%"
+            },
+            "ftpFilenames": {
+                "partial": "j1-partial.mar",
+                "complete": "complete.mar"
+            },
+            "platforms": {
+                "p": {
+                    "buildID": 31,
+                    "OS_FTP": "o",
+                    "OS_BOUNCER": "o",
+                    "locales": {
+                        "en-GB": {
+                            "partial": {
+                                "filesize": 6,
+                                "from": "samplePartial4",
+                                "hashValue": "5"
+                            },
+                            "complete": {
+                                "filesize": 38,
+                                "from": "*",
+                                "hashValue": "34"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """)
+        self.assertRaisesRegexp(ValueError, ("The hashValue length is different from the required length of 128 for sha512"),
+                                blob.validate, 'a', self.whitelistedDomains)
+
     def testGetPartialReleaseReferences_Happy_Case(self):
         partial_releases = self.sampleReleaseBlob.getReferencedReleases()
         self.assertTrue(4, len(partial_releases))
@@ -312,7 +352,8 @@ class TestOldVersionSpecialCases(unittest.TestCase):
                     "complete": {
                         "filesize": 1,
                         "from": "*",
-                        "hashValue": "1",
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                         "fileUrl": "http://boring.com/a"
                     }
                 }
@@ -340,7 +381,8 @@ class TestOldVersionSpecialCases(unittest.TestCase):
 <update type="minor" version="2.0.0.20" buildID="1" detailsURL="http://example.org/details">
 """
         expected = ["""
-<patch type="complete" URL="http://boring.com/a" hashFunction="sha512" hashValue="1" size="1"/>
+<patch type="complete" URL="http://boring.com/a" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="1"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -363,7 +405,8 @@ class TestOldVersionSpecialCases(unittest.TestCase):
 <update type="minor" version="3.0.9" buildID="1" detailsURL="http://example.org/details">
 """
         expected = ["""
-<patch type="complete" URL="http://boring.com/a" hashFunction="sha512" hashValue="1" size="1"/>
+<patch type="complete" URL="http://boring.com/a" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="1"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -386,7 +429,8 @@ class TestOldVersionSpecialCases(unittest.TestCase):
 <update type="minor" version="12.0" buildID="1" detailsURL="http://example.org/details">
 """
         expected = ["""
-<patch type="complete" URL="http://boring.com/a" hashFunction="sha512" hashValue="1" size="1"/>
+<patch type="complete" URL="http://boring.com/a" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="1"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -409,7 +453,8 @@ class TestOldVersionSpecialCases(unittest.TestCase):
 <update type="minor" version="12.0" extensionVersion="3.6" buildID="1" detailsURL="http://example.org/details">
 """
         expected = ["""
-<patch type="complete" URL="http://boring.com/a" hashFunction="sha512" hashValue="1" size="1"/>
+<patch type="complete" URL="http://boring.com/a" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="1"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -647,12 +692,14 @@ class TestSchema2Blob(unittest.TestCase):
                     "partial": {
                         "filesize": 6,
                         "from": "j1",
-                        "hashValue": "5"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdaacdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     },
                     "complete": {
                         "filesize": 38,
                         "from": "*",
-                        "hashValue": "34"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcaabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -694,7 +741,8 @@ class TestSchema2Blob(unittest.TestCase):
                     "complete": {
                         "filesize": 40,
                         "from": "*",
-                        "hashValue": "35"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+ccdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 },
                 "l2": {
@@ -702,7 +750,8 @@ class TestSchema2Blob(unittest.TestCase):
                     "complete": {
                         "filesize": 50,
                         "from": "*",
-                        "hashValue": "45"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -794,6 +843,49 @@ class TestSchema2Blob(unittest.TestCase):
                 }
                 """)
 
+    def testValidateHashLength(self):
+        blob = ReleaseBlobV2()
+        blob.loadJSON("""
+{
+    "name": "j2",
+    "schema_version": 2,
+    "hashFunction": "sha512",
+    "appVersion": "40.0",
+    "displayVersion": "40.0",
+    "platformVersion": "40.0",
+    "fileUrls": {
+        "c1": "http://a.com/%FILENAME%"
+    },
+    "ftpFilenames": {
+        "partial": "j1-partial.mar",
+        "complete": "complete.mar"
+    },
+    "platforms": {
+        "p": {
+            "buildID": 30,
+            "OS_FTP": "o",
+            "OS_BOUNCER": "o",
+            "locales": {
+                "l": {
+                    "partial": {
+                        "filesize": 6,
+                        "from": "j1",
+                        "hashValue": "12"
+                    },
+                    "complete": {
+                        "filesize": 38,
+                        "from": "*",
+                        "hashValue": "40"
+                    }
+                }
+            }
+        }
+    }
+}
+""")
+        self.assertRaisesRegexp(ValueError, ("The hashValue length is different from the required length of 128 for sha512"),
+                                blob.validate, 'k', self.whitelistedDomains)
+
     def testGetPartialReleaseReferences_Happy_Case(self):
         partial_releases = self.sampleReleaseBlob.getReferencedReleases()
         self.assertTrue(4, len(partial_releases))
@@ -821,7 +913,8 @@ class TestSchema2Blob(unittest.TestCase):
 <update type="minor" displayVersion="40.0" appVersion="40.0" platformVersion="40.0" buildID="30">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="34" size="38"/>
+<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcaabcdabcdabcdabcdabcdabcd" size="38"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -844,9 +937,11 @@ class TestSchema2Blob(unittest.TestCase):
 <update type="minor" displayVersion="40.0" appVersion="40.0" platformVersion="40.0" buildID="30">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="34" size="38"/>
+<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcaabcdabcdabcdabcdabcdabcd" size="38"/>
 """, """
-<patch type="partial" URL="http://a.com/j1-partial.mar" hashFunction="sha512" hashValue="5" size="6"/>
+<patch type="partial" URL="http://a.com/j1-partial.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdaacdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="6"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -871,7 +966,8 @@ class TestSchema2Blob(unittest.TestCase):
             'actions="silent" openURL="http://example.org/url/l" notificationURL="http://example.org/notification/l" ' \
             'alertURL="http://example.org/alert/l">'
         expected = ["""
-<patch type="complete" URL="http://a.com/complete.mar/o/o" hashFunction="sha512" hashValue="35" size="40"/>
+<patch type="complete" URL="http://a.com/complete.mar/o/o" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+ccdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="40"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -896,7 +992,8 @@ class TestSchema2Blob(unittest.TestCase):
             'showNeverForVersion="true" actions="silent" openURL="http://example.org/url/l2" ' \
             'notificationURL="http://example.org/notification/l2" alertURL="http://example.org/alert/l2">'
         expected = ["""
-<patch type="complete" URL="http://a.com/complete.mar/o/o" hashFunction="sha512" hashValue="45" size="50"/>
+<patch type="complete" URL="http://a.com/complete.mar/o/o" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="50"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -956,13 +1053,15 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
                     "partial": {
                         "filesize": 3,
                         "from": "j1",
-                        "hashValue": "4",
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                         "fileUrl": "http://a.com/p"
                     },
                     "complete": {
                         "filesize": 5,
                         "from": "*",
-                        "hashValue": "6",
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabccabcdabcd",
                         "fileUrl": "http://a.com/c"
                     }
                 }
@@ -991,7 +1090,8 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
 <update type="minor" displayVersion="2" appVersion="2" platformVersion="2" buildID="3">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/c" hashFunction="sha512" hashValue="6" size="5"/>
+<patch type="complete" URL="http://a.com/c" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabccabcdabcd" size="5"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1014,9 +1114,11 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
 <update type="minor" displayVersion="2" appVersion="2" platformVersion="2" buildID="3">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/c" hashFunction="sha512" hashValue="6" size="5"/>
+<patch type="complete" URL="http://a.com/c" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabccabcdabcd" size="5"/>
 """, """
-<patch type="partial" URL="http://a.com/p" hashFunction="sha512" hashValue="4" size="3"/>
+<patch type="partial" URL="http://a.com/p" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="3"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1092,13 +1194,15 @@ class TestSchema3Blob(unittest.TestCase):
                         {
                             "filesize": 2,
                             "from": "f1",
-                            "hashValue": "3",
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdcbcdabcd",
                             "fileUrl": "http://a.com/p1"
                         },
                         {
                             "filesize": 4,
                             "from": "f2",
-                            "hashValue": "5",
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                             "fileUrl": "http://a.com/p2"
                         }
                     ],
@@ -1106,13 +1210,15 @@ class TestSchema3Blob(unittest.TestCase):
                         {
                             "filesize": 29,
                             "from": "f2",
-                            "hashValue": "6",
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcc",
                             "fileUrl": "http://a.com/c1"
                         },
                         {
                             "filesize": 30,
                             "from": "*",
-                            "hashValue": "31",
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabccabcd",
                             "fileUrl": "http://a.com/c2"
                         }
                     ]
@@ -1122,7 +1228,8 @@ class TestSchema3Blob(unittest.TestCase):
                         {
                             "filesize": 32,
                             "from": "*",
-                            "hashValue": "33",
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabca",
                             "fileUrl": "http://a.com/c2m"
                         }
                     ]
@@ -1186,14 +1293,16 @@ class TestSchema3Blob(unittest.TestCase):
                         {
                             "filesize": 4,
                             "from": "g1",
-                            "hashValue": "5"
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                         }
                     ],
                     "completes": [
                         {
                             "filesize": 34,
                             "from": "*",
-                            "hashValue": "35"
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcc"
                         }
                     ]
                 }
@@ -1267,6 +1376,58 @@ class TestSchema3Blob(unittest.TestCase):
             }
         }
         """)
+
+    def testValidateHashLength(self):
+        blob = ReleaseBlobV3()
+        blob.loadJSON("""
+        {
+            "name": "f3",
+            "schema_version": 3,
+            "hashFunction": "sha512",
+            "appVersion": "25.0",
+            "displayVersion": "25.0",
+            "platformVersion": "25.0",
+            "platforms": {
+                "p": {
+                    "buildID": 29,
+                    "locales": {
+                        "l": {
+                            "partials": [
+                                {
+                                    "filesize": 2,
+                                    "from": "g1",
+                                    "hashValue": "3",
+                                    "fileUrl": "http://a.com/p1"
+                                },
+                                {
+                                    "filesize": 4,
+                                    "from": "g1",
+                                    "hashValue": "5",
+                                    "fileUrl": "http://a.com/p2"
+                                }
+                            ],
+                            "completes": [
+                                {
+                                    "filesize": 29,
+                                    "from": "f2",
+                                    "hashValue": "6",
+                                    "fileUrl": "http://a.com/c1"
+                                },
+                                {
+                                    "filesize": 30,
+                                    "from": "*",
+                                    "hashValue": "31",
+                                    "fileUrl": "http://a.com/c2"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        """)
+        self.assertRaisesRegexp(ValueError, ("The hashValue length is different from the required length of 128 for sha512"),
+                                blob.validate, 'f', self.whitelistedDomains)
 
     def testGetPartialReleaseReferences_Happy_Case(self):
         partial_releases = self.sampleReleaseBlobV3.getReferencedReleases()
@@ -1350,9 +1511,11 @@ class TestSchema3Blob(unittest.TestCase):
 <update type="minor" displayVersion="25.0" appVersion="25.0" platformVersion="25.0" buildID="29">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/c2" hashFunction="sha512" hashValue="31" size="30"/>
+<patch type="complete" URL="http://a.com/c2" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabccabcd" size="30"/>
 """, """
-<patch type="partial" URL="http://a.com/p1" hashFunction="sha512" hashValue="3" size="2"/>
+<patch type="partial" URL="http://a.com/p1" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdcbcdabcd" size="2"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1374,9 +1537,11 @@ class TestSchema3Blob(unittest.TestCase):
 <update type="minor" displayVersion="25.0" appVersion="25.0" platformVersion="25.0" buildID="29">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/c1" hashFunction="sha512" hashValue="6" size="29"/>
+<patch type="complete" URL="http://a.com/c1" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcc" size="29"/>
 """, """
-<patch type="partial" URL="http://a.com/p2" hashFunction="sha512" hashValue="5" size="4"/>
+<patch type="partial" URL="http://a.com/p2" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="4"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1399,7 +1564,8 @@ class TestSchema3Blob(unittest.TestCase):
 <update type="minor" displayVersion="25.0" appVersion="25.0" platformVersion="25.0" buildID="29">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/c2" hashFunction="sha512" hashValue="31" size="30"/>
+<patch type="complete" URL="http://a.com/c2" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabccabcd" size="30"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1422,7 +1588,8 @@ class TestSchema3Blob(unittest.TestCase):
 <update type="minor" displayVersion="25.0" appVersion="25.0" platformVersion="25.0" buildID="29">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/c2m" hashFunction="sha512" hashValue="33" size="32"/>
+<patch type="complete" URL="http://a.com/c2m" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabca" size="32"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1445,9 +1612,11 @@ class TestSchema3Blob(unittest.TestCase):
 <update type="minor" displayVersion="26.0" appVersion="26.0" platformVersion="26.0" buildID="40">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="35" size="34"/>
+<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcc" size="34"/>
 """, """
-<patch type="partial" URL="http://a.com/g1-partial.mar" hashFunction="sha512" hashValue="5" size="4"/>
+<patch type="partial" URL="http://a.com/g1-partial.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="4"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1470,9 +1639,11 @@ class TestSchema3Blob(unittest.TestCase):
 <update type="minor" displayVersion="26.0" appVersion="26.0" platformVersion="26.0" buildID="40">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/complete" hashFunction="sha512" hashValue="35" size="34"/>
+<patch type="complete" URL="http://a.com/complete" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcc" size="34"/>
 """, """
-<patch type="partial" URL="http://a.com/g1-partial" hashFunction="sha512" hashValue="5" size="4"/>
+<patch type="partial" URL="http://a.com/g1-partial" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="4"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1587,19 +1758,22 @@ class TestSchema4Blob(unittest.TestCase):
                         {
                             "filesize": 6,
                             "from": "h2",
-                            "hashValue": "7"
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabca"
                         },
                         {
                             "filesize": 8,
                             "from": "h1",
-                            "hashValue": "9"
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                         }
                     ],
                     "completes": [
                         {
                             "filesize": 40,
                             "from": "*",
-                            "hashValue": "41"
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb"
                         }
                     ]
                 }
@@ -1684,6 +1858,86 @@ class TestSchema4Blob(unittest.TestCase):
     }
 }
 """)
+
+    def testValidateHashLength(self):
+        blob = ReleaseBlobV4()
+        blob.loadJSON("""
+{
+    "name": "h3",
+    "schema_version": 4,
+    "hashFunction": "sha512",
+    "appVersion": "32.0",
+    "displayVersion": "32.0",
+    "platformVersion": "32.0",
+    "fileUrls": {
+        "c1": {
+            "partials": {
+                "h1": "http://a.com/h1-partial.mar",
+                "h2": "http://a.com/h2-partial.mar"
+            },
+            "completes": {
+                "*": "http://a.com/complete.mar"
+            }
+        },
+        "c2": {
+            "partials": {
+                "h1": "http://a.com/h1-%LOCALE%-partial",
+                "h2": "http://a.com/h2-%LOCALE%-partial"
+            },
+            "completes": {
+                "*": "http://a.com/%LOCALE%-complete"
+            }
+        },
+        "*": {
+            "partials": {
+                "h0": "http://a.com/h0-partial-catchall.mar",
+                "h1": "http://a.com/h1-partial-catchall",
+                "h2": "http://a.com/h2-partial-catchall"
+            },
+            "completes": {
+                "*": "http://a.com/complete-catchall"
+            }
+        }
+    },
+    "platforms": {
+        "p": {
+            "buildID": 500,
+            "OS_FTP": "p",
+            "OS_BOUNCER": "p",
+            "locales": {
+                "l": {
+                    "partials": [
+                        {
+                            "filesize": 60,
+                            "from": "h2",
+                            "hashValue": "70"
+                        },
+                        {
+                            "filesize": 80,
+                            "from": "h1",
+                            "hashValue": "90"
+                        },
+                        {
+                            "filesize": 90,
+                            "from": "h0",
+                            "hashValue": "100"
+                        }
+                    ],
+                    "completes": [
+                        {
+                            "filesize": 400,
+                            "from": "*",
+                            "hashValue": "410"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+""")
+        self.assertRaisesRegexp(ValueError, ("The hashValue length is different from the required length of 128 for sha512"),
+                                blob.validate, 'g', self.whitelistedDomains)
 
     def testGetPartialReleaseReferences_Happy_Case(self):
         sample_release_blob_v4 = ReleaseBlobV4()
@@ -1870,9 +2124,11 @@ class TestSchema4Blob(unittest.TestCase):
 <update type="minor" displayVersion="31.0" appVersion="31.0" platformVersion="31.0" buildID="50">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="41" size="40"/>
+<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb" size="40"/>
 """, """
-<patch type="partial" URL="http://a.com/h1-partial.mar" hashFunction="sha512" hashValue="9" size="8"/>
+<patch type="partial" URL="http://a.com/h1-partial.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="8"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1894,9 +2150,11 @@ class TestSchema4Blob(unittest.TestCase):
 <update type="minor" displayVersion="31.0" appVersion="31.0" platformVersion="31.0" buildID="50">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/l-complete" hashFunction="sha512" hashValue="41" size="40"/>
+<patch type="complete" URL="http://a.com/l-complete" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb" size="40"/>
 """, """
-<patch type="partial" URL="http://a.com/h1-l-partial" hashFunction="sha512" hashValue="9" size="8"/>
+<patch type="partial" URL="http://a.com/h1-l-partial" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="8"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1918,9 +2176,11 @@ class TestSchema4Blob(unittest.TestCase):
 <update type="minor" displayVersion="31.0" appVersion="31.0" platformVersion="31.0" buildID="50">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/complete-catchall" hashFunction="sha512" hashValue="41" size="40"/>
+<patch type="complete" URL="http://a.com/complete-catchall" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb" size="40"/>
 """, """
-<patch type="partial" URL="http://a.com/h1-partial-catchall" hashFunction="sha512" hashValue="9" size="8"/>
+<patch type="partial" URL="http://a.com/h1-partial-catchall" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" size="8"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1943,7 +2203,8 @@ class TestSchema4Blob(unittest.TestCase):
 <update type="minor" displayVersion="31.0" appVersion="31.0" platformVersion="31.0" buildID="50">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="41" size="40"/>
+<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb" size="40"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1965,7 +2226,8 @@ class TestSchema4Blob(unittest.TestCase):
 <update type="minor" displayVersion="31.0" appVersion="31.0" platformVersion="31.0" buildID="50">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/l-complete" hashFunction="sha512" hashValue="41" size="40"/>
+<patch type="complete" URL="http://a.com/l-complete" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb" size="40"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -1987,7 +2249,8 @@ class TestSchema4Blob(unittest.TestCase):
 <update type="minor" displayVersion="31.0" appVersion="31.0" platformVersion="31.0" buildID="50">
 """
         expected = ["""
-<patch type="complete" URL="http://a.com/complete-catchall" hashFunction="sha512" hashValue="41" size="40"/>
+<patch type="complete" URL="http://a.com/complete-catchall" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb" size="40"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -2096,7 +2359,8 @@ class TestSchema4Blob(unittest.TestCase):
                         {
                             "filesize": 4,
                             "from": "g1",
-                            "hashValue": "5",
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+acdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                             "fileUrl": "http://a.com/g1-partial"
                         }
                     ],
@@ -2104,7 +2368,8 @@ class TestSchema4Blob(unittest.TestCase):
                         {
                             "filesize": 34,
                             "from": "*",
-                            "hashValue": "35",
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                             "fileUrl": "http://a.com/complete"
                         }
                     ]
@@ -2223,14 +2488,16 @@ class TestSchema5Blob(unittest.TestCase):
                         {
                             "filesize": 8,
                             "from": "h1",
-                            "hashValue": "9"
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdcbcdabcdabcdabcdabca"
                         }
                     ],
                     "completes": [
                         {
                             "filesize": 40,
                             "from": "*",
-                            "hashValue": "41"
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb"
                         }
                     ]
                 }
@@ -2239,6 +2506,74 @@ class TestSchema5Blob(unittest.TestCase):
     }
 }
 """)
+
+    def testValidateHashLength(self):
+        blob = ReleaseBlobV5()
+        blob.loadJSON("""
+{
+    "name": "h2",
+    "schema_version": 5,
+    "hashFunction": "sha512",
+    "appVersion": "31.0",
+    "displayVersion": "31.0",
+    "platformVersion": "31.0",
+    "detailsUrl": "http://example.org/details/%LOCALE%",
+    "licenseUrl": "http://example.org/license/%LOCALE%",
+    "actions": "silent",
+    "billboardURL": "http://example.org/billboard/%LOCALE%",
+    "openURL": "http://example.org/url/%LOCALE%",
+    "notificationURL": "http://example.org/notification/%LOCALE%",
+    "alertURL": "http://example.org/alert/%LOCALE%",
+    "showPrompt": false,
+    "showNeverForVersion": true,
+    "promptWaitTime": 12345,
+    "fileUrls": {
+        "c1": {
+            "partials": {
+                "h1": "http://a.com/h1-partial.mar"
+            },
+            "completes": {
+                "*": "http://a.com/complete.mar"
+            }
+        },
+        "*": {
+            "partials": {
+                "h1": "http://a.com/h1-partial-catchall"
+            },
+            "completes": {
+                "*": "http://a.com/complete-catchall"
+            }
+        }
+    },
+    "platforms": {
+        "p": {
+            "buildID": 50,
+            "OS_FTP": "p",
+            "OS_BOUNCER": "p",
+            "locales": {
+                "l": {
+                    "partials": [
+                        {
+                            "filesize": 8,
+                            "from": "h1",
+                            "hashValue": "12"
+                        }
+                    ],
+                    "completes": [
+                        {
+                            "filesize": 40,
+                            "from": "*",
+                            "hashValue": "35"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+""")
+        self.assertRaisesRegexp(ValueError, ("The hashValue length is different from the required length of 128 for sha512"),
+                                blob.validate, 'h', self.whitelistedDomains)
 
     def testGetPartialReleaseReferences_Happy_Case(self):
         sample_release_blob_v5 = ReleaseBlobV5()
@@ -2419,9 +2754,11 @@ class TestSchema5Blob(unittest.TestCase):
             'actions="silent" openURL="http://example.org/url/l" notificationURL="http://example.org/notification/l" ' \
             'alertURL="http://example.org/alert/l" promptWaitTime="12345">'
         expected = ["""
-<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="41" size="40"/>
+<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb" size="40"/>
 """, """
-<patch type="partial" URL="http://a.com/h1-partial.mar" hashFunction="sha512" hashValue="9" size="8"/>
+<patch type="partial" URL="http://a.com/h1-partial.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdcbcdabcdabcdabcdabca" size="8"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -2499,14 +2836,16 @@ class TestSchema6Blob(unittest.TestCase):
                         {
                             "filesize": 8,
                             "from": "h1",
-                            "hashValue": "9"
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabca"
                         }
                     ],
                     "completes": [
                         {
                             "filesize": 40,
                             "from": "*",
-                            "hashValue": "41"
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb"
                         }
                     ]
                 }
@@ -2515,6 +2854,71 @@ class TestSchema6Blob(unittest.TestCase):
     }
 }
 """)
+
+    def testValidateHashLength(self):
+        blob = ReleaseBlobV6()
+        blob.loadJSON("""
+{
+    "name": "h2",
+    "schema_version": 6,
+    "hashFunction": "sha512",
+    "appVersion": "31.0",
+    "displayVersion": "31.0",
+    "detailsUrl": "http://example.org/details/%LOCALE%",
+    "actions": "silent",
+    "openURL": "http://example.org/url/%LOCALE%",
+    "notificationURL": "http://example.org/notification/%LOCALE%",
+    "alertURL": "http://example.org/alert/%LOCALE%",
+    "showPrompt": false,
+    "showNeverForVersion": true,
+    "promptWaitTime": 12345,
+    "fileUrls": {
+        "c1": {
+            "partials": {
+                "h1": "http://a.com/h1-partial.mar"
+            },
+            "completes": {
+                "*": "http://a.com/complete.mar"
+            }
+        },
+        "*": {
+            "partials": {
+                "h1": "http://a.com/h1-partial-catchall"
+            },
+            "completes": {
+                "*": "http://a.com/complete-catchall"
+            }
+        }
+    },
+    "platforms": {
+        "p": {
+            "buildID": 50,
+            "OS_FTP": "p",
+            "OS_BOUNCER": "p",
+            "locales": {
+                "l": {
+                    "partials": [
+                        {
+                            "filesize": 8,
+                            "from": "h1",
+                            "hashValue": "26"
+                        }
+                    ],
+                    "completes": [
+                        {
+                            "filesize": 40,
+                            "from": "*",
+                            "hashValue": "21"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+""")
+        self.assertRaisesRegexp(ValueError, ("The hashValue length is different from the required length of 128 for sha512"),
+                                blob.validate, 'h', self.whitelistedDomains)
 
     def testGetPartialReleaseReferences_Happy_Case(self):
         sample_release_blob_v6 = ReleaseBlobV6()
@@ -2620,9 +3024,11 @@ class TestSchema6Blob(unittest.TestCase):
             'actions="silent" openURL="http://example.org/url/l" notificationURL="http://example.org/notification/l" ' \
             'alertURL="http://example.org/alert/l" promptWaitTime="12345">'
         expected = ["""
-<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="41" size="40"/>
+<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb" size="40"/>
 """, """
-<patch type="partial" URL="http://a.com/h1-partial.mar" hashFunction="sha512" hashValue="9" size="8"/>
+<patch type="partial" URL="http://a.com/h1-partial.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabca" size="8"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"
@@ -2768,14 +3174,16 @@ class TestSchema7Blob(unittest.TestCase):
                         {
                             "filesize": 8,
                             "from": "h1",
-                            "hashValue": "9"
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabca"
                         }
                     ],
                     "completes": [
                         {
                             "filesize": 40,
                             "from": "*",
-                            "hashValue": "41"
+                            "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb"
                         }
                     ]
                 }
@@ -2784,6 +3192,72 @@ class TestSchema7Blob(unittest.TestCase):
     }
 }
 """)
+
+    def testValidateHashLength(self):
+        blob = ReleaseBlobV7()
+        blob.loadJSON("""
+{
+    "name": "h2",
+    "schema_version": 7,
+    "hashFunction": "sha512",
+    "appVersion": "31.0",
+    "displayVersion": "31.0",
+    "detailsUrl": "http://example.org/details/%LOCALE%",
+    "actions": "silent",
+    "openURL": "http://example.org/url/%LOCALE%",
+    "notificationURL": "http://example.org/notification/%LOCALE%",
+    "alertURL": "http://example.org/alert/%LOCALE%",
+    "showPrompt": false,
+    "showNeverForVersion": true,
+    "promptWaitTime": 12345,
+    "backgroundInterval": 123,
+    "fileUrls": {
+        "c1": {
+            "partials": {
+                "h1": "http://a.com/h1-partial.mar"
+            },
+            "completes": {
+                "*": "http://a.com/complete.mar"
+            }
+        },
+        "*": {
+            "partials": {
+                "h1": "http://a.com/h1-partial-catchall"
+            },
+            "completes": {
+                "*": "http://a.com/complete-catchall"
+            }
+        }
+    },
+    "platforms": {
+        "p": {
+            "buildID": 50,
+            "OS_FTP": "p",
+            "OS_BOUNCER": "p",
+            "locales": {
+                "l": {
+                    "partials": [
+                        {
+                            "filesize": 8,
+                            "from": "h1",
+                            "hashValue": "32"
+                        }
+                    ],
+                    "completes": [
+                        {
+                            "filesize": 40,
+                            "from": "*",
+                            "hashValue": "8"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+""")
+        self.assertRaisesRegexp(ValueError, ("The hashValue length is different from the required length of 128 for sha512"),
+                                blob.validate, 'h', self.whitelistedDomains)
 
     def testGetPartialReleaseReferences_Happy_Case(self):
         sample_release_blob_v7 = ReleaseBlobV7()
@@ -2872,9 +3346,11 @@ class TestSchema7Blob(unittest.TestCase):
             'actions="silent" openURL="http://example.org/url/l" notificationURL="http://example.org/notification/l" ' \
             'alertURL="http://example.org/alert/l" promptWaitTime="12345" backgroundInterval="123">'
         expected = ["""
-<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="41" size="40"/>
+<patch type="complete" URL="http://a.com/complete.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcb" size="40"/>
 """, """
-<patch type="partial" URL="http://a.com/h1-partial.mar" hashFunction="sha512" hashValue="9" size="8"/>
+<patch type="partial" URL="http://a.com/h1-partial.mar" hashFunction="sha512" hashValue="abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabca" size="8"/>
 """]
         expected = [x.strip() for x in expected]
         expected_footer = "</update>"

--- a/auslib/test/blobs/test_base.py
+++ b/auslib/test/blobs/test_base.py
@@ -40,7 +40,7 @@ class TestCreateBlob(unittest.TestCase):
             yaml_load.return_value = {
                 "title": "Test",
                 "type": "object",
-                "required": ["schema_version", "name"],
+                "required": ["schema_version", "name", "hashFunction"],
                 "additionalProperties": False,
                 "properties": {
                     "schema_version": {
@@ -48,17 +48,22 @@ class TestCreateBlob(unittest.TestCase):
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "hashFunction": {
+                        "type": "string"
                     }
                 }
             }
             blob = createBlob(dict(
                 schema_version=1,
                 name="foo",
+                hashFunction="sha512",
             ))
             blob.validate('fake', [])
             blob = createBlob(dict(
                 schema_version=1,
                 name="foo",
+                hashFunction="sha512",
             ))
             blob.validate('fake', [])
 

--- a/auslib/test/blobs/test_systemaddons.py
+++ b/auslib/test/blobs/test_systemaddons.py
@@ -85,6 +85,40 @@ class TestSchema1Blob(unittest.TestCase):
 }
 """)
 
+    def testValidateHashLength(self):
+        blob = SystemAddonsBlob()
+        blob.whitelistedDomains = {"a.com": ('gg',), 'boring.com': ('gg',)}
+        blob.loadJSON("""
+{
+    "name": "fake",
+    "schema_version": 5000,
+    "hashFunction": "SHA512",
+    "addons": {
+        "c": {
+            "version": "1",
+            "platforms": {
+                "p": {
+                    "filesize": 2,
+                    "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                    "fileUrl": "http://a.com/blah"
+                },
+                "q": {
+                    "filesize": 4,
+                    "hashValue": "5",
+                    "fileUrl": "http://boring.com/blah"
+                },
+                "q2": {
+                    "alias": "q"
+                }
+            }
+        }
+    }
+}
+""")
+        self.assertRaisesRegexp(ValueError, ("The hashValue length is different from the required length of 128 for sha512"),
+                                blob.validate, 'gg', self.whitelistedDomains)
+
     def testXML(self):
         updateQuery = {
             "product": "gg", "version": "3", "buildID": "1",
@@ -286,7 +320,8 @@ class TestSchema1Blob(unittest.TestCase):
                     },
                     "q": {
                         "filesize": 2,
-                        "hashValue": "3",
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                         "fileUrl": "http://boring.com/blah"
                     }
                 }
@@ -314,7 +349,8 @@ class TestSchema1Blob(unittest.TestCase):
                     },
                     "q": {
                         "filesize": 2,
-                        "hashValue": "3",
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                         "fileUrl": "http://boring.com/blah"
                     }
                 }
@@ -361,7 +397,8 @@ class TestSchema1Blob(unittest.TestCase):
                     "p": {},
                     "q": {
                         "filesize": 2,
-                        "hashValue": "3",
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                         "fileUrl": "http://boring.com/blah"
                     }
                 }
@@ -389,7 +426,8 @@ class TestSchema1Blob(unittest.TestCase):
                         "alias": "q"
                     },
                     "q": {
-                        "hashValue": "3",
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                         "fileUrl": "http://boring.com/blah"
                     }
                 }

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -3157,7 +3157,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3218,7 +3219,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             "complete": {
                 "filesize": 1,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='p', locale='c', data=data, old_data_version=1, changed_by='bill')
@@ -3235,14 +3237,16 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 1,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 },
                 "l": {
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3262,7 +3266,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             "complete": {
                 "filesize": 123,
                 "from": "*",
-                "hashValue": "abc"
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='p', locale='c', data=data, old_data_version=1, changed_by='bill', alias=['p4'])
@@ -3279,14 +3284,16 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 123,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 },
                 "l": {
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3309,7 +3316,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             "complete": {
                 "filesize": 123,
                 "from": "*",
-                "hashValue": "789"
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='p', locale='l', data=data, old_data_version=1, changed_by='bill')
@@ -3326,7 +3334,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 123,
                         "from": "*",
-                        "hashValue": "789"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3346,7 +3355,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             "complete": {
                 "filesize": 432,
                 "from": "*",
-                "hashValue": "abc"
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
             }
         }
         self.releases.addLocaleToRelease(name='b', product='b', platform='q', locale='l', data=data, old_data_version=1, changed_by='bill')
@@ -3363,7 +3373,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 432,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3378,7 +3389,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             "complete": {
                 "filesize": 432,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='p3', locale='l', data=data, old_data_version=1, changed_by='bill')
@@ -3395,7 +3407,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3409,7 +3422,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 432,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3424,7 +3438,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             "complete": {
                 "filesize": 324,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='q', locale='l', data=data, old_data_version=1, changed_by='bill')
@@ -3441,7 +3456,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3457,7 +3473,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 324,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3472,7 +3489,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             "complete": {
                 "filesize": 444,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
             }
         }
         self.releases.addLocaleToRelease(name='a', product='a', platform='p2', locale='j', data=data, old_data_version=1, changed_by='bill')
@@ -3489,14 +3507,16 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 },
                 "j": {
                     "complete": {
                         "filesize": 444,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3516,7 +3536,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
             "complete": {
                 "filesize": 1,
                 "from": "*",
-                "hashValue": "abc",
+                "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
             }
         }
         self.releases.t.update(values=dict(read_only=True, data_version=2)).where(self.releases.name == "a").execute()
@@ -3536,7 +3557,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3561,14 +3583,16 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 1,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 },
                 "l": {
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3593,14 +3617,16 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 1,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 },
                 "l": {
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3625,21 +3651,24 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 1,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 },
                 "l": {
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 },
                 "c1": {
                     "complete": {
                         "filesize": 1,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3671,7 +3700,8 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3696,14 +3726,16 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 1,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 },
                 "l": {
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }
@@ -3728,14 +3760,16 @@ class TestReleasesSchema1(unittest.TestCase, MemoryDatabaseMixin):
                     "complete": {
                         "filesize": 12,
                         "from": "*",
-                        "hashValue": "abc"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 },
                 "l": {
                     "complete": {
                         "filesize": 1234,
                         "from": "*",
-                        "hashValue": "def"
+                        "hashValue": "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcda\
+bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
                     }
                 }
             }


### PR DESCRIPTION
* Adds a new function 'validate' to overide the Base class 'validate' function
    which also checks the length of the hashValue corresponding to the
    hashFunction (added in the ReleaseBlobBase class for appRelease blobs)
* The only classes which required overriding this common function in apprelease blobs
    were appreleaseV1 and appreleaseV2 schemas due to the switch in the
    fields format from object to array for "partial" and "complete" field
* Also contains the tests to verify the proper functioning and
    updates to previous tests which used the validate function for both the blobs
* The other blobs either don't have the hashValue field (or have been updated earlier e.g gmp) , I hope I didn't miss anything 

Sorry for the delay in this PR ;)  