### PR TITLE
bug 1301724: add an indication on rules page of whether or not a rule has a change scheduled

### DIFF
--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -66,7 +66,7 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
         $scope.sc.sc_data_version = 1;
         $scope.sc.sc_id = response.sc_id;
         $scope.scheduled_changes.push($scope.sc);
-        $modalInstance.close();
+        $modalInstance.close($scope.sc.change_type);
       })
       .error(function(response, status) {
         if (typeof response === 'object') {

--- a/ui/app/js/controllers/rules_controller.js
+++ b/ui/app/js/controllers/rules_controller.js
@@ -38,8 +38,23 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
   } else {
     Rules.getRules()
     .success(function(response) {
-      $scope.rules = response.rules;
       $scope.rules_count = response.count;
+
+      Rules.getScheduledChanges(false)
+      .success(function(sc_response) {
+        response.rules.forEach(function(rule) {
+          rule.scheduled_change = null;
+          sc_response.scheduled_changes.forEach(function(sc) {
+            if (rule.rule_id === sc.rule_id) {
+              // Note the big honking assumption that there's only one scheduled change.
+              // At the time this code was written, this was enforced by the backend.
+              rule.scheduled_change = sc.change_type;
+            }
+          });
+          $scope.rules.push(rule);
+        });
+      });
+
       var pairExists = function(pr, ch) {
         var _rules = $scope.rules.filter(function(rule) {
           return rule.product === pr && rule.channel === ch;
@@ -189,6 +204,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         }
       }
     });
+    modalInstance.result.then(function(change_type) {
+      rule.scheduled_change = change_type;
+    });
   };
 
   $scope.openNewScheduledRuleChangeModal = function(rule) {
@@ -208,6 +226,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
           return sc;
         }
       }
+    });
+    modalInstance.result.then(function(change_type) {
+      rule.scheduled_change = change_type;
     });
   };
 

--- a/ui/app/js/services/rules_service.js
+++ b/ui/app/js/services/rules_service.js
@@ -38,8 +38,13 @@ angular.module("app").factory('Rules', function($http, ScheduledChanges, Helpers
       data.csrf_token = csrf_token;
       return $http.post('/api/rules/' + id + '/revisions', data);
     },
-    getScheduledChanges: function() {
-      return $http.get("/api/scheduled_changes/rules?all=1");
+    getScheduledChanges: function(all) {
+      if (all === undefined || all === true) {
+        return $http.get("/api/scheduled_changes/rules?all=1");
+      }
+      else {
+        return $http.get("/api/scheduled_changes/rules");
+      }
     },
     getScheduledChange: function(sc_id) {
       return $http.get("/api/scheduled_changes/rules/" + sc_id);

--- a/ui/app/templates/rules.html
+++ b/ui/app/templates/rules.html
@@ -65,8 +65,10 @@
       <div style="float: right">
         <i ng-if="rule_id && $first && (currentPage == 1)">Current</i>
         <button ng-if="rule_id && ((currentPage != 1) || !$first )" class="btn btn-default btn-xs" ng-click="openRevertModal(rule)">Revert to this</button>
-        <button ng-show="!rule_id" class="btn btn-warning btn-xs" ng-click="openNewScheduledRuleChangeModal(rule)">Schedule an Update</button>
-        <button ng-show="!rule_id" class="btn btn-danger btn-xs" ng-click="openNewScheduledDeleteModal(rule)">Schedule for Deletion</button>
+        <span ng-show="!rule_id && rule.scheduled_change === 'update'" class="label label-warning">Pending Update</span>
+        <span ng-show="!rule_id && rule.scheduled_change === 'delete'" class="label label-danger">Pending Delete</span>
+        <button ng-show="!rule_id && rule.scheduled_change === null" class="btn btn-warning btn-xs" ng-click="openNewScheduledRuleChangeModal(rule)">Schedule an Update</button>
+        <button ng-show="!rule_id && rule.scheduled_change === null" class="btn btn-danger btn-xs" ng-click="openNewScheduledDeleteModal(rule)">Schedule for Deletion</button>
         <button ng-show="!rule_id" class="btn btn-default btn-xs" ng-click="openUpdateModal(rule)">Update</button>
         <button ng-show="!rule_id" class="btn btn-default btn-xs" ng-click="openDeleteModal(rule)">Delete</button>
         <button ng-show="!rule_id" class="btn btn-default btn-xs" ng-click="openDuplicateModal(rule)">Duplicate</button>

--- a/ui/spec/controllers/rules_controller_spec.js
+++ b/ui/spec/controllers/rules_controller_spec.js
@@ -29,7 +29,8 @@ describe("controller: RulesController", function() {
         "channel": "nightly",
         "alias": null,
         "distVersion": null,
-        "whitelist": null
+        "whitelist": null,
+        "scheduled_change": null
     },
     {
         "comment": null,
@@ -53,7 +54,8 @@ describe("controller: RulesController", function() {
         "channel": null,
         "alias": null,
         "distVersion": null,
-        "whitelist": null
+        "whitelist": null,
+        "scheduled_change": null
     }
     ]
   };
@@ -79,6 +81,8 @@ describe("controller: RulesController", function() {
     it("should return all rules empty", function() {
       this.$httpBackend.expectGET('/api/rules')
       .respond(200, '{"rules": [], "count": 0}');
+      this.$httpBackend.expectGET('/api/scheduled_changes/rules')
+      .respond(200, '{"scheduled_changes": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/product')
       .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
       this.$httpBackend.expectGET('/api/rules/columns/channel')
@@ -90,6 +94,8 @@ describe("controller: RulesController", function() {
     it("should return all rules some", function() {
       this.$httpBackend.expectGET('/api/rules')
       .respond(200, JSON.stringify(sample_rules));
+      this.$httpBackend.expectGET('/api/scheduled_changes/rules')
+      .respond(200, '{"scheduled_changes": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/product')
       .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
       this.$httpBackend.expectGET('/api/rules/columns/channel')
@@ -105,6 +111,8 @@ describe("controller: RulesController", function() {
     it("should be possible to change selected filter", function() {
       this.$httpBackend.expectGET('/api/rules')
       .respond(200, JSON.stringify(sample_rules));
+      this.$httpBackend.expectGET('/api/scheduled_changes/rules')
+      .respond(200, '{"scheduled_changes": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/product')
       .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
       this.$httpBackend.expectGET('/api/rules/columns/channel')
@@ -125,6 +133,8 @@ describe("controller: RulesController", function() {
     it("should be possible to change ordering", function() {
       this.$httpBackend.expectGET('/api/rules')
       .respond(200, JSON.stringify(sample_rules));
+      this.$httpBackend.expectGET('/api/scheduled_changes/rules')
+      .respond(200, '{"scheduled_changes": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/product')
       .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
       this.$httpBackend.expectGET('/api/rules/columns/channel')


### PR DESCRIPTION
Ideally, the backend would return this information as part of every select() to Rules, but that turned out to be pretty tough. I think it's important to get a short term fix in place for this, and it's pretty easy to do on the frontend. It ends up looking like this:
https://screenshots.firefox.com/XLfchFC6YPHJCWhn/localhost