### PR TITLE
bug 1386756: add support for mig64 query parameter

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1466,8 +1466,10 @@ class Rules(AUSTable):
             self.table.append_column(Column("mig64", BIT))
         else:
             # It's not ideal to disable the constraint here, but if we leave it enabled
-            # the database cannot be downgraded (t
-            self.table.append_column(Column("mig64", Boolean(create_constraint=False)))
+            # the database cannot be downgraded (dropping the column will try to remove
+            # the column, but not the constraint). This is sqlite-only, so it only
+            # applies to unit tests, not deployed instances.
+            self.table.append_column(Column("mig64", Integer))
 
         AUSTable.__init__(self, db, dialect, scheduled_changes=True)
 

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1461,6 +1461,14 @@ class Rules(AUSTable):
                            Column('comment', String(500)),
                            )
 
+        if dialect == 'mysql':
+            from sqlalchemy.dialects.mysql import BIT
+            self.table.append_column(Column("mig64", BIT))
+        else:
+            # It's not ideal to disable the constraint here, but if we leave it enabled
+            # the database cannot be downgraded (t
+            self.table.append_column(Column("mig64", Boolean(create_constraint=False)))
+
         AUSTable.__init__(self, db, dialect, scheduled_changes=True)
 
     def getPotentialRequiredSignoffs(self, affected_rows, transaction=None):

--- a/auslib/migrate/versions/029_add_mig64.py
+++ b/auslib/migrate/versions/029_add_mig64.py
@@ -1,27 +1,21 @@
 from sqlalchemy import Column, MetaData, Table
 
+from auslib.db import CompatibleBooleanColumn
+
 
 def upgrade(migrate_engine):
     metadata = MetaData(bind=migrate_engine)
 
-    def get_column_type():
-        if migrate_engine.name == "mysql":
-            from sqlalchemy.dialects.mysql import BIT
-            return BIT
-        else:
-            from sqlalchemy import Integer
-            return Integer
-
-    mig64 = Column("mig64", get_column_type())
+    mig64 = Column("mig64", CompatibleBooleanColumn)
     mig64.create(Table("rules", metadata, autoload=True))
 
-    history_mig64 = Column("mig64", get_column_type())
+    history_mig64 = Column("mig64", CompatibleBooleanColumn)
     history_mig64.create(Table("rules_history", metadata, autoload=True))
 
-    base_mig64 = Column("base_mig64", get_column_type())
+    base_mig64 = Column("base_mig64", CompatibleBooleanColumn)
     base_mig64.create(Table("rules_scheduled_changes", metadata, autoload=True))
 
-    base_mig64 = Column("base_mig64", get_column_type())
+    base_mig64 = Column("base_mig64", CompatibleBooleanColumn)
     base_mig64.create(Table("rules_scheduled_changes_history", metadata, autoload=True))
 
 

--- a/auslib/migrate/versions/029_add_mig64.py
+++ b/auslib/migrate/versions/029_add_mig64.py
@@ -9,8 +9,8 @@ def upgrade(migrate_engine):
             from sqlalchemy.dialects.mysql import BIT
             return BIT
         else:
-            from sqlalchemy import Boolean
-            return Boolean(create_constraint=False)
+            from sqlalchemy import Integer
+            return Integer
 
     mig64 = Column("mig64", get_column_type())
     mig64.create(Table("rules", metadata, autoload=True))
@@ -24,23 +24,9 @@ def upgrade(migrate_engine):
     base_mig64 = Column("base_mig64", get_column_type())
     base_mig64.create(Table("rules_scheduled_changes_history", metadata, autoload=True))
 
-    c = Table("rules", metadata, autoload=True)
-    print c
-    print dir(c)
-    print c.constraints
-    print [x for x in c.constraints]
-
 
 def downgrade(migrate_engine):
     metadata = MetaData(bind=migrate_engine)
-    c = Table("rules", metadata, autoload=True)
-    print c
-    print dir(c)
-    print c.constraints
-    print [x for x in c.constraints]
-    print [dir(x) for x in c.constraints]
-    print "names"
-    print [x.name for x in c.constraints]
     Table('rules', metadata, autoload=True).c.mig64.drop()
     Table('rules_history', metadata, autoload=True).c.mig64.drop()
     Table('rules_scheduled_changes', metadata, autoload=True).c.base_mig64.drop()

--- a/auslib/migrate/versions/029_add_mig64.py
+++ b/auslib/migrate/versions/029_add_mig64.py
@@ -15,8 +15,8 @@ def upgrade(migrate_engine):
     base_mig64 = Column("base_mig64", CompatibleBooleanColumn)
     base_mig64.create(Table("rules_scheduled_changes", metadata, autoload=True))
 
-    base_mig64 = Column("base_mig64", CompatibleBooleanColumn)
-    base_mig64.create(Table("rules_scheduled_changes_history", metadata, autoload=True))
+    history_base_mig64 = Column("base_mig64", CompatibleBooleanColumn)
+    history_base_mig64.create(Table("rules_scheduled_changes_history", metadata, autoload=True))
 
 
 def downgrade(migrate_engine):

