### PR TITLE
Remove whitelists

### DIFF
--- a/auslib/web/admin/views/history.py
+++ b/auslib/web/admin/views/history.py
@@ -21,8 +21,8 @@ class HistoryView(AdminView):
     def get_revisions(self,
                       get_object_callback,
                       history_filters_callback,
-                      process_revisions_callback,
                       revisions_order_by,
+                      process_revisions_callback=None,
                       obj_not_found_msg='Requested object does not exist',
                       response_key='revisions'):
         """Get revisions for Releases, Rules or ScheduledChanges.
@@ -68,10 +68,11 @@ class HistoryView(AdminView):
             offset=offset,
             order_by=revisions_order_by)
 
-        _revisions = process_revisions_callback(revisions)
+        if process_revisions_callback:
+            revisions = process_revisions_callback(revisions)
 
         ret = dict()
-        ret[response_key] = _revisions
+        ret[response_key] = revisions
         ret['count'] = total_count
         return jsonify(ret)
 

--- a/auslib/web/common/history.py
+++ b/auslib/web/common/history.py
@@ -12,7 +12,7 @@ class HistoryHelper():
                  order_by,
                  get_object_callback,
                  history_filters_callback,
-                 process_revisions_callback,
+                 process_revisions_callback=None,
                  obj_not_found_msg='Requested object does not exist'):
         self.hist_table = hist_table
         self.order_by = order_by
@@ -44,10 +44,11 @@ class HistoryHelper():
             offset=offset,
             order_by=self.order_by)
 
-        _revisions = self.fn_process_revisions(revisions)
+        if self.fn_process_revisions:
+            revisions = self.fn_process_revisions(revisions)
 
         ret = {}
-        ret[response_key] = _revisions
+        ret[response_key] = revisions
         ret['count'] = total_count
         return jsonify(ret)
 

--- a/auslib/web/common/rules.py
+++ b/auslib/web/common/rules.py
@@ -20,15 +20,7 @@ def get_rules():
             where[field] = request.args[field]
 
     rules = dbo.rules.getOrderedRules(where=where)
-    count = 0
-    _rules = []
-    for rule in rules:
-        _rules.append(dict(
-            (key, value)
-            for key, value in rule.items()
-        ))
-        count += 1
-    return jsonify(count=count, rules=_rules)
+    return jsonify(count=len(rules), rules=rules)
 
 
 def get_rule(id_or_alias, with_csrf_headers=False):
@@ -48,48 +40,6 @@ def get_rule_with_csrf_headers(id_or_alias):
     return get_rule(id_or_alias, with_csrf_headers=True)
 
 
-def _process_revisions(revisions):
-    _mapping = {
-        # return : db name
-        'rule_id': 'rule_id',
-        'mapping': 'mapping',
-        'fallbackMapping': 'fallbackMapping',
-        'priority': 'priority',
-        'alias': 'alias',
-        'product': 'product',
-        'version': 'version',
-        'backgroundRate': 'backgroundRate',
-        'buildID': 'buildID',
-        'channel': 'channel',
-        'locale': 'locale',
-        'distribution': 'distribution',
-        'buildTarget': 'buildTarget',
-        'osVersion': 'osVersion',
-        'instructionSet': 'instructionSet',
-        'memory': 'memory',
-        'mig64': 'mig64',
-        'distVersion': 'distVersion',
-        'comment': 'comment',
-        'update_type': 'update_type',
-        'headerArchitecture': 'headerArchitecture',
-        'data_version': 'data_version',
-        # specific to revisions
-        'change_id': 'change_id',
-        'timestamp': 'timestamp',
-        'changed_by': 'changed_by',
-    }
-
-    _rules = []
-
-    for rule in revisions:
-        _rules.append(dict(
-            (key, rule[db_key])
-            for key, db_key in _mapping.items()
-        ))
-
-    return _rules
-
-
 def _get_filters(rule, history_table):
     return [history_table.rule_id == rule['rule_id'],
             history_table.data_version != null()]
@@ -102,7 +52,6 @@ def get_rule_history(rule_id):
                                    order_by=order_by,
                                    get_object_callback=lambda: dbo.rules.getRule(rule_id),
                                    history_filters_callback=_get_filters,
-                                   process_revisions_callback=_process_revisions,
                                    obj_not_found_msg='Requested rule does not exist')
     try:
         return history_helper.get_history(response_key='rules')


### PR DESCRIPTION
There are a couple of places where we appear to whitelist fields of records before we serialize them as part of a response. The original rationale for this seems to be because we wanted to rename fields for the frontend; see https://github.com/mozilla/balrog/commit/4338af9338012201e4fc355c778305bc09e905b7#diff-2ca168a4f3b72f6f00f46f8d3fd513a4R237. However, no renaming happens any more, and even if there were, we would probably use something more formal like a Marshmallow schema. That means this code is essentially a no-op so get rid of it.

I had originally intended this to be part of a different PR but I'm going to end up taking a different approach there so I'll just open this while I'm figuring out what my next step is.