### PR TITLE
Revert #363  "Bug 1380605 - add new OpenH264 download host to whitelists"

### DIFF
--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -10,7 +10,6 @@ DOMAIN_WHITELIST = {
     "download.cdn.mozilla.net": ("Firefox", "Fennec", "SeaMonkey"),
     "mozilla-nightly-updates.s3.amazonaws.com": ("Firefox",),
     "ciscobinary.openh264.org": ("OpenH264",),
-    "c7ab4fbd1155b1257820-fefb1450afc680271ea365edabf976ea.ssl.cf1.rackcdn.com": ("OpenH264",),
     "cdmdownload.adobe.com": ("CDM",),
     "clients2.googleusercontent.com": ("Widevine",),
     "redirector.gvt1.com": ("Widevine",),

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -12,7 +12,6 @@ DOMAIN_WHITELIST = {
     "download.cdn.mozilla.net": ("Firefox", "Fennec", "SeaMonkey"),
     "mozilla-nightly-updates.s3.amazonaws.com": ("Firefox",),
     "ciscobinary.openh264.org": ("OpenH264",),
-    "c7ab4fbd1155b1257820-fefb1450afc680271ea365edabf976ea.ssl.cf1.rackcdn.com": ("OpenH264",),
     "cdmdownload.adobe.com": ("CDM",),
     "clients2.googleusercontent.com": ("Widevine",),
     "redirector.gvt1.com": ("Widevine",),


### PR DESCRIPTION
This reverts commit 2e0517ac2d0fce1c8449527eec4f15cc653ef43b because of change of plans at partner.