--- a/auslib/migrate/versions/029_add_mig64.py
+++ b/auslib/migrate/versions/029_add_mig64.py
@@ -1,0 +1,47 @@
+from sqlalchemy import Column, MetaData, Table
+
+
+def upgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+
+    def get_column_type():
+        if migrate_engine.name == "mysql":
+            from sqlalchemy.dialects.mysql import BIT
+            return BIT
+        else:
+            from sqlalchemy import Boolean
+            return Boolean(create_constraint=False)
+
+    mig64 = Column("mig64", get_column_type())
+    mig64.create(Table("rules", metadata, autoload=True))
+
+    history_mig64 = Column("mig64", get_column_type())
+    history_mig64.create(Table("rules_history", metadata, autoload=True))
+
+    base_mig64 = Column("base_mig64", get_column_type())
+    base_mig64.create(Table("rules_scheduled_changes", metadata, autoload=True))
+
+    base_mig64 = Column("base_mig64", get_column_type())
+    base_mig64.create(Table("rules_scheduled_changes_history", metadata, autoload=True))
+
+    c = Table("rules", metadata, autoload=True)
+    print c
+    print dir(c)
+    print c.constraints
+    print [x for x in c.constraints]
+
+
+def downgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+    c = Table("rules", metadata, autoload=True)
+    print c
+    print dir(c)
+    print c.constraints
+    print [x for x in c.constraints]
+    print [dir(x) for x in c.constraints]
+    print "names"
+    print [x.name for x in c.constraints]
+    Table('rules', metadata, autoload=True).c.mig64.drop()
+    Table('rules_history', metadata, autoload=True).c.mig64.drop()
+    Table('rules_scheduled_changes', metadata, autoload=True).c.base_mig64.drop()
+    Table('rules_scheduled_changes_history', metadata, autoload=True).c.base_mig64.drop()

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -124,6 +124,10 @@ class ViewTest(unittest.TestCase):
         )
         dbo.rules.t.insert().execute(rule_id=6, product='fake', priority=40, backgroundRate=50, mapping='a', update_type='minor', channel="e", data_version=1)
         dbo.rules.t.insert().execute(rule_id=7, product='fake', priority=30, backgroundRate=85, mapping='a', update_type='minor', channel="c", data_version=1)
