### PR TITLE
bug 1384269: Fix revocation when more than one signoff has already happened.

### DIFF
--- a/auslib/web/admin/views/scheduled_changes.py
+++ b/auslib/web/admin/views/scheduled_changes.py
@@ -164,15 +164,16 @@ class SignoffsView(AdminView):
 
     @requirelogin
     def _delete(self, sc_id, transaction, changed_by):
-        where = {"sc_id": sc_id}
-        signoff = self.signoffs_table.select(where, transaction)
-        if not signoff:
-            return Response(status=404, response="{} has no signoff to revoke".format(changed_by))
-
         form = Form(request.args)
         if not form.validate():
             self.log.warning("Bad input: %s", form.errors)
             return Response(status=400, response=json.dumps(form.errors))
+
+        username = request.args.get("username", changed_by)
+        where = {"sc_id": sc_id, "username": username}
+        signoff = self.signoffs_table.select(where, transaction)
+        if not signoff:
+            return Response(status=404, response="{} has no signoff to revoke".format(changed_by))
 
         self.signoffs_table.delete(where, changed_by=changed_by, transaction=transaction)
         return Response(status=200)


### PR DESCRIPTION
I discovered this while investigating https://bugzilla.mozilla.org/show_bug.cgi?id=1383948. Basically, we never include username in the "where" clause for delete() when revoking signoffs. Non-admin users typically end up with this PermissionDeniedError: https://github.com/mozilla/balrog/blob/efb35a236768cc1dac6a1335c1a743b92764a737/auslib/db.py#L1433 -- because they try to revoke a signoff for a group they aren't a part of.

Admin users will end up getting a WrongNumberOfRowsError, because the eventually delete() tries to remove multiple rows at once, and we don't allow that.

In both cases, the fix is simple: include username in the where clause. The patch is complicated slightly be the fact that we allow admin users to revoke anyone's signoff. With this patch, the API supports it, although there's no UI built for it. @aksareen - I think this may require a small change to #355 once merged.