### PR TITLE
Remove systemCapabilities column

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1454,7 +1454,6 @@ class Rules(AUSTable):
                            Column('locale', String(200)),
                            Column('osVersion', String(1000)),
                            Column('memory', String(100)),
-                           Column('systemCapabilities', String(1000)),
                            Column('instructionSet', String(1000)),
                            Column('distribution', String(100)),
                            Column('distVersion', String(100)),

--- a/auslib/migrate/versions/028_remove_systemCapabilities.py
+++ b/auslib/migrate/versions/028_remove_systemCapabilities.py
@@ -1,0 +1,34 @@
+from sqlalchemy import Column, String, MetaData, Table
+
+
+def upgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+
+    Table('rules', metadata, autoload=True).c.systemCapabilities.drop()
+    Table('rules_history', metadata, autoload=True).c.systemCapabilities.drop()
+    Table('rules_scheduled_changes', metadata, autoload=True).c.base_systemCapabilities.drop()
+    Table('rules_scheduled_changes_history', metadata, autoload=True).c.base_systemCapabilities.drop()
+
+
+def downgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+
+    systemCapabilities = Column("systemCapabilities", String(1000))
+    systemCapabilities.create(Table("rules", metadata, autoload=True))
+
+    history_systemCapabilities = Column("systemCapabilities", String(1000))
+    history_systemCapabilities.create(Table("rules_history", metadata, autoload=True))
+
+    base_systemCapabilities = Column("base_systemCapabilities", String(1000))
+    base_systemCapabilities.create(Table("rules_scheduled_changes", metadata, autoload=True))
+
+    base_systemCapabilities = Column("base_systemCapabilities", String(1000))
+    base_systemCapabilities.create(Table("rules_scheduled_changes_history", metadata, autoload=True))
+
+    # make a best effort to restore the data
+    conn = migrate_engine.connect()
+    conn.execute("UPDATE rules SET systemCapabilities=instructionSet;")
+    conn.execute("UPDATE rules_history SET systemCapabilities=instructionSet;")
+    conn.execute("UPDATE rules_scheduled_changes SET base_systemCapabilities=base_instructionSet;")
+    conn.execute("UPDATE rules_scheduled_changes_history SET base_systemCapabilities=base_instructionSet;")
+    conn.close()

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -23,21 +23,21 @@ class TestRulesAPI_JSON(ViewTest):
                 "update_type": "minor", "channel": "a", "data_version": 1, "comment": None, "fallbackMapping": None,
                 "version": None, "buildID": None, "locale": None, "distribution": None, "osVersion": None,
                 "instructionSet": None, "distVersion": None, "headerArchitecture": None, "alias": None,
-                "memory": None, "systemCapabilities": None,
+                "memory": None,
             },
             {
                 "rule_id": 6, "product": "fake", "priority": 40, "backgroundRate": 50, "mapping": "a", "update_type": "minor",
                 "channel": "e", "data_version": 1, "buildTarget": None, "comment": None, "fallbackMapping": None,
                 "version": None, "buildID": None, "locale": None, "distribution": None, "osVersion": None,
                 "instructionSet": None, "distVersion": None, "headerArchitecture": None, "alias": None,
-                "memory": None, "systemCapabilities": None,
+                "memory": None,
             },
             {
                 "rule_id": 7, "product": "fake", "priority": 30, "backgroundRate": 85, "mapping": "a", "update_type": "minor",
                 "channel": "c", "data_version": 1, "buildTarget": None, "comment": None, "fallbackMapping": None,
                 "version": None, "buildID": None, "locale": None, "distribution": None, "osVersion": None,
                 "instructionSet": None, "distVersion": None, "headerArchitecture": None, "alias": None,
-                "memory": None, "systemCapabilities": None,
+                "memory": None,
             }
         ]
         self.assertEquals(got["count"], 3)
@@ -272,7 +272,6 @@ class TestSingleRuleView_JSON(ViewTest):
             buildTarget="d",
             osVersion=None,
             instructionSet=None,
-            systemCapabilities=None,
             distVersion=None,
             comment=None,
             update_type="minor",
@@ -300,7 +299,6 @@ class TestSingleRuleView_JSON(ViewTest):
             buildTarget="d",
             osVersion=None,
             instructionSet=None,