+        dbo.rules.t.insert().execute(
+            rule_id=8, product='fake2', priority=25, backgroundRate=100, mapping='a', update_type='minor', channel="c", mig64=True,
+            data_version=1
+        )
         self.client = app.test_client()
 
     def tearDown(self):

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1003,7 +1003,7 @@ cbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbda
         self.assertEquals(ret_data, json.loads("""
 {
     "releases": [
-        {"data_version": 1, "name": "a", "product": "a", "read_only": false, "rule_ids": [3, 4, 6, 7]},
+        {"data_version": 1, "name": "a", "product": "a", "read_only": false, "rule_ids": [3, 4, 6, 7, 8]},
         {"data_version": 1, "name": "ab", "product": "a", "read_only": false, "rule_ids": []}
     ]
 }
@@ -1688,7 +1688,7 @@ class TestRuleIdsReturned(ViewTest):
 
     def testMappingIncluded(self):
         rel_name = 'ab'
-        rule_id = 8
+        rule_id = 9
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -23,21 +23,21 @@ class TestRulesAPI_JSON(ViewTest):
                 "update_type": "minor", "channel": "a", "data_version": 1, "comment": None, "fallbackMapping": None,
                 "version": None, "buildID": None, "locale": None, "distribution": None, "osVersion": None,
                 "instructionSet": None, "distVersion": None, "headerArchitecture": None, "alias": None,
-                "memory": None,
+                "memory": None, "mig64": None,
             },
             {
                 "rule_id": 6, "product": "fake", "priority": 40, "backgroundRate": 50, "mapping": "a", "update_type": "minor",
                 "channel": "e", "data_version": 1, "buildTarget": None, "comment": None, "fallbackMapping": None,
                 "version": None, "buildID": None, "locale": None, "distribution": None, "osVersion": None,
                 "instructionSet": None, "distVersion": None, "headerArchitecture": None, "alias": None,
-                "memory": None,
+                "memory": None, "mig64": None,
             },
             {
                 "rule_id": 7, "product": "fake", "priority": 30, "backgroundRate": 85, "mapping": "a", "update_type": "minor",
                 "channel": "c", "data_version": 1, "buildTarget": None, "comment": None, "fallbackMapping": None,
                 "version": None, "buildID": None, "locale": None, "distribution": None, "osVersion": None,
                 "instructionSet": None, "distVersion": None, "headerArchitecture": None, "alias": None,
-                "memory": None,
+                "memory": None, "mig64": None,
             }
         ]
         self.assertEquals(got["count"], 3)
@@ -280,6 +280,7 @@ class TestSingleRuleView_JSON(ViewTest):
             rule_id=1,
             alias=None,
             memory=None,
+            mig64=None,
         )
         self.assertEquals(json.loads(ret.data), expected)
 
@@ -307,6 +308,7 @@ class TestSingleRuleView_JSON(ViewTest):
             rule_id=2,
             alias="frodo",
             memory=None,
+            mig64=None,
         )
         self.assertEquals(json.loads(ret.data), expected)
 
@@ -989,7 +991,7 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 1, "when": 1000000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 1, "priority": 100,
                     "version": "3.5", "buildTarget": "d", "backgroundRate": 100, "mapping": "b", "update_type": "minor",
-                    "data_version": 1, "alias": None, "product": "a", "channel": "a", "buildID": None, "locale": None, "memory": None,
+                    "data_version": 1, "alias": None, "product": "a", "channel": "a", "buildID": None, "locale": None, "memory": None, "mig64": None,
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
@@ -997,14 +999,14 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
                     "backgroundRate": 100, "product": "baz", "mapping": "ab", "update_type": "minor", "version": None,
-                    "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None, "memory": None,
+                    "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "insert", "signoffs": {}, "required_signoffs": {},
                 },
                 {
                     "sc_id": 3, "when": 2900000, "scheduled_by": "bill", "complete": False, "sc_data_version": 2, "rule_id": None, "priority": 150,
-                    "backgroundRate": 100, "channel": "a", "mapping": "ghi", "update_type": "minor", "version": None, "memory": None,
+                    "backgroundRate": 100, "channel": "a", "mapping": "ghi", "update_type": "minor", "version": None, "memory": None, "mig64": None,
                     "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
@@ -1013,7 +1015,7 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 5, "when": 600000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 4, "priority": None,
                     "backgroundRate": None, "channel": None, "mapping": None, "update_type": None, "version": None,
-                    "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None,
+                    "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": 1, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1},
@@ -1021,7 +1023,7 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
                     "backgroundRate": 100, "product": "fake", "mapping": "ab", "update_type": "minor", "version": None,
-                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None,
+                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "insert", "signoffs": {}, "required_signoffs": {"relman": 1},
@@ -1029,7 +1031,7 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
                     "backgroundRate": 50, "product": "fake", "mapping": "a", "update_type": "minor", "version": None,
-                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None,
+                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1},
@@ -1046,7 +1048,7 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 1, "when": 1000000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 1, "priority": 100,
                     "version": "3.5", "buildTarget": "d", "backgroundRate": 100, "mapping": "b", "update_type": "minor",
-                    "data_version": 1, "alias": None, "product": "a", "channel": "a", "buildID": None, "locale": None, "memory": None,
+                    "data_version": 1, "alias": None, "product": "a", "channel": "a", "buildID": None, "locale": None, "memory": None, "mig64": None,
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
@@ -1054,7 +1056,7 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
                     "backgroundRate": 100, "product": "baz", "mapping": "ab", "update_type": "minor", "version": None,
-                    "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None, "memory": None,
+                    "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "insert", "signoffs": {}, "required_signoffs": {},
@@ -1062,7 +1064,7 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 3, "when": 2900000, "scheduled_by": "bill", "complete": False, "sc_data_version": 2, "rule_id": None, "priority": 150,
                     "backgroundRate": 100, "channel": "a", "mapping": "ghi", "update_type": "minor", "version": None,
-                    "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None,
+                    "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "insert", "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1},
@@ -1070,7 +1072,7 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 4, "when": 500000, "scheduled_by": "bill", "complete": True, "sc_data_version": 2, "rule_id": 5, "priority": 80,
                     "version": "3.3", "buildTarget": "d", "backgroundRate": 0, "mapping": "c", "update_type": "minor",
-                    "data_version": 1, "alias": None, "product": None, "channel": None, "buildID": None, "locale": None, "memory": None,
+                    "data_version": 1, "alias": None, "product": None, "channel": None, "buildID": None, "locale": None, "memory": None, "mig64": None,
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
@@ -1078,7 +1080,7 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 5, "when": 600000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 4, "priority": None,
                     "backgroundRate": None, "channel": None, "mapping": None, "update_type": None, "version": None,
-                    "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None,
+                    "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": 1, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1},
@@ -1086,7 +1088,7 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
                     "backgroundRate": 100, "product": "fake", "mapping": "ab", "update_type": "minor", "version": None,
-                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None,
+                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "insert", "signoffs": {}, "required_signoffs": {"relman": 1},
@@ -1094,7 +1096,7 @@ class TestRuleScheduledChanges(ViewTest):
                 {
                     "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
                     "backgroundRate": 50, "product": "fake", "mapping": "a", "update_type": "minor", "version": None,
-                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None,
+                    "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1},
@@ -1121,7 +1123,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_mapping": "c", "base_update_type": "minor", "base_data_version": 1, "data_version": 1, "sc_id": 8, "complete": False, "base_alias": None,
             "base_product": None, "base_channel": None, "base_buildID": None, "base_locale": None, "base_osVersion": None, "base_distribution": None,
             "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None, "base_memory": None,
-            "base_instructionSet": None, "change_type": "update",
+            "base_mig64": None, "base_instructionSet": None, "change_type": "update",
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
@@ -1146,7 +1148,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_mapping": None, "base_update_type": None, "base_data_version": 1, "data_version": 1, "sc_id": 8, "complete": False, "base_alias": None,
             "base_product": None, "base_channel": None, "base_buildID": None, "base_locale": None, "base_osVersion": None, "base_distribution": None,
             "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None, "base_memory": None,
-            "base_instructionSet": None, "change_type": "delete",
+            "base_mig64": None, "base_instructionSet": None, "change_type": "delete",
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
@@ -1172,7 +1174,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_update_type": "minor", "base_mapping": "a", "sc_id": 8, "data_version": 1, "complete": False, "base_data_version": None,
             "base_rule_id": None, "base_buildTarget": None, "base_version": None, "base_alias": None, "base_buildID": None, "base_locale": None,
             "base_osVersion": None, "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None,
-            "base_comment": None, "base_instructionSet": None, "change_type": "insert", "base_memory": None,
+            "base_comment": None, "base_instructionSet": None, "change_type": "insert", "base_memory": None, "base_mig64": None,
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
@@ -1285,7 +1287,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_product": "a", "base_channel": "a", "base_buildID": None, "base_locale": None, "base_osVersion": None,
             "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None,
             "base_headerArchitecture": None, "base_comment": None, "base_instructionSet": None, "base_memory": "888",
-            "change_type": "update",
+            "base_mig64": None, "change_type": "update",
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 1).execute().fetchall()
@@ -1312,7 +1314,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_backgroundRate": 100, "base_mapping": "c", "base_update_type": "minor", "base_data_version": 1,
             "base_alias": None, "base_product": "a", "base_channel": "a", "base_buildID": None, "base_locale": None,
             "base_osVersion": None, "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None, "base_memory": None,
-            "base_headerArchitecture": None, "base_comment": None, "base_instructionSet": None, "change_type": "update",
+            "base_mig64": None, "base_headerArchitecture": None, "base_comment": None, "base_instructionSet": None, "change_type": "update",
         }
         self.assertEquals(db_data, expected)
 
@@ -1354,7 +1356,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_channel": "a", "base_buildID": None, "base_locale": None, "base_osVersion": None,
             "base_product": None, "base_data_version": None, "base_alias": None,
             "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None,
-            "base_headerArchitecture": None, "base_comment": None, "base_memory": None,
+            "base_headerArchitecture": None, "base_comment": None, "base_memory": None, "base_mig64": None,
             "base_instructionSet": None, "base_version": None, "base_rule_id": None, "base_buildTarget": None,
             "change_type": "insert",
         }
@@ -1413,7 +1415,7 @@ class TestRuleScheduledChanges(ViewTest):
             "rule_id": 1, "priority": 100, "version": "3.5", "buildTarget": "d", "backgroundRate": 100, "mapping": "b", "fallbackMapping": None,
             "update_type": "minor", "data_version": 2, "alias": None, "product": "a", "channel": "a", "buildID": None,
             "locale": None, "osVersion": None, "distribution": None, "distVersion": None, "headerArchitecture": None,
-            "comment": None, "instructionSet": None, "memory": None,
+            "comment": None, "instructionSet": None, "memory": None, "mig64": None,
         }
         self.assertEquals(dict(row), expected)
 
@@ -1429,7 +1431,7 @@ class TestRuleScheduledChanges(ViewTest):
             "rule_id": 8, "priority": 50, "version": None, "buildTarget": None, "backgroundRate": 100, "mapping": "ab", "fallbackMapping": None,
             "update_type": "minor", "data_version": 1, "alias": None, "product": "baz", "channel": None, "buildID": None,
             "locale": None, "osVersion": None, "distribution": None, "distVersion": None, "headerArchitecture": None,
-            "comment": None, "instructionSet": None, "memory": None,
+            "comment": None, "instructionSet": None, "memory": None, "mig64": None,
         }
         self.assertEquals(dict(row), expected)
 
@@ -1448,7 +1450,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "priority": 150, "backgroundRate": 100, "channel": "a", "mapping": "ghi", "fallbackMapping": None, "update_type": "minor",
                     "complete": False, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "rule_id": None,
                     "version": None, "product": None, "buildTarget": None, "buildID": None, "locale": None,
-                    "osVersion": None, "instructionSet": None, "distribution": None, "distVersion": None, "memory": None,
+                    "osVersion": None, "instructionSet": None, "distribution": None, "distVersion": None, "memory": None, "mig64": None,
                     "headerArchitecture": None, "comment": None, "alias": None, "data_version": None, "change_type": "insert",
                 },
                 {
@@ -1456,7 +1458,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "priority": 150, "backgroundRate": 100, "channel": "a", "mapping": "def", "fallbackMapping": None, "update_type": "minor",
                     "complete": False, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "rule_id": None,
                     "version": None, "product": None, "buildTarget": None, "buildID": None, "locale": None,
-                    "osVersion": None, "instructionSet": None, "distribution": None, "distVersion": None, "memory": None,
+                    "osVersion": None, "instructionSet": None, "distribution": None, "distVersion": None, "memory": None, "mig64": None,
                     "headerArchitecture": None, "comment": None, "alias": None, "data_version": None, "change_type": "insert",
                 },
             ],
@@ -1477,7 +1479,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_backgroundRate": 100, "base_channel": "a", "base_mapping": "def", "base_update_type": "minor", "base_version": None,
             "base_buildTarget": None, "base_alias": None, "base_product": None, "base_buildID": None, "base_locale": None, "base_osVersion": None,
             "base_distribution": None, 'base_fallbackMapping': None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None,
-            "base_data_version": None, "base_instructionSet": None, "base_memory": None, "change_type": "insert",
+            "base_data_version": None, "base_instructionSet": None, "base_memory": None, "base_mig64": None, "change_type": "insert",
         }
         self.assertEquals(db_data, expected)
         self.assertEquals(dbo.rules.scheduled_changes.conditions.history.t.count().execute().first()[0], 16)

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1911,7 +1911,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         expected = ["rule_id", "alias", "priority", "mapping", "fallbackMapping", "backgroundRate", "update_type",
                     "product", "version", "channel", "buildTarget", "buildID", "locale", "osVersion",
                     "instructionSet", "distribution", "distVersion", "headerArchitecture", "comment",
-                    "data_version", "memory"]
+                    "data_version", "memory", "mig64"]
         sc_expected = ["base_{}".format(c) for c in expected]
         self.assertEquals(set(columns), set(expected))
         # No need to test the non-base parts of history nor scheduled changes table

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -4373,6 +4373,22 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
             for table_name in base_capabilities_tables:
                 self.assertIn("base_systemCapabilities", metadata.tables[table_name].c)
 
+    def _add_mig64_test(self, db, upgrade=True):
+        metadata = self._get_reflected_metadata(db)
+        mig64_tables = ["rules", "rules_history"]
+        base_mig64_tables = ["rules_scheduled_changes", "rules_scheduled_changes_history"]
+
+        if upgrade:
+            for table_name in mig64_tables:
+                self.assertIn("mig64", metadata.tables[table_name].c)
+            for table_name in base_mig64_tables:
+                self.assertIn("base_mig64", metadata.tables[table_name].c)
+        else:
+            for table_name in mig64_tables:
+                self.assertNotIn("mig64", metadata.tables[table_name].c)
+            for table_name in base_mig64_tables:
+                self.assertNotIn("base_mig64", metadata.tables[table_name].c)
+
     def _fix_column_attributes_migration_test(self, db, upgrade=True):
         """
         Tests the upgrades and downgrades for version 22 work properly.
@@ -4425,6 +4441,7 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
             pass
 
         versions_migrate_tests_dict = {
+            28: self._add_mig64_test,
             27: self._remove_systemCapabilities_test,
             26: self._add_instructionSet_test,
             # No-op migration

--- a/auslib/test/web/api/base.py
+++ b/auslib/test/web/api/base.py
@@ -123,3 +123,5 @@ class CommonTestBase(unittest.TestCase):
 
         dbo.releases.history.t.insert().execute(change_id=1, changed_by="usr", timestamp=10,
                                                 name='q', product='q', data_version=1)
+        dbo.rules.t.insert().execute(rule_id=4, priority=90, backgroundRate=100, mapping='Firefox.55.0a1', update_type='minor', product='Firefox',
+                                     mig64=True, data_version=1)

--- a/auslib/test/web/api/test_rules.py
+++ b/auslib/test/web/api/test_rules.py
@@ -39,7 +39,7 @@ class TestPublicRulesAPI(CommonTestBase):
                         channel=None, comment=None, distVersion=None,
                         distribution=None, fallbackMapping=None,
                         headerArchitecture=None, locale=None, version=None,
-                        osVersion=None, memory=None, instructionSet=None)
+                        osVersion=None, memory=None, instructionSet=None, mig64=None)
         ret = self.public_client.get("/api/v1/rules/moz-releng")
         self.assertEqual(ret.status_code, 200, ret.data)
         got = json.loads(ret.data)

--- a/auslib/test/web/api/test_rules.py
+++ b/auslib/test/web/api/test_rules.py
@@ -6,7 +6,7 @@ class TestPublicRulesAPI(CommonTestBase):
     def test_get_rules(self):
         ret = self.public_client.get("/api/v1/rules")
         got = json.loads(ret.data)
-        self.assertEquals(got["count"], 3)
+        self.assertEquals(got["count"], 4)
         rules = [(rule["mapping"], rule["product"]) for rule in got["rules"]]
         self.assertIn(("Fennec.55.0a1", "Fennec"), rules)
         self.assertIn(("Firefox.55.0a1", "Firefox"), rules)

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -1858,6 +1858,7 @@ paths:
                   locale: null
                   mapping: "Firefox-45.7.0esr-build1"
                   memory: null
+                  mig64: null
                   osVersion: null
                   priority: 43
                   product: "Firefox"
@@ -4077,6 +4078,7 @@ definitions:
       - locale
       - mapping
       - memory
+      - mig64
       - osVersion
       - priority
       - product
@@ -4110,6 +4112,7 @@ definitions:
       - locale
       - mapping
       - memory
+      - mig64
       - osVersion
       - priority
       - product
@@ -4148,6 +4151,7 @@ definitions:
                 locale: null
                 mapping: "Firefox-45.7.0esr-build1"
                 memory: null
+                mig64: null
                 osVersion: null
                 priority: 43
                 product: "Firefox"
@@ -4356,6 +4360,11 @@ definitions:
         minLength: 0
         maxLength: 100
         example: null
+
+      mig64:
+        description: Whether or not the Rule should apply to queries that specify their 32 -> 64-bit migration status. If set to false or true, the query and the rule must match precisely. If set to null, the mig64 in the updateQuery is ignored.
+        type: ["boolean", "null"]
+        example: true
 
     #Warning: Do NOT add an example object here. Interferes with Example Value during
     # request generation in Swagger-UI

--- a/auslib/web/admin/views/rules.py
+++ b/auslib/web/admin/views/rules.py
@@ -186,6 +186,7 @@ class RuleHistoryAPIView(HistoryView):
             'osVersion': 'osVersion',
             'instructionSet': 'instructionSet',
             'memory': 'memory',
+            'mig64': 'mig64',
             'distVersion': 'distVersion',
             'comment': 'comment',
             'update_type': 'update_type',

--- a/auslib/web/common/rules_spec.yml
+++ b/auslib/web/common/rules_spec.yml
@@ -126,7 +126,7 @@ definitions:
         type: ['string', 'null']
         description: The amount of RAM, in megabytes, that the client must have for the rule to match. Comparisons such as "<8000" may be used.
       mig64:
-        description: Whether or not the Rule should apply to queries that specify their 32 -> 64-bit migration status. If set to false or true, the query and the rule must match precisely. If set to null, the mig64 in the updateQuery is ignored.
+        description: Whether or not the Rule should apply to queries that have opted into 32 -> 64-bit migration. If set to false or true, the query and the rule must match precisely. If set to null, the mig64 in the updateQuery is ignored.
         type: ["boolean", "null"]
       distribution:
         type: ['string', 'null']

--- a/auslib/web/common/rules_spec.yml
+++ b/auslib/web/common/rules_spec.yml
@@ -125,6 +125,9 @@ definitions:
       memory:
         type: ['string', 'null']
         description: The amount of RAM, in megabytes, that the client must have for the rule to match. Comparisons such as "<8000" may be used.
+      mig64:
+        description: Whether or not the Rule should apply to queries that specify their 32 -> 64-bit migration status. If set to false or true, the query and the rule must match precisely. If set to null, the mig64 in the updateQuery is ignored.
+        type: ["boolean", "null"]
       distribution:
         type: ['string', 'null']
         description: The partner distribution name that the application must send in order for the rule to match.

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -90,6 +90,12 @@ def getQueryFromURL(url):
     ua = request.headers.get('User-Agent')
     query['headerArchitecture'] = getHeaderArchitecture(query['buildTarget'], ua)
     query['force'] = (int(query.get('force', 0)) == 1)
+    # "1" is the only value that official clients send. We ignore any other values
+    # by setting mig64 to None.
+    if query.get("mig64") == "1":
+        query["mig64"] = True
+    else:
+        query["mig64"] = None
     return query
 
 

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -90,9 +90,9 @@ def getQueryFromURL(url):
     ua = request.headers.get('User-Agent')
     query['headerArchitecture'] = getHeaderArchitecture(query['buildTarget'], ua)
     query['force'] = (int(query.get('force', 0)) == 1)
-    # "1" is the only value that official clients send. We ignore any other values
-    # by setting mig64 to None.
     if "mig64" in query:
+        # "1" is the only value that official clients send. We ignore any other values
+        # by setting mig64 to None.
         if query.get("mig64") == "1":
             query["mig64"] = True
         else:

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -92,8 +92,11 @@ def getQueryFromURL(url):
     query['force'] = (int(query.get('force', 0)) == 1)
     # "1" is the only value that official clients send. We ignore any other values
     # by setting mig64 to None.
-    if query.get("mig64") == "1":
-        query["mig64"] = True
+    if "mig64" in query:
+        if query.get("mig64") == "1":
+            query["mig64"] = True
+        else:
+            query["mig64"] = False
     else:
         query["mig64"] = None
     return query

--- a/docs/source/database.rst
+++ b/docs/source/database.rst
@@ -105,6 +105,11 @@ Following tables show columns according to different Categories:
   |                        |                    | requesting the update has                        | memory to compare the incoming  | ">=8096"                   |
   |                        |                    |                                                  | one against                     |                            |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
+  |                        | mig64              | Whether or not the Rule should apply to queries  | Exact match only                | True, False, or NULL       |
+  |                        |                    | that have opted into 32 -> 64-bit migration.     |                                 |                            |
+  |                        |                    | If set to True or False the Rule and the query   |                                 |                            |
+  |                        |                    | must match precisely.                            |                                 |                            |
+  |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
   |                        | version            | The version of the application requesting an     | Exact string match or exact     | "36.0" or "36.0,36.1,36.2" |
   |                        |                    | update.                                          | matches from list of values or  | or ">=38.0a1"              |
   |                        |                    |                                                  | operator plus version           |                            |

--- a/ui/app/css/main.less
+++ b/ui/app/css/main.less
@@ -92,6 +92,8 @@ div.xor-group > div {
     margin: 10px 0px 10px;
 }
 
+/* This class is used in the primary Rule, Release, and Permissions UI. Some of our field
+   names don't fit into the default size, so we needed to make it wider */
 @media (min-width: 768px) {
   .dl-horizontal dt {
       width: 200px;

--- a/ui/app/css/main.less
+++ b/ui/app/css/main.less
@@ -96,6 +96,10 @@ div.xor-group > div {
   .dl-horizontal dt {
       width: 200px;
   }
+
+  .dl-horizontal dd {
+      margin-left: 220px;
+  }
 }
 
 @import 'loader';

--- a/ui/app/css/main.less
+++ b/ui/app/css/main.less
@@ -92,5 +92,11 @@ div.xor-group > div {
     margin: 10px 0px 10px;
 }
 
+@media (min-width: 768px) {
+  .dl-horizontal dt {
+      width: 200px;
+  }
+}
+
 @import 'loader';
 @import 'smallloader';

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -159,7 +159,6 @@
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.mig64}">
           <!-- TODO: Find better string for this -->
-          <!-- TODO: why is there no drop down indicator? -->
           <label for="id_mig64">Match clients that have opted into 32-bit to 64-bit migration?</label>
           <select id="id_mig64" ng-model="rule.mig64" class="form-control"
                   ng-options="value as key for (key, value) in {'Both': null, 'Yes': true, 'No': false}">

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -158,10 +158,14 @@
     <div class="row">
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.mig64}">
-          <!-- TODO: Find better string for this -->
-          <label for="id_mig64">Match clients that have opted into 32-bit to 64-bit migration?</label>
+          <label for="id_mig64">
+            64-bit Migration Opt-in
+            <span class="glyphicon glyphicon-question-sign"
+                  title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status. "Ignore" is usually what you want.'>
+            </span>
+          </label>
           <select id="id_mig64" ng-model="rule.mig64" class="form-control"
-                  ng-options="value as key for (key, value) in {'Both': null, 'Yes': true, 'No': false}">
+                  ng-options="value as key for (key, value) in {'Ignore': null, 'Yes': true, 'No': false}">
             <!-- Angular creates an extra entry because one of our values is null. This hides it.
                  From https://stackoverflow.com/a/24321497 -->
             <option value="" ng-if="false"></option>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -156,6 +156,22 @@
       </div>
     </div>
     <div class="row">
+      <div class="col-md-6">
+        <div class="form-group" ng-class="{'has-error': errors.mig64}">
+          <!-- TODO: Find better string for this -->
+          <!-- TODO: why is there no drop down indicator? -->
+          <label for="id_mig64">Match clients that have done 32-bit to 64-bit migration?</label>
+          <select id="id_mig64" ng-model="rule.mig64" class="form-control"
+                  ng-options="value as key for (key, value) in {'Both': null, 'Yes': true, 'No': false}">
+            <!-- Angular creates an extra entry because one of our values is null. This hides it.
+                 From https://stackoverflow.com/a/24321497 -->
+            <option value="" ng-if="false"></option>
+          </select>
+          <p class="help-block" ng-show="errors.mig64">{{ errors.mig64.join(', ') }}</p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
       <div class="col-md-12">
         <div class="form-group" ng-class="{'has-error': errors.comment}">
           <label for="id_comment">Comment</label>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -160,7 +160,7 @@
         <div class="form-group" ng-class="{'has-error': errors.mig64}">
           <!-- TODO: Find better string for this -->
           <!-- TODO: why is there no drop down indicator? -->
-          <label for="id_mig64">Match clients that have done 32-bit to 64-bit migration?</label>
+          <label for="id_mig64">Match clients that have opted into 32-bit to 64-bit migration?</label>
           <select id="id_mig64" ng-model="rule.mig64" class="form-control"
                   ng-options="value as key for (key, value) in {'Both': null, 'Yes': true, 'No': false}">
             <!-- Angular creates an extra entry because one of our values is null. This hides it.

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -148,15 +148,6 @@
         </div>
       </div>
       <div class="col-md-6">
-        <div class="form-group" ng-class="{'has-error': errors.alias}">
-          <label for="id_distribution">Alias</label>
-          <input type="text" class="form-control" id="id_distribution" ng-model="rule.alias">
-          <p class="help-block" ng-show="errors.alias">{{ errors.alias.join(', ') }}</p>
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.mig64}">
           <label for="id_mig64">
             64-bit Migration Opt-in
