### PR TITLE
bug 1380874: Remove signoff/revoke buttons from history.

### DIFF
--- a/ui/app/templates/permission_scheduled_changes.html
+++ b/ui/app/templates/permission_scheduled_changes.html
@@ -41,12 +41,12 @@
 
     <h3 class="panel-title">
       <div style="float: right">
-        <i ng-show="!scheduled_changes_rules_count && !sc.complete" ng-if=" scheduled_changes_rules_count && $first && (currentPage == 1)">Current</i>
-        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
+        <i ng-if=" scheduled_changes_rules_count && $first && (currentPage == 1)">Current</i>
+        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && ! sc['signoffs'].hasOwnProperty(current_user)">
             Signoff as...
         </button>
-        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
+        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
             Revoke your Signoff
         </button>

--- a/ui/app/templates/permission_scheduled_changes.html
+++ b/ui/app/templates/permission_scheduled_changes.html
@@ -41,12 +41,12 @@
 
     <h3 class="panel-title">
       <div style="float: right">
-        <i ng-if=" scheduled_changes_rules_count && $first && (currentPage == 1)">Current</i>
-        <button class="btn btn-xs btn-primary" ng-click="signoff(sc)"
+        <i ng-show="!scheduled_changes_rules_count && !sc.complete" ng-if=" scheduled_changes_rules_count && $first && (currentPage == 1)">Current</i>
+        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && ! sc['signoffs'].hasOwnProperty(current_user)">
             Signoff as...
         </button>
-        <button class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
+        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
             Revoke your Signoff
         </button>

--- a/ui/app/templates/permission_scheduled_changes.html
+++ b/ui/app/templates/permission_scheduled_changes.html
@@ -42,13 +42,13 @@
     <h3 class="panel-title">
       <div style="float: right">
         <i ng-if=" scheduled_changes_rules_count && $first && (currentPage == 1)">Current</i>
-        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
-                ng-show="! isEmpty(sc['required_signoffs']) && ! sc['signoffs'].hasOwnProperty(current_user)">
-            Signoff as...
+        <button ng-show="!scheduled_changes_rules_count && (! isEmpty(sc['required_signoffs']) &&
+          !sc['signoffs'].hasOwnProperty(current_user))" class="btn btn-xs btn-primary" ng-click="signoff(sc)">
+          Signoff as...
         </button>
-        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
-                ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
-            Revoke your Signoff
+        <button ng-show="!scheduled_changes_rules_count && (! isEmpty(sc['required_signoffs']) &&
+          sc['signoffs'].hasOwnProperty(current_user))" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)">
+          Revoke your Signoff
         </button>
         <button ng-show="!sc.complete" class="btn btn-default btn-xs" ng-click="openScheduledUpdateModal(sc)">Update</button>
         <button ng-show="!sc.complete" class="btn btn-default btn-xs" ng-click="openDeleteModal(sc)">Delete</button>

--- a/ui/app/templates/release_scheduled_changes.html
+++ b/ui/app/templates/release_scheduled_changes.html
@@ -51,13 +51,13 @@
     <h3 class="panel-title">
       <div style="float: right">
         <i ng-if="scheduled_changes_count && $first && (currentPage == 1)">Current</i>
-        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
-                ng-show="! isEmpty(sc['required_signoffs']) && ! sc['signoffs'].hasOwnProperty(current_user)">
-            Signoff as...
+        <button ng-show="!scheduled_changes_rules_count && (! isEmpty(sc['required_signoffs']) &&
+          !sc['signoffs'].hasOwnProperty(current_user))" class="btn btn-xs btn-primary" ng-click="signoff(sc)">
+          Signoff as...
         </button>
-        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
-                ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
-            Revoke your Signoff
+        <button ng-show="!scheduled_changes_rules_count && (! isEmpty(sc['required_signoffs']) &&
+          sc['signoffs'].hasOwnProperty(current_user))" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)">
+          Revoke your Signoff
         </button>
         <button class="btn btn-default btn-xs" ng-click="openDataModal(sc)">View Data</button>
         <button ng-show="!scheduled_changes_count && !sc.complete" class="btn btn-default btn-xs" ng-click="openUpdateModal(sc)">Update</button>

