### PR TITLE
Remove unsubstituted_url_variables handler

### DIFF
--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -893,24 +893,6 @@ class ClientTest(ClientTestBase):
         ret = self.client.get('/update/3/product_that_should_not_be_updated/1.0/1/p/l/a/a/a/a/update.xml')
         self.assertUpdatesAreEmpty(ret)
 
-    def testNonSubstitutedUrlVariablesReturn404(self):
-        request1 = '/update/1/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/update.xml'
-        request2 = '/update/2/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/update.xml'
-        request3 = '/update/3/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/' \
-            'update.xml'
-        request4 = '/update/4/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/' \
-            '%MOZ_VERSION%/update.xml'
-        request5 = '/update/5/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/' \
-            '%IMEI%/update.xml'
-        request6 = '/update/6/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%SYSTEM_CAPABILITIES%/%DISTRIBUTION%/' \
-            '%DISTRIBUTION_VERSION%/update.xml'
-
-        with mock.patch('auslib.web.public.client.get_update_blob') as mock_cr_view:
-            for request in [request1, request2, request3, request4, request5, request6]:
-                ret = self.client.get(request)
-                self.assertEqual(ret.status_code, 404)
-                self.assertFalse(mock_cr_view.called)
-
     @given(just('x'))
     @example(invalid_version='1x')
     @example(invalid_version='x1')

--- a/auslib/web/public/api.yml
+++ b/auslib/web/public/api.yml
@@ -190,66 +190,6 @@ paths:
         200:
           description: Update blob in text/xml format.
 
-  /update/1/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/update.xml:
-    get:
-      operationId: 'auslib.web.public.client.unsubstituted_url_variables_1'
-      description: Handles unsubstituted URL requests.
-      produces:
-        - text/xml
-      responses:
-        200:
-          description: Empty xml file.
-
-  /update/2/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/update.xml:
-    get:
-      operationId: 'auslib.web.public.client.unsubstituted_url_variables_2'
-      description: Handles unsubstituted URL requests.
-      produces:
-        - text/xml
-      responses:
-        200:
-          description: Empty xml file.
-
-  /update/3/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/update.xml:
-    get:
-      operationId: 'auslib.web.public.client.unsubstituted_url_variables_3'
-      description: Handles unsubstituted URL requests.
-      produces:
-        - text/xml
-      responses:
-        200:
-          description: Empty xml file.
-
-  /update/4/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/%MOZ_VERSION%/update.xml:
-    get:
-      operationId: 'auslib.web.public.client.unsubstituted_url_variables_4'
-      description: Handles unsubstituted URL requests.
-      produces:
-        - text/xml
-      responses:
-        200:
-          description: Empty xml file.
-
-  /update/5/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/%IMEI%/update.xml:
-    get:
-      operationId: 'auslib.web.public.client.unsubstituted_url_variables_5'
-      description: Handles unsubstituted URL requests.
-      produces:
-        - text/xml
-      responses:
-        200:
-          description: Empty xml file.
-
-  /update/6/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%SYSTEM_CAPABILITIES%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/update.xml:
-    get:
-      operationId: 'auslib.web.public.client.unsubstituted_url_variables_6'
-      description: Handles unsubstituted URL requests.
-      produces:
-        - text/xml
-      responses:
-        200:
-          description: Empty xml file.
-
   /__heartbeat__:
     get:
       operationId: 'auslib.web.public.dockerflow.heartbeat'

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -15,10 +15,6 @@ AUS = AUS()
 LOG = logging.getLogger(__name__)
 
 
-def unsubstituted_url_variables():
-    abort(404)
-
-
 def getHeaderArchitecture(buildTarget, ua):
     if buildTarget.startswith('Darwin'):
         if ua and 'PPC' in ua:
@@ -215,4 +211,3 @@ unsubstituted_url_var_functions = ["unsubstituted_url_variables_1",
 
 
 _set_functions(update_blob_functions, get_update_blob)
-_set_functions(unsubstituted_url_var_functions, unsubstituted_url_variables)

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -4,7 +4,7 @@ import sys
 
 from connexion import request
 
-from flask import abort, make_response, current_app as app
+from flask import make_response, current_app as app
 
 from auslib.AUS import AUS
 from auslib.global_state import dbo


### PR DESCRIPTION
This was added by https://bugzilla.mozilla.org/show_bug.cgi?id=1282569
because we were apparently encountering 400s tens of thousands of
times per day. However, it isn't clear why. Removing the handler falls
back to the real one, which fails to find any information and
generates the exact same response. This adds a tiny amount of database
load but simplifies the code.