### PR TITLE
Force a fallback mapping

### DIFF
--- a/auslib/AUS.py
+++ b/auslib/AUS.py
@@ -35,10 +35,8 @@ def getFallbackChannel(channel):
 class AUSRandom:
     """Abstract getting a randint to make it easier to test the range of
     possible values"""
-
-    def __init__(self, min=0, max=99):
-        self.min = min
-        self.max = max
+    min = 0
+    max = 99
 
     def getInt(self):
         return randint(self.min, self.max)

--- a/auslib/AUS.py
+++ b/auslib/AUS.py
@@ -6,6 +6,17 @@ import logging
 from auslib.global_state import dbo
 
 
+class ForceResult(object):
+    """Enumerated "result" class that represents a non-random result chosen by a caller."""
+    def __init__(self, name):
+        self.name = name
+
+
+# Magic constants that callers can use to choose a specific "random" result.
+SUCCEED = ForceResult('succeed')
+FAIL = ForceResult('fail')
+
+
 def isSpecialURL(url, specialForceHosts):
     if not specialForceHosts:
         return False
@@ -76,9 +87,9 @@ class AUS:
         # serve every request an update
         # backgroundRate=100 means all requests are served
         # backgroundRate=25 means only one quarter of requests are served
-        if not updateQuery['force'] and rule['backgroundRate'] < 100:
+        if not updateQuery['force'] == SUCCEED and rule['backgroundRate'] < 100:
             self.log.debug("backgroundRate < 100, rolling the dice")
-            if self.rand() >= rule['backgroundRate']:
+            if updateQuery['force'] == FAIL or self.rand() >= rule['backgroundRate']:
                 fallbackReleaseName = rule['fallbackMapping']
                 if fallbackReleaseName:
                     release = dbo.releases.getReleases(name=fallbackReleaseName, limit=1)[0]

--- a/auslib/AUS.py
+++ b/auslib/AUS.py
@@ -44,9 +44,9 @@ class AUSRandom:
 
 class AUS:
 
-    def __init__(self):
+    def __init__(self, rand=None):
         self.specialForceHosts = None
-        self.rand = AUSRandom()
+        self.rand = rand or AUSRandom()
         self.log = logging.getLogger(self.__class__.__name__)
 
     def evaluateRules(self, updateQuery):

--- a/auslib/AUS.py
+++ b/auslib/AUS.py
@@ -8,13 +8,14 @@ from auslib.global_state import dbo
 
 class ForceResult(object):
     """Enumerated "result" class that represents a non-random result chosen by a caller."""
-    def __init__(self, name):
+    def __init__(self, name, query_value):
         self.name = name
+        self.query_value = query_value
 
 
 # Magic constants that callers can use to choose a specific "random" result.
-SUCCEED = ForceResult('succeed')
-FAIL = ForceResult('fail')
+SUCCEED = ForceResult('succeed', '1')
+FAIL = ForceResult('fail', '-1')
 
 
 def isSpecialURL(url, specialForceHosts):

--- a/auslib/AUS.py
+++ b/auslib/AUS.py
@@ -43,9 +43,6 @@ class AUSRandom:
     def getInt(self):
         return randint(self.min, self.max)
 
-    def getRange(self):
-        return range(self.min, self.max + 1)
-
 
 class AUS:
 

--- a/auslib/AUS.py
+++ b/auslib/AUS.py
@@ -46,7 +46,7 @@ class AUS:
 
     def __init__(self, rand=None):
         self.specialForceHosts = None
-        self.rand = rand or AUSRandom()
+        self.rand = rand or AUSRandom().getInt
         self.log = logging.getLogger(self.__class__.__name__)
 
     def evaluateRules(self, updateQuery):
@@ -78,7 +78,7 @@ class AUS:
         # backgroundRate=25 means only one quarter of requests are served
         if not updateQuery['force'] and rule['backgroundRate'] < 100:
             self.log.debug("backgroundRate < 100, rolling the dice")
-            if self.rand.getInt() >= rule['backgroundRate']:
+            if self.rand() >= rule['backgroundRate']:
                 fallbackReleaseName = rule['fallbackMapping']
                 if fallbackReleaseName:
                     release = dbo.releases.getReleases(name=fallbackReleaseName, limit=1)[0]

--- a/auslib/AUS.py
+++ b/auslib/AUS.py
@@ -1,3 +1,4 @@
+import functools
 from random import randint
 from urlparse import urlparse
 
@@ -44,21 +45,11 @@ def getFallbackChannel(channel):
     return channel.split('-cck-')[0]
 
 
-class AUSRandom:
-    """Abstract getting a randint to make it easier to test the range of
-    possible values"""
-    min = 0
-    max = 99
-
-    def getInt(self):
-        return randint(self.min, self.max)
-
-
 class AUS:
 
-    def __init__(self, rand=None):
+    def __init__(self):
         self.specialForceHosts = None
-        self.rand = rand or AUSRandom().getInt
+        self.rand = functools.partial(randint, 0, 99)
         self.log = logging.getLogger(self.__class__.__name__)
 
     def evaluateRules(self, updateQuery):

