### PR TITLE
bug 1398237: adjust release process for new stage set-up

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,3 +1,27 @@
+# There's a lot going on in this file, and a lot of duplicated logic across multiple tasks.
+# Here's a summary of what we're doing for CI and Release:
+#  - We run backend, frontend, agent, and client tests on every push
+#    to the master branch, and every pull request.
+#
+#    - Ideally, we'd run tests for pushes to any branch, but every time
+#      a tag is created, it makes a push event that overrides the tests
+#      that already ran on that commit on the master branch. Limiting
+#      push events to the master branch avoids the messiness this
+#      generates.
+#
+#  - We build new docker images upon every push to the master branch.
+#    These show up on Dockerhub with tags that reference the commit.
+#
+#  - We build new docker images upon every Release (the official kind
+#    that are created through the Github UI -- not just tags). These
+#    show up on Dockerhub with tags that reference the Release version.
+#
+# Things we would like to do in the future:
+#  - Block all docker image creation tasks on tests passing. This is blocked
+#    on support for decision tasks (https://bugzilla.mozilla.org/show_bug.cgi?id=1252144).
+#
+#  - Build and publish the client library whenever a Release happens.
+#
 version: 0
 allowPullRequests: public
 metadata:
@@ -30,6 +54,8 @@ tasks:
           - pull_request.synchronize
           - pull_request.reopened
           - push
+        branches:
+          - master
     metadata:
       name: Balrog back-end tests
       description: Balrog Python tests
@@ -57,6 +83,8 @@ tasks:
           - pull_request.synchronize
           - pull_request.reopened
           - push
+        branches:
+          - master
     metadata:
       name: Balrog front-end tests
       description: Balrog JavaScript tests
@@ -84,13 +112,43 @@ tasks:
           - pull_request.synchronize
           - pull_request.reopened
           - push
+        branches:
+          - master
     metadata:
       name: Balrog Agent Tests
       description: Balrog Agent Tests
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"
 
-# TODO: make this depend on the test task after https://bugzilla.mozilla.org/show_bug.cgi?id=1252144 is fixed
+  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
+    workerType: "{{ taskcluster.docker.workerType }}"
+    payload:
+      maxRunTime: 1200
+      image: "mozillareleases/python-test-runner"
+      env:
+        NO_VOLUME_MOUNT: 1
+      command:
+        - "/bin/bash"
+        - "-c"
+        - "git clone $GITHUB_HEAD_REPO_URL && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd client && bash run-tests.sh"
+      features:
+        dind: true
+    extra:
+      github:
+        env: true
+        events:
+          - pull_request.opened
+          - pull_request.synchronize
+          - pull_request.reopened
+          - push
+        branches:
+          - master
+    metadata:
+      name: Balrog Python Client Tests
+      description: Balrog Python Client Tests
+      owner: "{{ event.head.user.email }}"
+      source: "{{ event.head.repo.url }}"
+
   - provisionerId: "{{ taskcluster.docker.provisionerId }}"
     workerType: "{{ taskcluster.docker.workerType }}"
     scopes:
@@ -118,35 +176,7 @@ tasks:
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"
 
-  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
-    workerType: "{{ taskcluster.docker.workerType }}"
-    payload:
-      maxRunTime: 1200
-      image: "mozillareleases/python-test-runner"
-      env:
-        NO_VOLUME_MOUNT: 1
-      command:
-        - "/bin/bash"
-        - "-c"
-        - "git clone $GITHUB_HEAD_REPO_URL && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd client && bash run-tests.sh"
-      features:
-        dind: true
-    extra:
-      github:
-        env: true
-        events:
-          - pull_request.opened
-          - pull_request.synchronize
-          - pull_request.reopened
-          - push
-    metadata:
-      name: Balrog Python Client Tests
-      description: Balrog Python Client Tests
-      owner: "{{ event.head.user.email }}"
-      source: "{{ event.head.repo.url }}"
 
-
-# TODO: make this depend on the test task after https://bugzilla.mozilla.org/show_bug.cgi?id=1252144 is fixed
   - provisionerId: "{{ taskcluster.docker.provisionerId }}"
     workerType: "{{ taskcluster.docker.workerType }}"
     scopes:
@@ -174,7 +204,6 @@ tasks:
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"
 
-# TODO: make this depend on the test task after https://bugzilla.mozilla.org/show_bug.cgi?id=1252144 is fixed
   - provisionerId: "{{ taskcluster.docker.provisionerId }}"
     workerType: "{{ taskcluster.docker.workerType }}"
     scopes:
@@ -188,19 +217,21 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone -b {{ event.version }} {{ event.head.repo.url }} && cd balrog && scripts/push-dockerimage.sh"
+        - "git clone -b {{ event.version }} {{ event.head.repo.url }} && cd balrog && scripts/push-dockerimage.sh {{ event.version }}"
     extra:
       github:
         env: true
         events:
           - release
+    routes:
+      - index.github.mozilla.balrog.releases.latest.app
+      - index.github.mozilla.balrog.releases.{{ event.version }}.app
     metadata:
       name: Balrog Docker Image Creation (release event)
       description: Balrog Docker Image Creation (release event)
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"
 
-# TODO: make this depend on the test task after https://bugzilla.mozilla.org/show_bug.cgi?id=1252144 is fixed
   - provisionerId: "{{ taskcluster.docker.provisionerId }}"
     workerType: "{{ taskcluster.docker.workerType }}"
     scopes:
@@ -214,12 +245,15 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone -b {{ event.version }} {{ event.head.repo.url }} && cd balrog/agent && scripts/push-dockerimage.sh"
+        - "git clone -b {{ event.version }} {{ event.head.repo.url }} && cd balrog/agent && scripts/push-dockerimage.sh {{ event.version }}"
     extra:
       github:
         env: true
         events:
           - release
+    routes:
+      - index.github.mozilla.balrog.releases.latest.agent
+      - index.github.mozilla.balrog.releases.{{ event.version }}.agent
     metadata:
       name: Balrog Agent Docker Image Creation (release event)
       description: Balrog Agent Docker Image Creation (release event)

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -224,8 +224,8 @@ tasks:
         events:
           - release
     routes:
-      - index.github.mozilla.balrog.releases.latest.app
-      - index.github.mozilla.balrog.releases.{{ event.version }}.app
+      - index.project.balrog.releases.latest.app
+      - index.project.balrog.releases.{{ event.version }}.app
     metadata:
       name: Balrog Docker Image Creation (release event)
       description: Balrog Docker Image Creation (release event)
@@ -252,8 +252,8 @@ tasks:
         events:
           - release
     routes:
-      - index.github.mozilla.balrog.releases.latest.agent
-      - index.github.mozilla.balrog.releases.{{ event.version }}.agent
+      - index.project.balrog.releases.latest.agent
+      - index.project.balrog.releases.{{ event.version }}.agent
     metadata:
       name: Balrog Agent Docker Image Creation (release event)
       description: Balrog Agent Docker Image Creation (release event)

--- a/agent/scripts/push-dockerimage.sh
+++ b/agent/scripts/push-dockerimage.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+extra_tag=$1
+
 password_url="taskcluster/secrets/v1/secret/repo:github.com/mozilla/balrog:dockerhub"
 artifact_url="taskcluster/queue/v1/task/${TASK_ID}/runs/${RUN_ID}/artifacts/public/docker-image-shasum256.txt"
 artifact_expiry=$(date -d "+1 year" -u +%FT%TZ)
@@ -16,7 +18,11 @@ fi
 
 commit=$(git rev-parse HEAD)
 version=$(cat version.txt)
-branch=$(git rev-parse --abbrev-ref HEAD)
+# This is hardcoded because we can't accurately set it programatically for
+# release events, where we've updated to a tag. At the time of writing,
+# we only built docker images for commits to master or release events...
+branch=master
+#branch=$(git rev-parse --abbrev-ref HEAD)
 date=$(date --utc +%Y-%m-%d-%H-%M)
 
 echo "{
@@ -30,23 +36,25 @@ branch_tag="${branch}"
 if [ "$branch" == "master" ]; then
     branch_tag="latest"
 fi
-date_tag="${branch}-${date}"
 commit_tag="${branch}-${commit}"
 
 echo "Building Docker image"
 docker build -t mozilla/balrogagent:${branch_tag} .
-echo "Tagging Docker image with date tag"
-docker tag mozilla/balrogagent:${branch_tag} "mozilla/balrogagent:${date_tag}"
 echo "Tagging Docker image with git commit tag"
 docker tag mozilla/balrogagent:${branch_tag} "mozilla/balrogagent:${commit_tag}"
 echo "Logging into Dockerhub"
 docker login -e $dockerhub_email -u $dockerhub_username -p $dockerhub_password
 echo "Pushing Docker image"
 docker push mozilla/balrogagent:${branch_tag}
-docker push mozilla/balrogagent:${date_tag}
 docker push mozilla/balrogagent:${commit_tag}
 