-            systemCapabilities=None,
             distVersion=None,
             comment=None,
             update_type="minor",
@@ -993,7 +991,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "data_version": 1, "alias": None, "product": "a", "channel": "a", "buildID": None, "locale": None, "memory": None,
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "update", "signoffs": {}, "required_signoffs": {}, "systemCapabilities": None,
+                    "change_type": "update", "signoffs": {}, "required_signoffs": {},
                 },
                 {
                     "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
@@ -1001,7 +999,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None, "memory": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "insert", "signoffs": {}, "required_signoffs": {}, "systemCapabilities": None,
+                    "change_type": "insert", "signoffs": {}, "required_signoffs": {},
                 },
                 {
                     "sc_id": 3, "when": 2900000, "scheduled_by": "bill", "complete": False, "sc_data_version": 2, "rule_id": None, "priority": 150,
@@ -1009,7 +1007,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "insert", "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1}, "systemCapabilities": None,
+                    "change_type": "insert", "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
                 },
                 {
                     "sc_id": 5, "when": 600000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 4, "priority": None,
@@ -1017,7 +1015,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": 1, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1}, "systemCapabilities": None,
+                    "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1},
                 },
                 {
                     "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
@@ -1025,7 +1023,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "insert", "signoffs": {}, "required_signoffs": {"relman": 1}, "systemCapabilities": None,
+                    "change_type": "insert", "signoffs": {}, "required_signoffs": {"relman": 1},
                 },
                 {
                     "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
@@ -1033,7 +1031,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1}, "systemCapabilities": None,
+                    "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1},
                 },
             ],
         }
@@ -1050,7 +1048,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "data_version": 1, "alias": None, "product": "a", "channel": "a", "buildID": None, "locale": None, "memory": None,
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "update", "signoffs": {}, "required_signoffs": {}, "systemCapabilities": None,
+                    "change_type": "update", "signoffs": {}, "required_signoffs": {},
                 },
                 {
                     "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
@@ -1058,7 +1056,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None, "memory": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "insert", "signoffs": {}, "required_signoffs": {}, "systemCapabilities": None,
+                    "change_type": "insert", "signoffs": {}, "required_signoffs": {},
                 },
                 {
                     "sc_id": 3, "when": 2900000, "scheduled_by": "bill", "complete": False, "sc_data_version": 2, "rule_id": None, "priority": 150,
@@ -1066,7 +1064,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "insert", "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1}, "systemCapabilities": None,
+                    "change_type": "insert", "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
                 },
                 {
                     "sc_id": 4, "when": 500000, "scheduled_by": "bill", "complete": True, "sc_data_version": 2, "rule_id": 5, "priority": 80,
@@ -1074,7 +1072,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "data_version": 1, "alias": None, "product": None, "channel": None, "buildID": None, "locale": None, "memory": None,
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "update", "signoffs": {}, "required_signoffs": {}, "systemCapabilities": None,
+                    "change_type": "update", "signoffs": {}, "required_signoffs": {},
                 },
                 {
                     "sc_id": 5, "when": 600000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 4, "priority": None,
@@ -1082,7 +1080,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": 1, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1}, "systemCapabilities": None,
+                    "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1},
                 },
                 {
                     "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
@@ -1090,7 +1088,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "insert", "signoffs": {}, "required_signoffs": {"relman": 1}, "systemCapabilities": None,
+                    "change_type": "insert", "signoffs": {}, "required_signoffs": {"relman": 1},
                 },
                 {
                     "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
@@ -1098,7 +1096,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1}, "systemCapabilities": None,
+                    "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1},
                 },
             ],
         }
@@ -1122,7 +1120,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_mapping": "c", "base_update_type": "minor", "base_data_version": 1, "data_version": 1, "sc_id": 8, "complete": False, "base_alias": None,
             "base_product": None, "base_channel": None, "base_buildID": None, "base_locale": None, "base_osVersion": None, "base_distribution": None,
             "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None, "base_memory": None,
-            "base_instructionSet": None, "change_type": "update", "base_systemCapabilities": None,
+            "base_instructionSet": None, "change_type": "update",
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
@@ -1147,7 +1145,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_mapping": None, "base_update_type": None, "base_data_version": 1, "data_version": 1, "sc_id": 8, "complete": False, "base_alias": None,
             "base_product": None, "base_channel": None, "base_buildID": None, "base_locale": None, "base_osVersion": None, "base_distribution": None,
             "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None, "base_memory": None,