--- a/ui/app/templates/release_scheduled_changes.html
+++ b/ui/app/templates/release_scheduled_changes.html
@@ -50,12 +50,12 @@
 
     <h3 class="panel-title">
       <div style="float: right">
-        <i ng-show="!scheduled_changes_rules_count && !sc.complete" ng-if="scheduled_changes_count && $first && (currentPage == 1)">Current</i>
-        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
+        <i ng-if="scheduled_changes_count && $first && (currentPage == 1)">Current</i>
+        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && ! sc['signoffs'].hasOwnProperty(current_user)">
             Signoff as...
         </button>
-        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
+        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
             Revoke your Signoff
         </button>

--- a/ui/app/templates/release_scheduled_changes.html
+++ b/ui/app/templates/release_scheduled_changes.html
@@ -50,12 +50,12 @@
 
     <h3 class="panel-title">
       <div style="float: right">
-        <i ng-if="scheduled_changes_count && $first && (currentPage == 1)">Current</i>
-        <button class="btn btn-xs btn-primary" ng-click="signoff(sc)"
+        <i ng-show="!scheduled_changes_rules_count && !sc.complete" ng-if="scheduled_changes_count && $first && (currentPage == 1)">Current</i>
+        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && ! sc['signoffs'].hasOwnProperty(current_user)">
             Signoff as...
         </button>
-        <button class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
+        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
             Revoke your Signoff
         </button>

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -54,13 +54,13 @@
     <h3 class="panel-title">
       <div style="float: right">
         <i ng-if=" scheduled_changes_rules_count && $first && (currentPage == 1)">Current</i>
-        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
-                ng-show="! isEmpty(sc['required_signoffs']) && ! sc['signoffs'].hasOwnProperty(current_user)">
-            Signoff as...
+        <button ng-show="!scheduled_changes_rules_count && (! isEmpty(sc['required_signoffs']) &&
+          !sc['signoffs'].hasOwnProperty(current_user))" class="btn btn-xs btn-primary" ng-click="signoff(sc)">
+          Signoff as...
         </button>
-        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
-                ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
-            Revoke your Signoff
+        <button ng-show="!scheduled_changes_rules_count && (! isEmpty(sc['required_signoffs']) &&
+          sc['signoffs'].hasOwnProperty(current_user))" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)">
+          Revoke your Signoff
         </button>
         <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-default btn-xs" ng-click="openUpdateModal(sc)">Update</button>
         <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-default btn-xs" ng-click="openDeleteModal(sc)">Delete</button>

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -53,12 +53,12 @@
 
     <h3 class="panel-title">
       <div style="float: right">
-        <i ng-show="!scheduled_changes_rules_count && !sc.complete"  ng-if=" scheduled_changes_rules_count && $first && (currentPage == 1)">Current</i>
-        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
+        <i ng-if=" scheduled_changes_rules_count && $first && (currentPage == 1)">Current</i>
+        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && ! sc['signoffs'].hasOwnProperty(current_user)">
             Signoff as...
         </button>
-        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
+        <button ng-show="!scheduled_changes_rules_count" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
             Revoke your Signoff
         </button>

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -53,12 +53,12 @@
 
     <h3 class="panel-title">
       <div style="float: right">
-        <i ng-if=" scheduled_changes_rules_count && $first && (currentPage == 1)">Current</i>
-        <button class="btn btn-xs btn-primary" ng-click="signoff(sc)"
+        <i ng-show="!scheduled_changes_rules_count && !sc.complete"  ng-if=" scheduled_changes_rules_count && $first && (currentPage == 1)">Current</i>
+        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-primary" ng-click="signoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && ! sc['signoffs'].hasOwnProperty(current_user)">
             Signoff as...
         </button>
-        <button class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
+        <button ng-show="!scheduled_changes_rules_count && !sc.complete" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)"
                 ng-show="! isEmpty(sc['required_signoffs']) && sc['signoffs'].hasOwnProperty(current_user)">
             Revoke your Signoff
         </button>


### PR DESCRIPTION
Currently, the history pages have the signoff/revoke signoff buttons. It is unnecessary to control permissions from history pages. This PR removes the buttons.