-sha256=$(docker images --no-trunc mozilla/balrogagent | grep "${date_tag}" | awk '/^mozilla/ {print $3}')
+if [ ! -z $extra_tag ]; then
+  echo "Tagging Docker image with ${extra_tag}"
+  docker tag mozilla/balrogagent:${branch_tag} "mozilla/balrogagent:${extra_tag}"
+  docker push mozilla/balrogagent:${extra_tag}
+fi
+
+sha256=$(docker images --no-trunc mozilla/balrogagent | grep "${commit_tag}" | awk '/^mozilla/ {print $3}')
 echo "SHA256 is ${sha256}, creating artifact for it"
 put_url=$(curl --retry 5 --retry-delay 5 --data "{\"storageType\": \"s3\", \"contentType\": \"text/plain\", \"expires\": \"${artifact_expiry}\"}" ${artifact_url} | python -c 'import json; import sys; print json.load(sys.stdin)["putUrl"]')
 curl --retry 5 --retry-delay 5 -X PUT -H "Content-Type: text/plain" --data "${sha256}" "${put_url}"

--- a/scripts/push-dockerimage.sh
+++ b/scripts/push-dockerimage.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+extra_tag=$1
+
 password_url="taskcluster/secrets/v1/secret/repo:github.com/mozilla/balrog:dockerhub"
 artifact_url="taskcluster/queue/v1/task/${TASK_ID}/runs/${RUN_ID}/artifacts/public/docker-image-shasum256.txt"
 artifact_expiry=$(date -d "+1 year" -u +%FT%TZ)
@@ -16,7 +18,11 @@ fi
 
 commit=$(git rev-parse HEAD)
 version=$(cat version.txt)
-branch=$(git rev-parse --abbrev-ref HEAD)
+# This is hardcoded because we can't accurately set it programatically for
+# release events, where we've updated to a tag. At the time of writing,
+# we only built docker images for commits to master or release events...
+branch=master
+#branch=$(git rev-parse --abbrev-ref HEAD)
 date=$(date --utc +%Y-%m-%d-%H-%M)
 
 echo "{
@@ -26,31 +32,29 @@ echo "{
     \"build\": \"https://tools.taskcluster.net/task-inspector/#${TASK_ID}\"
 }" > version.json
 
-# Initialize and update the UI submodule
-git submodule init
-git submodule update
-
 branch_tag="${branch}"
 if [ "$branch" == "master" ]; then
     branch_tag="latest"
 fi
-date_tag="${branch}-${date}"
 commit_tag="${branch}-${commit}"
 
 echo "Building Docker image"
 docker build -t mozilla/balrog:${branch_tag} .
-echo "Tagging Docker image with date tag"
-docker tag mozilla/balrog:${branch_tag} "mozilla/balrog:${date_tag}"
 echo "Tagging Docker image with git commit tag"
 docker tag mozilla/balrog:${branch_tag} "mozilla/balrog:${commit_tag}"
 echo "Logging into Dockerhub"
 docker login -e $dockerhub_email -u $dockerhub_username -p $dockerhub_password
 echo "Pushing Docker image"
 docker push mozilla/balrog:${branch_tag}
-docker push mozilla/balrog:${date_tag}
 docker push mozilla/balrog:${commit_tag}
 
-sha256=$(docker images --no-trunc mozilla/balrog | grep "${date_tag}" | awk '/^mozilla/ {print $3}')
+if [ ! -z $extra_tag ]; then
+  echo "Tagging Docker image with ${extra_tag}"
+  docker tag mozilla/balrog:${branch_tag} "mozilla/balrog:${extra_tag}"
+  docker push mozilla/balrog:${extra_tag}
+fi
+
+sha256=$(docker images --no-trunc mozilla/balrog | grep "${commit_tag}" | awk '/^mozilla/ {print $3}')
 echo "SHA256 is ${sha256}, creating artifact for it"
 put_url=$(curl --retry 5 --retry-delay 5 --data "{\"storageType\": \"s3\", \"contentType\": \"text/plain\", \"expires\": \"${artifact_expiry}\"}" ${artifact_url} | python -c 'import json; import sys; print json.load(sys.stdin)["putUrl"]')
 curl --retry 5 --retry-delay 5 -X PUT -H "Content-Type: text/plain" --data "${sha256}" "${put_url}"


### PR DESCRIPTION
This adjusts the Taskcluster jobs + docker image scripts to work with the new release process we've come up with in https://bugzilla.mozilla.org/show_bug.cgi?id=1398236. Specifically, it starts creating tags on Dockerhub with the Release version in them. The new stage environment will automatically update itself to the new images when this happens.

To support this, I had to make a few other changes as well
- Limit CI tasks to pull requests + pushes to the master branch (see the comment in .taskcluster.yml for why).
- Add routes to the Release-only tasks, to make them easier to find.

I know this is going to be painful to review because you can't really run any of it yourself. I have shadow set-up that I used in testing this, feel free to have a look at it. I can give you access if you want to play around yourself, too: https://github.com/testbhearsum/balrog, https://hub.docker.com/r/bhearsumtesttest/