-            "base_instructionSet": None, "change_type": "delete", "base_systemCapabilities": None,
+            "base_instructionSet": None, "change_type": "delete",
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
@@ -1173,7 +1171,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_update_type": "minor", "base_mapping": "a", "sc_id": 8, "data_version": 1, "complete": False, "base_data_version": None,
             "base_rule_id": None, "base_buildTarget": None, "base_version": None, "base_alias": None, "base_buildID": None, "base_locale": None,
             "base_osVersion": None, "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None,
-            "base_comment": None, "base_instructionSet": None, "change_type": "insert", "base_memory": None, "base_systemCapabilities": None,
+            "base_comment": None, "base_instructionSet": None, "change_type": "insert", "base_memory": None,
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
@@ -1262,7 +1260,7 @@ class TestRuleScheduledChanges(ViewTest):
     def testUpdateScheduledChange(self):
         data = {
             "when": 2000000, "data_version": 1, "rule_id": 1, "priority": 100, "version": "3.5", "buildTarget": "d",
-            "backgroundRate": 100, "mapping": "c", "update_type": "minor", "sc_data_version": 1,
+            "backgroundRate": 100, "mapping": "c", "update_type": "minor", "sc_data_version": 1, "memory": "888",
         }
         ret = self._post("/scheduled_changes/rules/1", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
@@ -1276,8 +1274,8 @@ class TestRuleScheduledChanges(ViewTest):
             "base_mapping": "c", "base_update_type": "minor", "base_data_version": 1, "base_alias": None,
             "base_product": "a", "base_channel": "a", "base_buildID": None, "base_locale": None, "base_osVersion": None,
             "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None,
-            "base_headerArchitecture": None, "base_comment": None, "base_instructionSet": None, "base_memory": None,
-            "change_type": "update", "base_systemCapabilities": None,
+            "base_headerArchitecture": None, "base_comment": None, "base_instructionSet": None, "base_memory": "888",
+            "change_type": "update",
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 1).execute().fetchall()
@@ -1304,7 +1302,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_backgroundRate": 100, "base_mapping": "c", "base_update_type": "minor", "base_data_version": 1,
             "base_alias": None, "base_product": "a", "base_channel": "a", "base_buildID": None, "base_locale": None,
             "base_osVersion": None, "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None, "base_memory": None,
-            "base_headerArchitecture": None, "base_comment": None, "base_instructionSet": None, "change_type": "update", "base_systemCapabilities": None,
+            "base_headerArchitecture": None, "base_comment": None, "base_instructionSet": None, "change_type": "update",
         }
         self.assertEquals(db_data, expected)
 
@@ -1348,7 +1346,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None,
             "base_headerArchitecture": None, "base_comment": None, "base_memory": None,
             "base_instructionSet": None, "base_version": None, "base_rule_id": None, "base_buildTarget": None,
-            "change_type": "insert", "base_systemCapabilities": None,
+            "change_type": "insert",
         }
         self.assertEquals(db_data, expected)
         rows = dbo.rules.scheduled_changes.signoffs.t.select().where(
@@ -1405,7 +1403,7 @@ class TestRuleScheduledChanges(ViewTest):
             "rule_id": 1, "priority": 100, "version": "3.5", "buildTarget": "d", "backgroundRate": 100, "mapping": "b", "fallbackMapping": None,
             "update_type": "minor", "data_version": 2, "alias": None, "product": "a", "channel": "a", "buildID": None,
             "locale": None, "osVersion": None, "distribution": None, "distVersion": None, "headerArchitecture": None,
-            "comment": None, "instructionSet": None, "memory": None, "systemCapabilities": None,
+            "comment": None, "instructionSet": None, "memory": None,
         }
         self.assertEquals(dict(row), expected)
 
@@ -1421,7 +1419,7 @@ class TestRuleScheduledChanges(ViewTest):
             "rule_id": 8, "priority": 50, "version": None, "buildTarget": None, "backgroundRate": 100, "mapping": "ab", "fallbackMapping": None,
             "update_type": "minor", "data_version": 1, "alias": None, "product": "baz", "channel": None, "buildID": None,
             "locale": None, "osVersion": None, "distribution": None, "distVersion": None, "headerArchitecture": None,
