### PR TITLE
Replacing request.json with request.get_json() to stop deprecation warnings in logs

### DIFF
--- a/auslib/web/admin/views/permissions.py
+++ b/auslib/web/admin/views/permissions.py
@@ -73,16 +73,16 @@ class SpecificPermissionView(AdminView):
         try:
             if dbo.permissions.getUserPermissions(username, transaction).get(permission):
                 # Existing Permission
-                if not connexion.request.json.get("data_version"):
+                if not connexion.request.get_json().get("data_version"):
                     return problem(400, "Bad Request", "'data_version' is missing from request body")
 
                 options_dict = None
-                if connexion.request.json.get("options"):
-                    options_dict = json.loads(connexion.request.json.get("options"))
+                if connexion.request.get_json().get("options"):
+                    options_dict = json.loads(connexion.request.get_json().get("options"))
 
                 dbo.permissions.update(where={"username": username, "permission": permission},
                                        what={"options": options_dict}, changed_by=changed_by,
-                                       old_data_version=connexion.request.json.get("data_version"),
+                                       old_data_version=connexion.request.get_json().get("data_version"),
                                        transaction=transaction)
                 new_data_version = dbo.permissions.getPermission(username=username, permission=permission,
                                                                  transaction=transaction)['data_version']
@@ -90,8 +90,8 @@ class SpecificPermissionView(AdminView):
             else:
                 # New Permission
                 options_dict = None
-                if connexion.request.json.get("options"):
-                    options_dict = json.loads(connexion.request.json.get("options"))
+                if connexion.request.get_json().get("options"):
+                    options_dict = json.loads(connexion.request.get_json().get("options"))
                 dbo.permissions.insert(changed_by, transaction=transaction, username=username, permission=permission,
                                        options=options_dict)
                 return Response(status=201, response=json.dumps(dict(new_data_version=1)))
@@ -106,15 +106,15 @@ class SpecificPermissionView(AdminView):
                                                                  " %s not found for %s" % (permission, username))
         try:
             # Existing Permission
-            if not connexion.request.json.get("data_version"):
+            if not connexion.request.get_json().get("data_version"):
                 return problem(400, "Bad Request", "'data_version' is missing from request body")
             options_dict = None
-            if connexion.request.json.get("options"):
-                options_dict = json.loads(connexion.request.json.get("options"))
+            if connexion.request.get_json().get("options"):
+                options_dict = json.loads(connexion.request.get_json().get("options"))
 
             dbo.permissions.update(where={"username": username, "permission": permission},
                                    what={"options": options_dict}, changed_by=changed_by,
-                                   old_data_version=connexion.request.json.get("data_version"),
+                                   old_data_version=connexion.request.get_json().get("data_version"),
                                    transaction=transaction)
             new_data_version = dbo.permissions.getPermission(username=username, permission=permission,
                                                              transaction=transaction)['data_version']
@@ -150,14 +150,14 @@ class PermissionScheduledChangesView(ScheduledChangesView):
 
     @requirelogin
     def _post(self, transaction, changed_by):
-        change_type = connexion.request.json.get("change_type")
+        change_type = connexion.request.get_json().get("change_type")
 
         what = {}
-        for field in connexion.request.json:
+        for field in connexion.request.get_json():
             if field == "csrf_token":
                 continue
 
-            what[field] = connexion.request.json[field]
+            what[field] = connexion.request.get_json()[field]
 
         if what.get("options", None):
             what["options"] = json.loads(what.get("options"))
@@ -177,7 +177,7 @@ class PermissionScheduledChangeView(ScheduledChangeView):
 
     @requirelogin
     def _post(self, sc_id, transaction, changed_by):
-        if connexion.request.json and connexion.request.json.get("data_version"):
+        if connexion.request.get_json() and connexion.request.get_json().get("data_version"):
             form = EditScheduledChangeExistingPermissionForm()
         else:
             form = EditScheduledChangeNewPermissionForm()

