### PR TITLE
Update to Node 4.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ COPY requirements.txt /app/
 RUN apt-get install -q --yes gcc && \
     pip install -r requirements.txt && \
     apt-get -q --yes remove gcc && \
+    apt-get -q --yes install apt-transport-https curl && \
+    curl -sLf -o /dev/null 'https://deb.nodesource.com/node_4.x/dists/jessie/Release' && \
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    echo 'deb https://deb.nodesource.com/node_4.x jessie main' > /etc/apt/sources.list.d/nodesource.list && \
     apt-get -q --yes autoremove && \
     apt-get clean && \
     rm -rf /root/.cache
@@ -33,10 +37,10 @@ COPY version.json /app/
 WORKDIR /app
 
 RUN cd ui && \
-    apt-get -q --yes install nodejs nodejs-legacy npm && \
+    apt-get -q --yes install nodejs && \
     npm install && \
     npm run build && \
-    apt-get -q --yes remove nodejs nodejs-legacy npm && \
+    apt-get -q --yes remove nodejs && \
     apt-get -q --yes autoremove && \
     apt-get clean && \
     rm -rf /root/.npm /tmp/phantomjs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get install -q --yes gcc && \
     curl -sLf -o /dev/null 'https://deb.nodesource.com/node_4.x/dists/jessie/Release' && \
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
     echo 'deb https://deb.nodesource.com/node_4.x jessie main' > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get -q update && \
     apt-get -q --yes autoremove && \
     apt-get clean && \
     rm -rf /root/.cache
@@ -36,8 +37,9 @@ COPY version.json /app/
 
 WORKDIR /app
 
+# bzip2 is needed to unpack the phantomjs image that npm installs
 RUN cd ui && \
-    apt-get -q --yes install nodejs && \
+    apt-get -q --yes install nodejs bzip2 && \
     npm install && \
     npm run build && \
     apt-get -q --yes remove nodejs && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,14 +8,21 @@ FROM python:2.7-slim
 MAINTAINER bhearsum@mozilla.com
 
 # Some versions of the python:2.7 Docker image remove libpcre3, which uwsgi needs for routing support to be enabled.
-# Node and npm are to build the frontend. nodejs-legacy is needed by this version of npm.
 # mysql-client is needed to import sample data
 # libmysqlclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
 # libfontconfig1 is required by phantomjs
 # git is needed to send coverage information
+# gcc is needed to build Python SQL module as well as uwsgi.
+# Use nodesource repo to get more modern nodejs. Node and npm are to build the frontend.
 RUN apt-get -q update \
-    && apt-get -q --yes install netcat libpcre3 libpcre3-dev nodejs nodejs-legacy npm libmysqlclient-dev mysql-client \
-                                libfontconfig1 netcat git curl \
+    && apt-get -q --yes install apt-transport-https curl \
+    && curl -sLf -o /dev/null 'https://deb.nodesource.com/node_4.x/dists/jessie/Release' \
+    && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+    && echo 'deb https://deb.nodesource.com/node_4.x jessie main' > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get -q --yes install nodejs gcc \
+                       netcat libpcre3 libpcre3-dev libmysqlclient-dev mysql-client \
+                       libfontconfig1 netcat git \
     && apt-get clean
 
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
 
   balrogui:
-    image: node:0.10
+    image: node:4.8
     depends_on:
       balrogadmin:
         condition: service_healthy


### PR DESCRIPTION
Move off of a no-longer-supported version of NodeJS to a version that
is still at least barely supported.

Debian's jessie-backports repo has an updated version of NodeJS, but
it wasn't possible to use npm with it because of
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=861178, which
prevents the installation of nodejs-dev, which prevents the
installation of node-gyp, on which npm depends. As a result, we
introduce a Nodesource repository, which seems to work fine.

This means NodeJS is no longer the limiting factor for ES6
support. Now PhantomJS is.