-            "comment": None, "instructionSet": None, "memory": None, "systemCapabilities": None,
+            "comment": None, "instructionSet": None, "memory": None,
         }
         self.assertEquals(dict(row), expected)
 
@@ -1441,7 +1439,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "complete": False, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "rule_id": None,
                     "version": None, "product": None, "buildTarget": None, "buildID": None, "locale": None,
                     "osVersion": None, "instructionSet": None, "distribution": None, "distVersion": None, "memory": None,
-                    "headerArchitecture": None, "comment": None, "alias": None, "data_version": None, "change_type": "insert", "systemCapabilities": None,
+                    "headerArchitecture": None, "comment": None, "alias": None, "data_version": None, "change_type": "insert",
                 },
                 {
                     "change_id": 2, "changed_by": "bill", "timestamp": 6, "sc_id": 3, "scheduled_by": "bill", "when": 2000000, "sc_data_version": 1,
@@ -1449,7 +1447,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "complete": False, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "rule_id": None,
                     "version": None, "product": None, "buildTarget": None, "buildID": None, "locale": None,
                     "osVersion": None, "instructionSet": None, "distribution": None, "distVersion": None, "memory": None,
-                    "headerArchitecture": None, "comment": None, "alias": None, "data_version": None, "change_type": "insert", "systemCapabilities": None,
+                    "headerArchitecture": None, "comment": None, "alias": None, "data_version": None, "change_type": "insert",
                 },
             ],
         }
@@ -1469,7 +1467,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_backgroundRate": 100, "base_channel": "a", "base_mapping": "def", "base_update_type": "minor", "base_version": None,
             "base_buildTarget": None, "base_alias": None, "base_product": None, "base_buildID": None, "base_locale": None, "base_osVersion": None,
             "base_distribution": None, 'base_fallbackMapping': None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None,
-            "base_data_version": None, "base_instructionSet": None, "base_memory": None, "change_type": "insert", "base_systemCapabilities": None,
+            "base_data_version": None, "base_instructionSet": None, "base_memory": None, "change_type": "insert",
         }
         self.assertEquals(db_data, expected)
         self.assertEquals(dbo.rules.scheduled_changes.conditions.history.t.count().execute().first()[0], 16)

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1911,7 +1911,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         expected = ["rule_id", "alias", "priority", "mapping", "fallbackMapping", "backgroundRate", "update_type",
                     "product", "version", "channel", "buildTarget", "buildID", "locale", "osVersion",
                     "instructionSet", "distribution", "distVersion", "headerArchitecture", "comment",
-                    "data_version", "memory", "systemCapabilities"]
+                    "data_version", "memory"]
         sc_expected = ["base_{}".format(c) for c in expected]
         self.assertEquals(set(columns), set(expected))
         # No need to test the non-base parts of history nor scheduled changes table

--- a/auslib/test/web/api/test_rules.py
+++ b/auslib/test/web/api/test_rules.py
@@ -39,8 +39,7 @@ class TestPublicRulesAPI(CommonTestBase):
                         channel=None, comment=None, distVersion=None,
                         distribution=None, fallbackMapping=None,
                         headerArchitecture=None, locale=None, version=None,
-                        osVersion=None, memory=None, instructionSet=None,
-                        systemCapabilities=None)
+                        osVersion=None, memory=None, instructionSet=None)
         ret = self.public_client.get("/api/v1/rules/moz-releng")
         self.assertEqual(ret.status_code, 200, ret.data)
         got = json.loads(ret.data)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -5,7 +5,7 @@
 docker build  -t balrogtest -f Dockerfile.dev .
 # When running in Taskcluster, we want to send coverage data. To do that we need the repo token
 # that is stored in the Secrets Service. We cannot access that from within the test container,
-# so we must do it here, and that pass it in.
+# so we must do it here, and that pass it in
 COVERALLS_REPO_TOKEN=""
 if [[ $GITHUB_BASE_REPO_URL == "https://github.com/mozilla/balrog.git" ]];
 then


### PR DESCRIPTION
This is part 3 of 3 to give us a smooth update path for #346. It is built on top of #348 and #349 and simply removes the last remnants of the systemCapabilities column.