@@ -171,6 +162,15 @@
             <option value="" ng-if="false"></option>
           </select>
           <p class="help-block" ng-show="errors.mig64">{{ errors.mig64.join(', ') }}</p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-6">
+        <div class="form-group" ng-class="{'has-error': errors.alias}">
+          <label for="id_distribution">Alias</label>
+          <input type="text" class="form-control" id="id_distribution" ng-model="rule.alias">
+          <p class="help-block" ng-show="errors.alias">{{ errors.alias.join(', ') }}</p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -206,9 +206,14 @@
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.mig64}">
-          <label for="id_mig64">Match clients that have opted into 32-bit to 64-bit migration?</label>
+          <label for="id_mig64">
+            64-bit Migration Opt-in
+            <span class="glyphicon glyphicon-question-sign"
+                  title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status. "Ignore" is usually what you want.'>
+            </span>
+          </label>
           <select id="id_mig64" ng-model="rule.mig64" class="form-control"
-                  ng-options="value as key for (key, value) in {'Both': null, 'Yes': true, 'No': false}">
+                  ng-options="value as key for (key, value) in {'Ignore': null, 'Yes': true, 'No': false}">
             <!-- Angular creates an extra entry because one of our values is null. This hides it.
                  From https://stackoverflow.com/a/24321497 -->
             <option value="" ng-if="false"></option>

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -212,7 +212,7 @@
                   title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status. "Ignore" is usually what you want.'>
             </span>
           </label>
