### PR TITLE
improves query matching #1379244

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1487,11 +1487,21 @@ class Rules(AUSTable):
     def _matchesRegex(self, foo, bar):
         # Expand wildcards and use ^/$ to make sure we don't succeed on partial
         # matches. Eg, 3.6* matches 3.6, 3.6.1, 3.6b3, etc.
-        test = foo.replace('.', '\.').replace('*', '.*')
-        test = '^%s$' % test
-        if re.match(test, bar):
+        # Channel length must be strictly greater than two
+        # And globbing is allowed at the end of channel-name only
+        if foo.endswith('*'):
+            if(len(foo) >= 3):
+                test = foo.replace('.', '\.').replace('*', '\*', foo.count('*') - 1)
+                test = '^{}.*$'.format(test[:-1])
+                if re.match(test, bar):
+                    return True
+                return False
+            else:
+                return False
+        elif (foo == bar):
             return True
-        return False
+        else:
+            return False
 
     def _channelMatchesRule(self, ruleChannel, queryChannel, fallbackChannel):
         """Decides whether a channel from the rules matches an incoming one.

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -2710,7 +2710,7 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.releases.t.update(values=dict(read_only=True, data_version=2)).where(self.releases.name == "a").execute()
         self.assertRaises(ReadOnlyError, self.releases._proceedIfNotReadOnly, 'a')
 
-    def testGetRulesMatchingQueryChannelImprovedGlobbing(self):
+    def testGetRulesMatchingQueryChannelCheckMinLengthGlobbing(self):
         # To ensure length of ruleChannel is >=3
         expected = []
         rules = self.rules.getRulesMatchingQuery(
@@ -2724,10 +2724,25 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         rules = self._stripNullColumns(rules)
         self.assertEquals(rules, expected)
 
-        # To ensure globbing at end only
+    def testtestGetRulesMatchingQueryChannelGlobbingAtEndPass(self):
+        # To ensure globbing at end only -- Pass case
         expected = [dict(rule_id=6, priority=100, backgroundRate=100, channel='r*test*', update_type='z', data_version=1)]
         rules = self.rules.getRulesMatchingQuery(
             dict(name='', product='', version='3.0', channel='r*test-cck-blah',
+                 buildTarget='', buildID='', locale='', osVersion='', distribution='',
+                 distVersion='', headerArchitecture='',
+                 force=False, queryVersion=3,
+                 ),
+            fallbackChannel='releasetest'
+        )
+        rules = self._stripNullColumns(rules)
+        self.assertEquals(rules, expected)
+
+    def testtestGetRulesMatchingQueryChannelGlobbingAtEndFail(self):
+        # To ensure globbing at end only -- Fail case
+        expected = []
+        rules = self.rules.getRulesMatchingQuery(
+            dict(name='', product='', version='3.0', channel='raaatest',
                  buildTarget='', buildID='', locale='', osVersion='', distribution='',
                  distVersion='', headerArchitecture='',
                  force=False, queryVersion=3,

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -2422,6 +2422,32 @@ class TestRulesSpecial(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         rules = self._stripNullColumns(rules)
         self.assertEquals(rules, expected)
 
+        # To ensure length of ruleChannel is >=3
+        expected = [dict(rule_id=2, priority=100, backgroundRate=100, channel='r*', update_type='z', data_version=1)]
+        rules = self.rules.getRulesMatchingQuery(
+            dict(name='', product='', version='3.0', channel='releasetest',
+                 buildTarget='', buildID='', locale='', osVersion='', distribution='',
+                 distVersion='', headerArchitecture='',
+                 force=False, queryVersion=3,
+                 ),
+            fallbackChannel='releasetest'
+        )
+        rules = self._stripNullColumns(rules)
+        self.assertNotEquals(rules, expected)
+
+        # To ensure globbing at end only
+        expected = [dict(rule_id=2, priority=100, backgroundRate=100, channel='r*test*', update_type='z', data_version=1)]
+        rules = self.rules.getRulesMatchingQuery(
+            dict(name='', product='', version='3.0', channel='releasetest-cck-blah',
+                 buildTarget='', buildID='', locale='', osVersion='', distribution='',
+                 distVersion='', headerArchitecture='',
+                 force=False, queryVersion=3,
+                 ),
+            fallbackChannel='releasetest'
+        )
+        rules = self._stripNullColumns(rules)
+        self.assertNotEquals(rules, expected)
+
     def testGetRulesMatchingBuildIDComparison(self):
         expected = [dict(rule_id=3, priority=100, backgroundRate=100, buildID='>=20010101222222', update_type='z', data_version=1)]
         rules = self.rules.getRulesMatchingQuery(


### PR DESCRIPTION
Presently `_matchesRegex` provides too much freedom this tries to limit that.