--- a/auslib/blobs/apprelease.py
+++ b/auslib/blobs/apprelease.py
@@ -697,7 +697,7 @@ class UnifiedFileUrlsMixin(object):
 
         # pass on forcing for special hosts (eg download.m.o for mozilla metrics)
         if updateQuery['force']:
-            url = self.processSpecialForceHosts(url, specialForceHosts)
+            url = self.processSpecialForceHosts(url, specialForceHosts, updateQuery['force'])
 
         return url
 

--- a/auslib/blobs/apprelease.py
+++ b/auslib/blobs/apprelease.py
@@ -271,7 +271,7 @@ class SeparatedFileUrlsMixin(object):
             url = url.replace('%os_bouncer%', platformData['OS_BOUNCER'])
         # pass on forcing for special hosts (eg download.m.o for mozilla metrics)
         if updateQuery['force']:
-            url = self.processSpecialForceHosts(url, specialForceHosts)
+            url = self.processSpecialForceHosts(url, specialForceHosts, updateQuery['force'])
 
         return url
 

--- a/auslib/blobs/base.py
+++ b/auslib/blobs/base.py
@@ -120,12 +120,12 @@ class Blob(dict):
         failing open)."""
         return False
 
-    def processSpecialForceHosts(self, url, specialForceHosts):
+    def processSpecialForceHosts(self, url, specialForceHosts, force_arg):
         if isSpecialURL(url, specialForceHosts):
             if '?' in url:
-                url += '&force=1'
+                url += '&force=' + force_arg.query_value
             else:
-                url += '?force=1'
+                url += '?force=' + force_arg.query_value
         return url
 
     def getInnerHeaderXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -8,6 +8,7 @@ import logging
 import mock
 import unittest
 
+from auslib.AUS import SUCCEED, FAIL
 from auslib.global_state import dbo
 from auslib.errors import BadDataError
 from auslib.web.public.base import app
@@ -330,7 +331,7 @@ class TestOldVersionSpecialCases(unittest.TestCase):
             "product": "h", "version": "2.0.0.20", "buildID": "0",
             "buildTarget": "p", "locale": "m", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, None)
@@ -353,7 +354,7 @@ class TestOldVersionSpecialCases(unittest.TestCase):
             "product": "h", "version": "3.0.9", "buildID": "0",
             "buildTarget": "p", "locale": "m", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, None)
@@ -376,7 +377,7 @@ class TestOldVersionSpecialCases(unittest.TestCase):
             "product": "h", "version": "3.5.19", "buildID": "0",
             "buildTarget": "p", "locale": "m", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, None)
@@ -399,7 +400,7 @@ class TestOldVersionSpecialCases(unittest.TestCase):
             "product": "h", "version": "3.6", "buildID": "0",
             "buildTarget": "p", "locale": "m", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, None)
@@ -488,7 +489,7 @@ class TestSpecialQueryParams(unittest.TestCase):
             "product": "h", "version": "0.5", "buildID": "0",
             "buildTarget": "p", "locale": "l", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -511,7 +512,7 @@ class TestSpecialQueryParams(unittest.TestCase):
             "product": "h", "version": "0.5", "buildID": "0",
             "buildTarget": "p", "locale": "l", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 1
+            "force": SUCCEED,
         }
         returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -529,12 +530,35 @@ class TestSpecialQueryParams(unittest.TestCase):
         self.assertItemsEqual(returned, expected)
         self.assertEqual(returned_footer.strip(), expected_footer.strip())
 
+    def testSpecialQueryParamForcedFail(self):
+        updateQuery = {
+            "product": "h", "version": "0.5", "buildID": "0",
+            "buildTarget": "p", "locale": "l", "channel": "a",
+            "osVersion": "a", "distribution": "a", "distVersion": "a",
+            "force": FAIL,
+        }
+        returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned_footer = self.blob.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned = [x.strip() for x in returned]
+        expected_header = """
+<update type="minor" version="1.0" extensionVersion="1.0" buildID="1" detailsURL="http://example.org/details" licenseURL="http://example.org/license">
+"""
+        expected = ["""
+<patch type="complete" URL="http://a.com/?foo=a&force=-1" hashFunction="sha512" hashValue="1" size="1"/>
+"""]
+        expected = [x.strip() for x in expected]
+        expected_footer = "</update>"
+        self.assertEqual(returned_header.strip(), expected_header.strip())
+        self.assertItemsEqual(returned, expected)
+        self.assertEqual(returned_footer.strip(), expected_footer.strip())
+
     def testNonSpecialQueryParam(self):
         updateQuery = {
             "product": "h", "version": "0.5", "buildID": "0",
             "buildTarget": "p", "locale": "m", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -557,7 +581,7 @@ class TestSpecialQueryParams(unittest.TestCase):
             "product": "h", "version": "0.5", "buildID": "0",
             "buildTarget": "p", "locale": "m", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 1
+            "force": SUCCEED,
         }
         returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -580,7 +604,7 @@ class TestSpecialQueryParams(unittest.TestCase):
             "product": "h", "version": "0.5", "buildID": "0",
             "buildTarget": "p", "locale": "m", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -811,7 +835,7 @@ class TestSchema2Blob(unittest.TestCase):
             "product": "j", "version": "35.0", "buildID": "4",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobJ2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobJ2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -834,7 +858,7 @@ class TestSchema2Blob(unittest.TestCase):
             "product": "j", "version": "39.0", "buildID": "28",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobJ2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobJ2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -859,7 +883,7 @@ class TestSchema2Blob(unittest.TestCase):
             "product": "k", "version": "35.0", "buildID": "4",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobK.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobK.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -884,7 +908,7 @@ class TestSchema2Blob(unittest.TestCase):
             "product": "k", "version": "35.0", "buildID": "4",
             "buildTarget": "p", "locale": "l2", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobK.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobK.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -981,7 +1005,7 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
             "product": "j", "version": "0.5", "buildID": "0",
             "buildTarget": "p", "locale": "l", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobJ2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobJ2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1004,7 +1028,7 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
             "product": "j", "version": "0.5", "buildID": "1",
             "buildTarget": "p", "locale": "l", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobJ2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobJ2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1340,7 +1364,7 @@ class TestSchema3Blob(unittest.TestCase):
             "product": "f", "version": "22.0", "buildID": "5",
             "buildTarget": "p", "locale": "l", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobF3.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobF3.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1364,7 +1388,7 @@ class TestSchema3Blob(unittest.TestCase):
             "product": "f", "version": "23.0", "buildID": "6",
             "buildTarget": "p", "locale": "l", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobF3.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobF3.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1389,7 +1413,7 @@ class TestSchema3Blob(unittest.TestCase):
             "product": "f", "version": "20.0", "buildID": "1",
             "buildTarget": "p", "locale": "l", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobF3.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobF3.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1412,7 +1436,7 @@ class TestSchema3Blob(unittest.TestCase):
             "product": "f", "version": "20.0", "buildID": "1",
             "buildTarget": "p", "locale": "m", "channel": "a",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobF3.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobF3.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1435,7 +1459,7 @@ class TestSchema3Blob(unittest.TestCase):
             "product": "g", "version": "23.0", "buildID": "8",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobG2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobG2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1460,7 +1484,7 @@ class TestSchema3Blob(unittest.TestCase):
             "product": "g", "version": "23.0", "buildID": "8",
             "buildTarget": "p", "locale": "l", "channel": "c2",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobG2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobG2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1860,7 +1884,7 @@ class TestSchema4Blob(unittest.TestCase):
             "product": "h", "version": "30.0", "buildID": "10",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobH2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobH2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1884,7 +1908,7 @@ class TestSchema4Blob(unittest.TestCase):
             "product": "h", "version": "30.0", "buildID": "10",
             "buildTarget": "p", "locale": "l", "channel": "c2",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobH2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobH2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1908,7 +1932,7 @@ class TestSchema4Blob(unittest.TestCase):
             "product": "h", "version": "30.0", "buildID": "10",
             "buildTarget": "p", "locale": "l", "channel": "c3",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobH2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobH2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1933,7 +1957,7 @@ class TestSchema4Blob(unittest.TestCase):
             "product": "h", "version": "25.0", "buildID": "2",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobH2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobH2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1955,7 +1979,7 @@ class TestSchema4Blob(unittest.TestCase):
             "product": "h", "version": "25.0", "buildID": "2",
             "buildTarget": "p", "locale": "l", "channel": "c2",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobH2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobH2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -1977,7 +2001,7 @@ class TestSchema4Blob(unittest.TestCase):
             "product": "h", "version": "25.0", "buildID": "2",
             "buildTarget": "p", "locale": "l", "channel": "c3",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobH2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobH2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -2000,7 +2024,7 @@ class TestSchema4Blob(unittest.TestCase):
             "product": "h", "version": "29.0", "buildID": "5",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobH3.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobH3.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -2407,7 +2431,7 @@ class TestSchema5Blob(unittest.TestCase):
             "product": "h", "version": "30.0", "buildID": "10",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobH2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobH2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -2609,7 +2633,7 @@ class TestSchema6Blob(unittest.TestCase):
             "product": "h", "buildID": "10",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobH2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobH2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -2861,7 +2885,7 @@ class TestSchema7Blob(unittest.TestCase):
             "product": "h", "buildID": "10",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobH2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobH2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -2984,7 +3008,7 @@ class TestSchema8Blob(unittest.TestCase):
             "product": "h", "buildID": "10",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         returned_header = self.blobH2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
         returned = self.blobH2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
@@ -3089,7 +3113,7 @@ class TestUnifiedFileUrlsMixin(unittest.TestCase):
             "product": "h", "version": "30.0", "buildID": "10",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         patchKey = "partials"
         patch = {"from": "h1"}
@@ -3105,7 +3129,7 @@ class TestUnifiedFileUrlsMixin(unittest.TestCase):
             "product": "h", "version": "30.0", "buildID": "10",
             "buildTarget": "p", "locale": "l", "channel": "c1",
             "osVersion": "a", "distribution": "a", "distVersion": "a",
-            "force": 0
+            "force": None,
         }
         patchKey = "partials"
         patch = {"from": "h2"}

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -7,6 +7,10 @@ from auslib.AUS import AUS
 from auslib.blobs.base import createBlob
 
 
+def getRange(rand):
+    return range(rand.min, rand.max + 1)
+
+
 def setUpModule():
     # Silence SQLAlchemy-Migrate's debugging logger
     logging.getLogger('migrate').setLevel(logging.CRITICAL)
@@ -17,7 +21,7 @@ def RandomAUSTestWithoutFallback(AUS, backgroundRate, force, mapping):
         m.return_value = [dict(backgroundRate=backgroundRate, priority=1, mapping=mapping, update_type='minor',
                                fallbackMapping=None)]
 
-        results = AUS.rand.getRange()
+        results = getRange(AUS.rand)
         resultsLength = len(results)
 
         def se(*args, **kwargs):
@@ -46,7 +50,7 @@ def RandomAUSTestWithFallback(AUS, backgroundRate, force, mapping):
         m.return_value = [dict(backgroundRate=backgroundRate, priority=1, mapping=mapping, update_type='minor',
                                fallbackMapping='fallback')]
 
-        results = AUS.rand.getRange()
+        results = getRange(AUS.rand)
         resultsLength = len(results)
 
         def se(*args, **kwargs):

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -16,67 +16,6 @@ def setUpModule():
     logging.getLogger('migrate').setLevel(logging.CRITICAL)
 
 
-def RandomAUSTestWithoutFallback(backgroundRate, force, mapping):
-    with mock.patch('auslib.db.Rules.getRulesMatchingQuery') as m:
-        m.return_value = [dict(backgroundRate=backgroundRate, priority=1, mapping=mapping, update_type='minor',
-                               fallbackMapping=None)]
-
-        results = getRange(AUSRandom)
-        resultsLength = len(results)
-
-        def se(*args, **kwargs):
-            return results.pop()
-
-        aus = AUS(se)
-        served = 0
-        tested = 0
-        while len(results) > 0:
-            updateQuery = dict(
-                channel='foo', force=force, buildTarget='a', buildID='0',
-                locale='a', version='1.0',
-            )
-            r, _ = aus.evaluateRules(updateQuery)
-            tested += 1
-            if r:
-                served += 1
-            # bail out if we're not asking for any randint's
-            if resultsLength == len(results):
-                break
-        return (served, tested)
-
-
-def RandomAUSTestWithFallback(backgroundRate, force, mapping):
-    with mock.patch('auslib.db.Rules.getRulesMatchingQuery') as m:
-        m.return_value = [dict(backgroundRate=backgroundRate, priority=1, mapping=mapping, update_type='minor',
-                               fallbackMapping='fallback')]
-
-        results = getRange(AUSRandom)
-        resultsLength = len(results)
-
-        def se(*args, **kwargs):
-            return results.pop()
-        aus = AUS(se)
-
-        served_mapping = 0
-        served_fallback = 0
-        tested = 0
-        while len(results) > 0:
-            updateQuery = dict(
-                channel='foo', force=force, buildTarget='a', buildID='0',
-                locale='a', version='1.0',
-            )
-            r, _ = aus.evaluateRules(updateQuery)
-            tested += 1
-            if r['name'] == mapping:
-                served_mapping += 1
-            elif r['name'] == "fallback":
-                served_fallback += 1
-            # bail out if we're not asking for any randint's
-            if resultsLength == len(results):
-                break
-        return (served_mapping, served_fallback, tested)
-
-
 class TestAUSThrottlingWithoutFallback(unittest.TestCase):
 
     def setUp(self):
@@ -93,71 +32,107 @@ class TestAUSThrottlingWithoutFallback(unittest.TestCase):
     def tearDown(self):
         dbo.reset()
 
+    def random_aus_test(self, background_rate, force, mapping, fallback=False):
+        with mock.patch('auslib.db.Rules.getRulesMatchingQuery') as m:
+            fallback = fallback and 'fallback'  # convert True to string
+            m.return_value = [dict(backgroundRate=background_rate, priority=1, mapping=mapping, update_type='minor',
+                                   fallbackMapping=fallback)]
+
+            results = getRange(AUSRandom)
+            resultsLength = len(results)
+
+            def se(*args, **kwargs):
+                return results.pop()
+
+            aus = AUS(se)
+            served_mapping = 0
+            served_fallback = 0
+            tested = 0
+            while len(results) > 0:
+                updateQuery = dict(
+                    channel='foo', force=force, buildTarget='a', buildID='0',
+                    locale='a', version='1.0',
+                )
+                r, _ = aus.evaluateRules(updateQuery)
+                tested += 1
+                if r and r['name'] == mapping:
+                    served_mapping += 1
+                elif fallback and r['name'] == fallback:
+                    served_fallback += 1
+                # bail out if we're not asking for any randint's
+                if resultsLength == len(results):
+                    break
+            return (served_mapping, served_fallback, tested)
+
     def testThrottling100(self):
-        (served, tested) = RandomAUSTestWithoutFallback(backgroundRate=100, force=False, mapping='b')
+        (served, _, tested) = self.random_aus_test(background_rate=100, force=False, mapping='b')
 
         self.assertEqual(served, 1)
         self.assertEqual(tested, 1)
 
     def testThrottling50(self):
-        (served, tested) = RandomAUSTestWithoutFallback(backgroundRate=50, force=False, mapping='b')
+        (served, _, tested) = self.random_aus_test(background_rate=50, force=False, mapping='b')
 
         self.assertEqual(served, 50)
         self.assertEqual(tested, 100)
 
     def testThrottling25(self):
-        (served, tested) = RandomAUSTestWithoutFallback(backgroundRate=25, force=False, mapping='b')
+        (served, _, tested) = self.random_aus_test(background_rate=25, force=False, mapping='b')
 
         self.assertEqual(served, 25)
         self.assertEqual(tested, 100)
 
     def testThrottlingZero(self):
-        (served, tested) = RandomAUSTestWithoutFallback(backgroundRate=0, force=False, mapping='b')
+        (served, _, tested) = self.random_aus_test(background_rate=0, force=False, mapping='b')
         self.assertEqual(served, 0)
         self.assertEqual(tested, 100)
 
     def testThrottling25WithForcing(self):
-        (served, tested) = RandomAUSTestWithoutFallback(backgroundRate=25, force=True, mapping='b')
+        (served, _, tested) = self.random_aus_test(background_rate=25, force=True, mapping='b')
 
         self.assertEqual(served, 1)
         self.assertEqual(tested, 1)
 
-
     def testThrottling100WithFallback(self):
-        (served_mapping, served_fallback, tested) = RandomAUSTestWithFallback(backgroundRate=100,
-                                                                              force=False, mapping='b')
+        (served_mapping, served_fallback, tested) = self.random_aus_test(background_rate=100,
+                                                                         force=False, mapping='b',
+                                                                         fallback=True)
 
         self.assertEqual(served_mapping, 1)
         self.assertEqual(served_fallback, 0)
         self.assertEqual(tested, 1)
 
     def testThrottling50WithFallback(self):
-        (served_mapping, served_fallback, tested) = RandomAUSTestWithFallback(backgroundRate=50,
-                                                                              force=False, mapping='b')
+        (served_mapping, served_fallback, tested) = self.random_aus_test(background_rate=50,
+                                                                         force=False, mapping='b',
+                                                                         fallback=True)
 
         self.assertEqual(served_mapping, 50)
         self.assertEqual(served_fallback, 50)
         self.assertEqual(tested, 100)
 
     def testThrottling25WithFallback(self):
-        (served_mapping, served_fallback, tested) = RandomAUSTestWithFallback(backgroundRate=25,
-                                                                              force=False, mapping='b')
+        (served_mapping, served_fallback, tested) = self.random_aus_test(background_rate=25,
+                                                                         force=False, mapping='b',
+                                                                         fallback=True)
 
         self.assertEqual(served_mapping, 25)
         self.assertEqual(served_fallback, 75)
         self.assertEqual(tested, 100)
 
     def testThrottlingZeroWithFallback(self):
-        (served_mapping, served_fallback, tested) = RandomAUSTestWithFallback(backgroundRate=0,
-                                                                              force=False, mapping='b')
+        (served_mapping, served_fallback, tested) = self.random_aus_test(background_rate=0,
+                                                                         force=False, mapping='b',
+                                                                         fallback=True)
 
         self.assertEqual(served_mapping, 0)
         self.assertEqual(served_fallback, 100)
         self.assertEqual(tested, 100)
 
     def testThrottling25WithForcingAndFallback(self):
-        (served_mapping, served_fallback, tested) = RandomAUSTestWithFallback(backgroundRate=25,
-                                                                              force=True, mapping='b')
+        (served_mapping, served_fallback, tested) = self.random_aus_test(background_rate=25,
+                                                                         force=True, mapping='b',
+                                                                         fallback=True)
 
         self.assertEqual(served_mapping, 1)
         self.assertEqual(served_fallback, 0)

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -123,21 +123,6 @@ class TestAUSThrottlingWithoutFallback(unittest.TestCase):
         self.assertEqual(tested, 1)
 
 
-class TestAUSThrottlingWithFallback(unittest.TestCase):
-    def setUp(self):
-        dbo.setDb('sqlite:///:memory:')
-        dbo.create()
-        dbo.releases.t.insert().execute(
-            name='b', product='b', data_version=1,
-            data=createBlob({"name": "b", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}))
-
-        dbo.releases.t.insert().execute(
-            name='fallback', product='b', data_version=1,
-            data=createBlob({"name": "fallback", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}))
-
-    def tearDown(self):
-        dbo.reset()
-
     def testThrottling100WithFallback(self):
         (served_mapping, served_fallback, tested) = RandomAUSTestWithFallback(backgroundRate=100,
                                                                               force=False, mapping='b')
@@ -146,7 +131,7 @@ class TestAUSThrottlingWithFallback(unittest.TestCase):
         self.assertEqual(served_fallback, 0)
         self.assertEqual(tested, 1)
 
-    def testThrottling50(self):
+    def testThrottling50WithFallback(self):
         (served_mapping, served_fallback, tested) = RandomAUSTestWithFallback(backgroundRate=50,
                                                                               force=False, mapping='b')
 
@@ -154,7 +139,7 @@ class TestAUSThrottlingWithFallback(unittest.TestCase):
         self.assertEqual(served_fallback, 50)
         self.assertEqual(tested, 100)
 
-    def testThrottling25(self):
+    def testThrottling25WithFallback(self):
         (served_mapping, served_fallback, tested) = RandomAUSTestWithFallback(backgroundRate=25,
                                                                               force=False, mapping='b')
 
@@ -162,7 +147,7 @@ class TestAUSThrottlingWithFallback(unittest.TestCase):
         self.assertEqual(served_fallback, 75)
         self.assertEqual(tested, 100)
 
-    def testThrottlingZero(self):
+    def testThrottlingZeroWithFallback(self):
         (served_mapping, served_fallback, tested) = RandomAUSTestWithFallback(backgroundRate=0,
                                                                               force=False, mapping='b')
 
@@ -170,7 +155,7 @@ class TestAUSThrottlingWithFallback(unittest.TestCase):
         self.assertEqual(served_fallback, 100)
         self.assertEqual(tested, 100)
 
-    def testThrottling25WithForcing(self):
+    def testThrottling25WithForcingAndFallback(self):
         (served_mapping, served_fallback, tested) = RandomAUSTestWithFallback(backgroundRate=25,
                                                                               force=True, mapping='b')
 

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -27,24 +27,22 @@ def RandomAUSTestWithoutFallback(backgroundRate, force, mapping):
         def se(*args, **kwargs):
             return results.pop()
 
-        aus = AUS()
-        with mock.patch('auslib.AUS.AUSRandom.getInt') as m2:
-            m2.side_effect = se
-            served = 0
-            tested = 0
-            while len(results) > 0:
-                updateQuery = dict(
-                    channel='foo', force=force, buildTarget='a', buildID='0',
-                    locale='a', version='1.0',
-                )
-                r, _ = aus.evaluateRules(updateQuery)
-                tested += 1
-                if r:
-                    served += 1
-                # bail out if we're not asking for any randint's
-                if resultsLength == len(results):
-                    break
-            return (served, tested)
+        aus = AUS(mock.Mock(getInt=mock.Mock(side_effect=se)))
+        served = 0
+        tested = 0
+        while len(results) > 0:
+            updateQuery = dict(
+                channel='foo', force=force, buildTarget='a', buildID='0',
+                locale='a', version='1.0',
+            )
+            r, _ = aus.evaluateRules(updateQuery)
+            tested += 1
+            if r:
+                served += 1
+            # bail out if we're not asking for any randint's
+            if resultsLength == len(results):
+                break
+        return (served, tested)
 
 
 def RandomAUSTestWithFallback(backgroundRate, force, mapping):
@@ -57,27 +55,26 @@ def RandomAUSTestWithFallback(backgroundRate, force, mapping):
 
         def se(*args, **kwargs):
             return results.pop()
-        aus = AUS()
-        with mock.patch('auslib.AUS.AUSRandom.getInt') as m2:
-            m2.side_effect = se
-            served_mapping = 0
-            served_fallback = 0
-            tested = 0
-            while len(results) > 0:
-                updateQuery = dict(
-                    channel='foo', force=force, buildTarget='a', buildID='0',
-                    locale='a', version='1.0',
-                )
-                r, _ = aus.evaluateRules(updateQuery)
-                tested += 1
-                if r['name'] == mapping:
-                    served_mapping += 1
-                elif r['name'] == "fallback":
-                    served_fallback += 1
-                # bail out if we're not asking for any randint's
-                if resultsLength == len(results):
-                    break
-            return (served_mapping, served_fallback, tested)
+        aus = AUS(mock.Mock(getInt=mock.Mock(side_effect=se)))
+
+        served_mapping = 0
+        served_fallback = 0
+        tested = 0
+        while len(results) > 0:
+            updateQuery = dict(
+                channel='foo', force=force, buildTarget='a', buildID='0',
+                locale='a', version='1.0',
+            )
+            r, _ = aus.evaluateRules(updateQuery)
+            tested += 1
+            if r['name'] == mapping:
+                served_mapping += 1
+            elif r['name'] == "fallback":
+                served_fallback += 1
+            # bail out if we're not asking for any randint's
+            if resultsLength == len(results):
+                break
+        return (served_mapping, served_fallback, tested)
 
 
 class TestAUSThrottlingWithoutFallback(unittest.TestCase):

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -32,7 +32,8 @@ class TestAUSThrottlingWithoutFallback(unittest.TestCase):
     def tearDown(self):
         dbo.reset()
 
-    def random_aus_test(self, background_rate, force, mapping, fallback=False):
+    def random_aus_test(self, background_rate, force, fallback=False):
+        mapping = 'b'
         with mock.patch('auslib.db.Rules.getRulesMatchingQuery') as m:
             fallback = fallback and 'fallback'  # convert True to string
             m.return_value = [dict(backgroundRate=background_rate, priority=1, mapping=mapping, update_type='minor',
@@ -65,37 +66,37 @@ class TestAUSThrottlingWithoutFallback(unittest.TestCase):
             return (served_mapping, served_fallback, tested)
 
     def testThrottling100(self):
-        (served, _, tested) = self.random_aus_test(background_rate=100, force=False, mapping='b')
+        (served, _, tested) = self.random_aus_test(background_rate=100, force=False)
 
         self.assertEqual(served, 1)
         self.assertEqual(tested, 1)
 
     def testThrottling50(self):
-        (served, _, tested) = self.random_aus_test(background_rate=50, force=False, mapping='b')
+        (served, _, tested) = self.random_aus_test(background_rate=50, force=False)
 
         self.assertEqual(served, 50)
         self.assertEqual(tested, 100)
 
     def testThrottling25(self):
-        (served, _, tested) = self.random_aus_test(background_rate=25, force=False, mapping='b')
+        (served, _, tested) = self.random_aus_test(background_rate=25, force=False)
 
         self.assertEqual(served, 25)
         self.assertEqual(tested, 100)
 
     def testThrottlingZero(self):
-        (served, _, tested) = self.random_aus_test(background_rate=0, force=False, mapping='b')
+        (served, _, tested) = self.random_aus_test(background_rate=0, force=False)
         self.assertEqual(served, 0)
         self.assertEqual(tested, 100)
 
     def testThrottling25WithForcing(self):
-        (served, _, tested) = self.random_aus_test(background_rate=25, force=True, mapping='b')
+        (served, _, tested) = self.random_aus_test(background_rate=25, force=True)
 
         self.assertEqual(served, 1)
         self.assertEqual(tested, 1)
 
     def testThrottling100WithFallback(self):
         (served_mapping, served_fallback, tested) = self.random_aus_test(background_rate=100,
-                                                                         force=False, mapping='b',
+                                                                         force=False,
                                                                          fallback=True)
 
         self.assertEqual(served_mapping, 1)
@@ -104,7 +105,7 @@ class TestAUSThrottlingWithoutFallback(unittest.TestCase):
 
     def testThrottling50WithFallback(self):
         (served_mapping, served_fallback, tested) = self.random_aus_test(background_rate=50,
-                                                                         force=False, mapping='b',
+                                                                         force=False,
                                                                          fallback=True)
 
         self.assertEqual(served_mapping, 50)
@@ -113,7 +114,7 @@ class TestAUSThrottlingWithoutFallback(unittest.TestCase):
 
     def testThrottling25WithFallback(self):
         (served_mapping, served_fallback, tested) = self.random_aus_test(background_rate=25,
-                                                                         force=False, mapping='b',
+                                                                         force=False,
                                                                          fallback=True)
 
         self.assertEqual(served_mapping, 25)
@@ -122,7 +123,7 @@ class TestAUSThrottlingWithoutFallback(unittest.TestCase):
 
     def testThrottlingZeroWithFallback(self):
         (served_mapping, served_fallback, tested) = self.random_aus_test(background_rate=0,
-                                                                         force=False, mapping='b',
+                                                                         force=False,
                                                                          fallback=True)
 
         self.assertEqual(served_mapping, 0)
@@ -131,7 +132,7 @@ class TestAUSThrottlingWithoutFallback(unittest.TestCase):
 
     def testThrottling25WithForcingAndFallback(self):
         (served_mapping, served_fallback, tested) = self.random_aus_test(background_rate=25,
-                                                                         force=True, mapping='b',
+                                                                         force=True,
                                                                          fallback=True)
 
         self.assertEqual(served_mapping, 1)

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -3,12 +3,11 @@ import mock
 import unittest
 
 from auslib.global_state import dbo
-from auslib.AUS import AUS, AUSRandom, SUCCEED, FAIL
+from auslib.AUS import AUS, SUCCEED, FAIL
 from auslib.blobs.base import createBlob
 
 
-def getRange(rand):
-    return range(rand.min, rand.max + 1)
+ENTIRE_RANGE = range(0, 100)
 
 
 def setUpModule():
@@ -39,13 +38,14 @@ class TestAUSThrottlingWithoutFallback(unittest.TestCase):
             m.return_value = [dict(backgroundRate=background_rate, priority=1, mapping=mapping, update_type='minor',
                                    fallbackMapping=fallback)]
 
-            results = getRange(AUSRandom)
+            results = list(ENTIRE_RANGE)
             resultsLength = len(results)
 
             def se(*args, **kwargs):
                 return results.pop()
 
-            aus = AUS(se)
+            aus = AUS()
+            aus.rand = mock.Mock(side_effect=se)
             served_mapping = 0
             served_fallback = 0
             tested = 0

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -3,7 +3,7 @@ import mock
 import unittest
 
 from auslib.global_state import dbo
-from auslib.AUS import AUS
+from auslib.AUS import AUS, AUSRandom
 from auslib.blobs.base import createBlob
 
 
@@ -21,12 +21,13 @@ def RandomAUSTestWithoutFallback(backgroundRate, force, mapping):
         m.return_value = [dict(backgroundRate=backgroundRate, priority=1, mapping=mapping, update_type='minor',
                                fallbackMapping=None)]
 
-        aus = AUS()
-        results = getRange(aus.rand)
+        results = getRange(AUSRandom)
         resultsLength = len(results)
 
         def se(*args, **kwargs):
             return results.pop()
+
+        aus = AUS()
         with mock.patch('auslib.AUS.AUSRandom.getInt') as m2:
             m2.side_effect = se
             served = 0
@@ -51,12 +52,12 @@ def RandomAUSTestWithFallback(backgroundRate, force, mapping):
         m.return_value = [dict(backgroundRate=backgroundRate, priority=1, mapping=mapping, update_type='minor',
                                fallbackMapping='fallback')]
 
-        aus = AUS()
-        results = getRange(aus.rand)
+        results = getRange(AUSRandom)
         resultsLength = len(results)
 
         def se(*args, **kwargs):
             return results.pop()
+        aus = AUS()
         with mock.patch('auslib.AUS.AUSRandom.getInt') as m2:
             m2.side_effect = se
             served_mapping = 0

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -27,7 +27,7 @@ def RandomAUSTestWithoutFallback(backgroundRate, force, mapping):
         def se(*args, **kwargs):
             return results.pop()
 
-        aus = AUS(mock.Mock(getInt=mock.Mock(side_effect=se)))
+        aus = AUS(se)
         served = 0
         tested = 0
         while len(results) > 0:
@@ -55,7 +55,7 @@ def RandomAUSTestWithFallback(backgroundRate, force, mapping):
 
         def se(*args, **kwargs):
             return results.pop()
-        aus = AUS(mock.Mock(getInt=mock.Mock(side_effect=se)))
+        aus = AUS(se)
 
         served_mapping = 0
         served_fallback = 0

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -86,7 +86,7 @@ def getQueryFromURL(url):
     ua = request.headers.get('User-Agent')
     query['headerArchitecture'] = getHeaderArchitecture(query['buildTarget'], ua)
     force = query.get('force')
-    query['force'] = {'1': SUCCEED, '0': FAIL}.get(force)
+    query['force'] = {'1': SUCCEED, '-1': FAIL}.get(force)
     if "mig64" in query:
         # "1" is the only value that official clients send. We ignore any other values
         # by setting mig64 to None.

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -64,7 +64,7 @@ def getCleanQueryFromURL(url):
         if len(force_split) < 2:
             force_split = force_value.split('%3F', 1)
 
-        query['force'] = int(force_split[0])
+        query['force'] = force_split[0]
 
         avast_parameter = force_split[1]
         avast_split = avast_parameter.split('=')

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -6,7 +6,7 @@ from connexion import request
 
 from flask import make_response, current_app as app
 
-from auslib.AUS import AUS
+from auslib.AUS import AUS, SUCCEED, FAIL
 from auslib.global_state import dbo
 
 import logging
@@ -85,7 +85,8 @@ def getQueryFromURL(url):
     query['osVersion'] = urllib.unquote(query['osVersion'])
     ua = request.headers.get('User-Agent')
     query['headerArchitecture'] = getHeaderArchitecture(query['buildTarget'], ua)
-    query['force'] = (int(query.get('force', 0)) == 1)
+    force = query.get('force')
+    query['force'] = {'1': SUCCEED, '0': FAIL}.get(force)
     if "mig64" in query:
         # "1" is the only value that official clients send. We ignore any other values
         # by setting mig64 to None.

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -86,7 +86,10 @@ def getQueryFromURL(url):
     ua = request.headers.get('User-Agent')
     query['headerArchitecture'] = getHeaderArchitecture(query['buildTarget'], ua)
     force = query.get('force')
-    query['force'] = {'1': SUCCEED, '-1': FAIL}.get(force)
+    query['force'] = {
+        SUCCEED.query_value: SUCCEED,
+        FAIL.query_value: FAIL
+    }.get(force)
     if "mig64" in query:
         # "1" is the only value that official clients send. We ignore any other values
         # by setting mig64 to None.


### PR DESCRIPTION
Currently it's possible to cause a request to definitely receive the up-to-date mapping using the `force=1` argument. However, it isn't possible to cause a request to definitely receive the fallback mapping. Add this by adding a `force=0` argument.

While we're here, refactor the AUS tests a bit.

This PR, being somewhat involved, may be easiest to read commit-by-commit.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1391668.