-          <select id="id_mig64" ng-model="rule.mig64" class="form-control"
+          <select id="id_mig64" ng-model="sc.mig64" class="form-control"
                   ng-options="value as key for (key, value) in {'Ignore': null, 'Yes': true, 'No': false}">
             <!-- Angular creates an extra entry because one of our values is null. This hides it.
                  From https://stackoverflow.com/a/24321497 -->
@@ -250,4 +250,4 @@
   <button class="btn btn-primary" ng-show="!saving" ng-click="saveChanges()">Save Changes</button>
   <button class="btn btn-default" ng-show="!saving" ng-click="cancel()">Cancel</button>
 </div>
-
+G

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -206,7 +206,7 @@
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.mig64}">
-          <label for="id_mig64">Match clients that have done 32-bit to 64-bit migration?</label>
+          <label for="id_mig64">Match clients that have opted into 32-bit to 64-bit migration?</label>
           <select id="id_mig64" ng-model="rule.mig64" class="form-control"
                   ng-options="value as key for (key, value) in {'Both': null, 'Yes': true, 'No': false}">
             <!-- Angular creates an extra entry because one of our values is null. This hides it.

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -205,10 +205,24 @@
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
+        <div class="form-group" ng-class="{'has-error': errors.mig64}">
+          <label for="id_mig64">Match clients that have done 32-bit to 64-bit migration?</label>
+          <select id="id_mig64" ng-model="rule.mig64" class="form-control"
+                  ng-options="value as key for (key, value) in {'Both': null, 'Yes': true, 'No': false}">
+            <!-- Angular creates an extra entry because one of our values is null. This hides it.
+                 From https://stackoverflow.com/a/24321497 -->
+            <option value="" ng-if="false"></option>
+          </select>
+          <p class="help-block" ng-show="errors.mig64">{{ errors.mig64.join(', ') }}</p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
         <div class="form-group" ng-class="{'has-error': errors.comment}">
