### PR TITLE
Fix bug with scheduled deletes

### DIFF
--- a/agent/balrogagent/cmd.py
+++ b/agent/balrogagent/cmd.py
@@ -28,7 +28,9 @@ async def run_agent(loop, balrog_api_root, balrog_username, balrog_password, tel
                                             auth=auth, loop=loop)
                 sc = (await resp.json())["scheduled_changes"]
                 if endpoint == 'rules':
-                    sc = sorted(sc, key=lambda k: (k["priority"], k["when"]), reverse=True)
+                    # Rules are sorted by priority, when available. Deletions will not have
+                    # a priority set, so we treat them as the lowest priority possible.
+                    sc = sorted(sc, key=lambda k: (k["when"], k["priority"] or 0), reverse=True)
                 resp.close()
                 logging.debug("Found %s", len(sc))
                 for change in sc:

--- a/agent/balrogagent/test/test_cmd.py
+++ b/agent/balrogagent/test/test_cmd.py
@@ -235,7 +235,9 @@ class TestRunAgent(asynctest.TestCase):
                             "telemetry_product": None, "telemetry_channel": None}],
               'rules': [{"priority": 100, "sc_id": 1, "when": 23400, "telemetry_uptake": None,
                          "telemetry_product": None, "telemetry_channel": None},
-                        {"priority": 300, "sc_id": 2, "when": 7000, "telemetry_uptake": None,
+                        {"priority": None, "sc_id": 2, "when": 7000, "telemetry_uptake": None,
+                         "telemetry_product": None, "telemetry_channel": None},
+                        {"priority": 70, "sc_id": 4, "when": 7000, "telemetry_uptake": None,
                          "telemetry_product": None, "telemetry_channel": None},
                         {"priority": 50, "sc_id": 3, "when": 329, "telemetry_uptake": None,
                          "telemetry_product": None, "telemetry_channel": None}],
@@ -249,9 +251,10 @@ class TestRunAgent(asynctest.TestCase):
               }
         await self._runAgent(sc, request)
         self.assertEquals(telemetry_is_ready.call_count, 0)
-        self.assertEquals(time_is_ready.call_count, 10)
-        self.assertEquals(request.call_count, 15)
+        self.assertEquals(time_is_ready.call_count, 11)
+        self.assertEquals(request.call_count, 16)
         called_endpoints = [call[0][1] for call in request.call_args_list]
         self.assertLess(called_endpoints.index('/scheduled_changes/rules'), called_endpoints.index('/scheduled_changes/releases'))
-        self.assertLess(called_endpoints.index('/scheduled_changes/rules/2/enact'), called_endpoints.index('/scheduled_changes/rules/1/enact'))
-        self.assertLess(called_endpoints.index('/scheduled_changes/rules/1/enact'), called_endpoints.index('/scheduled_changes/rules/3/enact'))
+        self.assertLess(called_endpoints.index('/scheduled_changes/rules/1/enact'), called_endpoints.index('/scheduled_changes/rules/4/enact'))
+        self.assertLess(called_endpoints.index('/scheduled_changes/rules/4/enact'), called_endpoints.index('/scheduled_changes/rules/2/enact'))
+        self.assertLess(called_endpoints.index('/scheduled_changes/rules/2/enact'), called_endpoints.index('/scheduled_changes/rules/3/enact'))


### PR DESCRIPTION
Fallout from https://bugzilla.mozilla.org/show_bug.cgi?id=1304026 - scheduled deletes to rules stopped working because priority is set to None. I also fixed the sort order to consider "when" ahead of "priority".