--- a/auslib/web/admin/views/releases.py
+++ b/auslib/web/admin/views/releases.py
@@ -76,32 +76,32 @@ def changeRelease(release, changed_by, transaction, existsCallback, commitCallba
                               - the old_data_version from the PartialReleaseForm
     """
     new = True
-    product = connexion.request.json.get("product")
-    incomingData = json.loads(connexion.request.json.get("data"))
+    product = connexion.request.get_json().get("product")
+    incomingData = json.loads(connexion.request.get_json().get("data"))
 
     copyTo = list()
-    if connexion.request.json.get("copyTo"):
-        copyTo = json.loads(connexion.request.json.get("copyTo"))
+    if connexion.request.get_json().get("copyTo"):
+        copyTo = json.loads(connexion.request.get_json().get("copyTo"))
 
     alias = list()
-    if connexion.request.json.get("alias"):
-        alias = json.loads(connexion.request.json.get("alias"))
+    if connexion.request.get_json().get("alias"):
+        alias = json.loads(connexion.request.get_json().get("alias"))
 
-    old_data_version = connexion.request.json.get("data_version")
+    old_data_version = connexion.request.get_json().get("data_version")
 
     # schema_version is an attribute at the root level of a blob.
     # Endpoints that receive an entire blob can find it there.
     # Those that don't have to pass it as a form element instead.
 
-    if connexion.request.json.get("schema_version"):
-        schema_version = connexion.request.json.get("schema_version")
+    if connexion.request.get_json().get("schema_version"):
+        schema_version = connexion.request.get_json().get("schema_version")
     elif incomingData.get("schema_version"):
         schema_version = incomingData.get("schema_version")
     else:
         return problem(400, "Bad Request", "schema_version is required")
 
-    if connexion.request.json.get("hashFunction"):
-        hashFunction = connexion.request.json.get("hashFunction")
+    if connexion.request.get_json().get("hashFunction"):
+        hashFunction = connexion.request.get_json().get("hashFunction")
     elif incomingData.get("hashFunction"):
         hashFunction = incomingData.get("hashFunction")
     else:
@@ -240,13 +240,13 @@ class SingleReleaseView(AdminView):
     @requirelogin
     def _put(self, release, changed_by, transaction):
         if dbo.releases.getReleases(name=release, limit=1):
-            if not connexion.request.json.get("data_version"):
+            if not connexion.request.get_json().get("data_version"):
                 return problem(400, "Bad Request", "data_version field is missing")
             try:
-                blob = createBlob(connexion.request.json.get("blob"))
+                blob = createBlob(connexion.request.get_json().get("blob"))
                 dbo.releases.update(where={"name": release},
-                                    what={"data": blob, "product": connexion.request.json.get("product")},
-                                    changed_by=changed_by, old_data_version=connexion.request.json.get("data_version"),
+                                    what={"data": blob, "product": connexion.request.get_json().get("product")},
+                                    changed_by=changed_by, old_data_version=connexion.request.get_json().get("data_version"),
                                     transaction=transaction)
             except BlobValidationError as e:
                 msg = "Couldn't update release: %s" % e
@@ -267,9 +267,9 @@ class SingleReleaseView(AdminView):
             return jsonify(new_data_version=data_version)
         else:
             try:
-                blob = createBlob(connexion.request.json.get("blob"))
+                blob = createBlob(connexion.request.get_json().get("blob"))
                 dbo.releases.insert(changed_by=changed_by, transaction=transaction, name=release,
-                                    product=connexion.request.json.get("product"), data=blob)
+                                    product=connexion.request.get_json().get("product"), data=blob)
             except BlobValidationError as e:
                 msg = "Couldn't update release: %s" % e
                 self.log.warning("Bad input: %s", msg)
@@ -336,10 +336,10 @@ class ReleaseReadOnlyView(AdminView):
         if not releases:
             return problem(404, "Not Found", "Release: %s not found" % release)
 
-        data_version = connexion.request.json.get("data_version")
+        data_version = connexion.request.get_json().get("data_version")
         is_release_read_only = dbo.releases.isReadOnly(release)
 
-        if connexion.request.json.get("read_only"):
+        if connexion.request.get_json().get("read_only"):
             if not is_release_read_only:
                 dbo.releases.update(where={"name": release}, what={"read_only": True}, changed_by=changed_by,
                                     old_data_version=data_version, transaction=transaction)
@@ -464,15 +464,15 @@ class ReleasesAPIView(AdminView):
 
     @requirelogin
     def _post(self, changed_by, transaction):
-        if dbo.releases.getReleaseInfo(name=connexion.request.json.get("name"), transaction=transaction, nameOnly=True,
+        if dbo.releases.getReleaseInfo(name=connexion.request.get_json().get("name"), transaction=transaction, nameOnly=True,
                                        limit=1):
-            return problem(400, "Bad Request", "Release: %s already exists" % connexion.request.json.get("name"),
+            return problem(400, "Bad Request", "Release: %s already exists" % connexion.request.get_json().get("name"),
                            ext={"data": "Database already contains the release"})
         try:
-            blob = createBlob(connexion.request.json.get("blob"))
+            blob = createBlob(connexion.request.get_json().get("blob"))
             name = dbo.releases.insert(changed_by=changed_by, transaction=transaction,
-                                       name=connexion.request.json.get("name"),
-                                       product=connexion.request.json.get("product"),
+                                       name=connexion.request.get_json().get("name"),
+                                       product=connexion.request.get_json().get("product"),
                                        data=blob)
         except BlobValidationError as e:
             msg = "Couldn't create release: %s" % e
@@ -516,13 +516,13 @@ class ReleaseScheduledChangesView(ScheduledChangesView):
 
     @requirelogin
     def _post(self, transaction, changed_by):
-        change_type = connexion.request.json.get("change_type")
+        change_type = connexion.request.get_json().get("change_type")
 
         what = {}
-        for field in connexion.request.json:
+        for field in connexion.request.get_json():
             if field == "csrf_token":
                 continue
-            what[field] = connexion.request.json[field]
+            what[field] = connexion.request.get_json()[field]
 
         if change_type == "update":
             if not what.get("data_version", None):
@@ -553,7 +553,7 @@ class ReleaseScheduledChangeView(ScheduledChangeView):
 
     @requirelogin
     def _post(self, sc_id, transaction, changed_by):
-        change_type = connexion.request.json.get("change_type")
+        change_type = connexion.request.get_json().get("change_type")
 
         if change_type == "update":
             form = EditScheduledChangeExistingReleaseForm()

--- a/auslib/web/admin/views/required_signoffs.py
+++ b/auslib/web/admin/views/required_signoffs.py
@@ -88,10 +88,10 @@ class ProductRequiredSignoffsView(RequiredSignoffsView):
 
     @requirelogin
     def _post(self, transaction, changed_by):
-        what = {"product": connexion.request.json.get("product"),
-                "channel": connexion.request.json.get("channel"),
-                "role": connexion.request.json.get("role"),
-                "signoffs_required": int(connexion.request.json.get("signoffs_required")),
+        what = {"product": connexion.request.get_json().get("product"),
+                "channel": connexion.request.get_json().get("channel"),
+                "role": connexion.request.get_json().get("role"),
+                "signoffs_required": int(connexion.request.get_json().get("signoffs_required")),
                 }
         return super(ProductRequiredSignoffsView, self)._post(what, transaction, changed_by)
 
@@ -117,13 +117,13 @@ class ProductRequiredSignoffsScheduledChangesView(ScheduledChangesView):
 
     @requirelogin
     def _post(self, transaction, changed_by):
-        change_type = connexion.request.json.get("change_type")
+        change_type = connexion.request.get_json().get("change_type")
 
         what = {}
-        for field in connexion.request.json:
+        for field in connexion.request.get_json():
             if field == "csrf_token":
                 continue
-            what[field] = connexion.request.json[field]
+            what[field] = connexion.request.get_json()[field]
 
         if change_type == "update":
             for field in ["signoffs_required", "data_version"]:
@@ -154,7 +154,7 @@ class ProductRequiredSignoffScheduledChangeView(ScheduledChangeView):
 
     @requirelogin
     def _post(self, sc_id, transaction, changed_by):
-        if connexion.request.json and connexion.request.json.get("data_version"):
+        if connexion.request.get_json() and connexion.request.get_json().get("data_version"):
             form = EditScheduledChangeExistingProductRequiredSignoffForm()
         else:
             form = EditScheduledChangeNewProductRequiredSignoffForm()
@@ -201,9 +201,9 @@ class PermissionsRequiredSignoffsView(RequiredSignoffsView):
 
     @requirelogin
     def _post(self, transaction, changed_by):
-        what = {"product": connexion.request.json.get("product"),
-                "role": connexion.request.json.get("role"),
-                "signoffs_required": int(connexion.request.json.get("signoffs_required")),
+        what = {"product": connexion.request.get_json().get("product"),
+                "role": connexion.request.get_json().get("role"),
+                "signoffs_required": int(connexion.request.get_json().get("signoffs_required")),
                 }
         return super(PermissionsRequiredSignoffsView, self)._post(what, transaction, changed_by)
 
@@ -227,13 +227,13 @@ class PermissionsRequiredSignoffsScheduledChangesView(ScheduledChangesView):
 
     @requirelogin
     def _post(self, transaction, changed_by):
-        change_type = connexion.request.json.get("change_type")
+        change_type = connexion.request.get_json().get("change_type")
 
         what = {}
-        for field in connexion.request.json:
+        for field in connexion.request.get_json():
             if field == "csrf_token":
                 continue
-            what[field] = connexion.request.json[field]
+            what[field] = connexion.request.get_json()[field]
 
         if change_type == "update":
             for field in ["signoffs_required", "data_version"]:
@@ -264,7 +264,7 @@ class PermissionsRequiredSignoffScheduledChangeView(ScheduledChangeView):
 
     @requirelogin
     def _post(self, sc_id, transaction, changed_by):
-        if connexion.request.json and connexion.request.json.get("data_version"):
+        if connexion.request.get_json() and connexion.request.get_json().get("data_version"):
             form = EditScheduledChangeExistingPermissionsRequiredSignoffForm()
         else:
             form = EditScheduledChangeNewPermissionsRequiredSignoffForm()

--- a/auslib/web/admin/views/scheduled_changes.py
+++ b/auslib/web/admin/views/scheduled_changes.py
@@ -107,7 +107,7 @@ class ScheduledChangeView(AdminView):
             # from the rule (aka, set as NULL in the db). The underlying Form
             # will have already converted it to None, so we can treat it the
             # same as a modification here.
-            if connexion.request.json and k in connexion.request.json:
+            if connexion.request.get_json() and k in connexion.request.get_json():
                 what[k] = v.data
 
         where = {"sc_id": sc_id}
@@ -152,7 +152,7 @@ class SignoffsView(AdminView):
 
     @requirelogin
     def _post(self, sc_id, transaction, changed_by):
-        what = {"role": connexion.request.json.get("role")}
+        what = {"role": connexion.request.get_json().get("role")}
         self.signoffs_table.insert(changed_by, transaction, sc_id=sc_id, **what)
         return Response(status=200)
 


### PR DESCRIPTION
Recent upgrade of flask and its dependencies resulted in newer version of flask wrapper request.json getting deprecated. Hence the PR to prevent the warning from getting continuously logged for almost every single API request. Though the warning has been removed in a recent PR in the pallets/flask repository but the change hasn't been publicly released yet. Here's the [link](https://github.com/pallets/flask/commit/5bc0d15359b73afcb324eb696f9caeb362efa7cc#diff-19c8e0492e54e949ac9617eb6e6c5d47L51) to the warning code.