-        <label for="id_comment">Comment</label>
-        <input type="text" class="form-control" id="id_comment" ng-model="sc.comment">
-        <p class="help-block" ng-show="errors.comment">{{ errors.comment.join(', ') }}</p>
+          <label for="id_comment">Comment</label>
+          <input type="text" class="form-control" id="id_comment" ng-model="sc.comment">
+          <p class="help-block" ng-show="errors.comment">{{ errors.comment.join(', ') }}</p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -161,15 +161,15 @@
       <dd>{{ sc.instructionSet }}</dd>
       <dt ng-show="sc.memory">Memory:</dt>
       <dd>{{ sc.memory }}</dd>
-      <dt ng-show="rule.mig64 !== null">
+      <dt ng-show="sc.mig64 !== null">
         64-Bit Migration Opt-in
         <span class="glyphicon glyphicon-question-sign"
            title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status.'>
         </span>
         : 
       </dt>
-      <dd ng-if="rule.mig64 === true">Yes</dd>
-      <dd ng-if="rule.mig64 === false">No</dd>
+      <dd ng-if="sc.mig64 === true">Yes</dd>
+      <dd ng-if="sc.mig64 === false">No</dd>
       <dt ng-show="sc.distVersion">Dist Version:</dt>
       <dd>{{ sc.distVersion }}</dd>
       <dt ng-show="sc.update_type">Update type:</dt>

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -162,7 +162,7 @@
       <dt ng-show="sc.memory">Memory:</dt>
       <dd>{{ sc.memory }}</dd>
       <!-- TODO: find better name for this -->
-      <dt ng-show="rule.mig64">64-Bit Migration Opt-in:</dt>
+      <dt ng-show="rule.mig64 !== null">64-Bit Migration Opt-in:</dt>
       <dd ng-if="rule.mig64 === true">Yes</dd>
       <dd ng-if="rule.mig64 === false">No</dd>
       <dt ng-show="sc.distVersion">Dist Version:</dt>

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -166,7 +166,7 @@
         <span class="glyphicon glyphicon-question-sign"
            title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status.'>
         </span>
-        : 
+        :
       </dt>
       <dd ng-if="sc.mig64 === true">Yes</dd>
       <dd ng-if="sc.mig64 === false">No</dd>

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -161,8 +161,13 @@
       <dd>{{ sc.instructionSet }}</dd>
       <dt ng-show="sc.memory">Memory:</dt>
       <dd>{{ sc.memory }}</dd>
-      <!-- TODO: find better name for this -->
-      <dt ng-show="rule.mig64 !== null">64-Bit Migration Opt-in:</dt>
+      <dt ng-show="rule.mig64 !== null">
+        64-Bit Migration Opt-in
+        <span class="glyphicon glyphicon-question-sign"
+           title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status.'>
+        </span>
+        : 
+      </dt>
       <dd ng-if="rule.mig64 === true">Yes</dd>
       <dd ng-if="rule.mig64 === false">No</dd>
       <dt ng-show="sc.distVersion">Dist Version:</dt>

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -161,7 +161,7 @@
       <dd>{{ sc.instructionSet }}</dd>
       <dt ng-show="sc.memory">Memory:</dt>
       <dd>{{ sc.memory }}</dd>
-      <dt ng-show="sc.mig64 !== null">
+      <dt ng-show="sc.mig64 !== null && sc.mig64 !== undefined">
         64-Bit Migration Opt-in
         <span class="glyphicon glyphicon-question-sign"
            title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status.'>

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -161,6 +161,10 @@
       <dd>{{ sc.instructionSet }}</dd>
       <dt ng-show="sc.memory">Memory:</dt>
       <dd>{{ sc.memory }}</dd>
+      <!-- TODO: find better name for this -->
+      <dt ng-show="rule.mig64">64-Bit Migration Opt-in:</dt>
+      <dd ng-if="rule.mig64 === true">Yes</dd>
+      <dd ng-if="rule.mig64 === false">No</dd>
       <dt ng-show="sc.distVersion">Dist Version:</dt>
       <dd>{{ sc.distVersion }}</dd>
       <dt ng-show="sc.update_type">Update type:</dt>

--- a/ui/app/templates/rules.html
+++ b/ui/app/templates/rules.html
@@ -147,7 +147,13 @@
       <dt ng-show="rule.memory">Memory:</dt>
       <dd>{{ rule.memory }}</dd>
       <!-- TODO: find better name for this -->
-      <dt ng-show="rule.mig64">64-Bit Migration Opt-in:</dt>
+      <dt ng-show="rule.mig64 !== null">
+        64-Bit Migration Opt-in
+        <span class="glyphicon glyphicon-question-sign"
+           title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status. "Ignore" is usually what you want.'>     
+        </span>
+        : 
+      </dt>
       <dd ng-if="rule.mig64 === true">Yes</dd>
       <dd ng-if="rule.mig64 === false">No</dd>
       <dt ng-show="rule.distVersion">Dist Version:</dt>

--- a/ui/app/templates/rules.html
+++ b/ui/app/templates/rules.html
@@ -151,7 +151,7 @@
         <span class="glyphicon glyphicon-question-sign"
            title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status.'>
         </span>
-        : 
+        :
       </dt>
       <dd ng-if="rule.mig64 === true">Yes</dd>
       <dd ng-if="rule.mig64 === false">No</dd>

--- a/ui/app/templates/rules.html
+++ b/ui/app/templates/rules.html
@@ -146,11 +146,10 @@
       <dd>{{ rule.instructionSet }}</dd>
       <dt ng-show="rule.memory">Memory:</dt>
       <dd>{{ rule.memory }}</dd>
-      <!-- TODO: find better name for this -->
       <dt ng-show="rule.mig64 !== null">
         64-Bit Migration Opt-in
         <span class="glyphicon glyphicon-question-sign"
-           title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status. "Ignore" is usually what you want.'>     
+           title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status.'>
         </span>
         : 
       </dt>

--- a/ui/app/templates/rules.html
+++ b/ui/app/templates/rules.html
@@ -146,6 +146,10 @@
       <dd>{{ rule.instructionSet }}</dd>
       <dt ng-show="rule.memory">Memory:</dt>
       <dd>{{ rule.memory }}</dd>
+      <!-- TODO: find better name for this -->
+      <dt ng-show="rule.mig64">64-Bit Migration Opt-in:</dt>
+      <dd ng-if="rule.mig64 === true">Yes</dd>
+      <dd ng-if="rule.mig64 === false">No</dd>
       <dt ng-show="rule.distVersion">Dist Version:</dt>
       <dd>{{ rule.distVersion }}</dd>
       <dt ng-show="rule.update_type">Update type:</dt>

--- a/ui/app/templates/rules.html
+++ b/ui/app/templates/rules.html
@@ -146,7 +146,7 @@
       <dd>{{ rule.instructionSet }}</dd>
       <dt ng-show="rule.memory">Memory:</dt>
       <dd>{{ rule.memory }}</dd>
-      <dt ng-show="rule.mig64 !== null">
+      <dt ng-show="rule.mig64 !== null && rule.mig64 !== undefined">
         64-Bit Migration Opt-in
         <span class="glyphicon glyphicon-question-sign"
            title='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status.'>

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
     "jasmine-given": "^2.6.2",
     "lineman": "^0.34.0",
     "lineman-angular": "^0.3.0",
-    "lineman-less": "0.0.1",
+    "lineman-less": "0.1.0",
     "phantomjs-prebuilt": "^2.1.12",
     "protractor": "^1.2.0-beta1",
     "testem": "^1.12.0"


### PR DESCRIPTION
This adds support for the mig64 query parameter as described in https://bugzilla.mozilla.org/show_bug.cgi?id=1386756#c0. Between that, the comments, and the doc updates I _think_ this should be reasonable self explanatory - please let me know if anything is unclear.

In addition to the unit tests I verified this by ensuring that I could create and update both Rules and Rule Scheduled Changes with all mig64 values, and that every possibility in the truth table was correct.

I'm not sure the UI is the best, but I couldn't come up with any better idea than a drop down. Because the parameter is so opaque I tried to add some helpful text to the UI.