### PR TITLE
Add "is signoff required" to UI overall

### DIFF
--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -396,11 +396,13 @@ class TestPermissionsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 20000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "permission": "release_locale", "username": "ashanti", "options": None, "data_version": 1,
                     "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.permissions.select({"permission": "release_locale", "username": "ashanti"})[0],
                 },
                 {
                     "sc_id": 4, "when": 76000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "permission": "scheduled_change", "username": "mary", "options": None, "data_version": 1,
                     "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.permissions.select({"permission": "scheduled_change", "username": "mary"})[0],
                 },
                 {
                     "sc_id": 5, "when": 98000000, "scheduled_by": "bill", "change_type": "insert", "complete": False, "sc_data_version": 1,
@@ -411,6 +413,7 @@ class TestPermissionsScheduledChanges(ViewTest):
                     "sc_id": 6, "when": 38000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "permission": "release", "username": "bob", "options": {"products": ["a", "b"]}, "data_version": 1,
                     "signoffs": {}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissions.select({"permission": "release", "username": "bob"})[0],
                 },
             ],
         }
@@ -430,16 +433,19 @@ class TestPermissionsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 20000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "permission": "release_locale", "username": "ashanti", "options": None, "data_version": 1,
                     "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.permissions.select({"permission": "release_locale", "username": "ashanti"})[0],
                 },
                 {
                     "sc_id": 3, "when": 30000000, "scheduled_by": "bill", "change_type": "insert", "complete": True, "sc_data_version": 2,
                     "permission": "permission", "username": "bob", "options": None, "data_version": None, "signoffs": {},
                     "required_signoffs": {},
+                    # No original_row on completed changes.
                 },
                 {
                     "sc_id": 4, "when": 76000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "permission": "scheduled_change", "username": "mary", "options": None, "data_version": 1,
                     "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.permissions.select({"permission": "scheduled_change", "username": "mary"})[0],
                 },
                 {
                     "sc_id": 5, "when": 98000000, "scheduled_by": "bill", "change_type": "insert", "complete": False, "sc_data_version": 1,
@@ -450,6 +456,7 @@ class TestPermissionsScheduledChanges(ViewTest):
                     "sc_id": 6, "when": 38000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "permission": "release", "username": "bob", "options": {"products": ["a", "b"]}, "data_version": 1,
                     "signoffs": {}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissions.select({"permission": "release", "username": "bob"})[0],
                 },
             ],
         }

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1004,8 +1004,8 @@ cbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbda
         self.assertEquals(ret_data, json.loads("""
 {
     "releases": [
-        {"data_version": 1, "name": "a", "product": "a", "read_only": false, "rule_ids": [3, 4, 6, 7, 8]},
-        {"data_version": 1, "name": "ab", "product": "a", "read_only": false, "rule_ids": []}
+        {"data_version": 1, "name": "a", "product": "a", "read_only": false, "rule_ids": [3, 4, 6, 7, 8], "required_signoffs": {"releng": 1}},
+        {"data_version": 1, "name": "ab", "product": "a", "read_only": false, "rule_ids": [], "required_signoffs": {}}
     ]
 }
 """))

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1129,11 +1129,13 @@ class TestReleasesScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 6000000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "name": "a", "product": "a", "data": {"name": "a", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"},
                     "read_only": False, "data_version": 1, "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.releases.select({'name': 'a'})[0],
                 },
                 {
                     "sc_id": 4, "when": 230000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "name": "ab", "product": None, "data": None, "read_only": False, "data_version": 1, "signoffs": {"ben": "releng", "bill": "releng"},
                     "required_signoffs": {},
+                    "original_row": dbo.releases.select({'name': 'ab'})[0],
                 },
             ]
         }
@@ -1153,16 +1155,19 @@ class TestReleasesScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 6000000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "name": "a", "product": "a", "data": {"name": "a", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"},
                     "read_only": False, "data_version": 1, "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.releases.select({'name': 'a'})[0],
                 },
                 {
                     "sc_id": 3, "when": 10000000, "scheduled_by": "bill", "change_type": "update", "complete": True, "sc_data_version": 2,
                     "name": "b", "product": "b", "data": {"name": "b", "hashFunction": "sha512", "schema_version": 1}, "read_only": False,
                     "data_version": 1, "signoffs": {}, "required_signoffs": {},
+                    # No original_row for complete changes.
                 },
                 {
                     "sc_id": 4, "when": 230000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "name": "ab", "product": None, "data": None, "read_only": False, "data_version": 1, "signoffs": {"ben": "releng", "bill": "releng"},
                     "required_signoffs": {},
+                    "original_row": dbo.releases.select({'name': 'ab'})[0],
                 },
             ]
         }

--- a/auslib/test/admin/views/test_required_signoffs.py
+++ b/auslib/test/admin/views/test_required_signoffs.py
@@ -190,11 +190,13 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 200000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "product": "fake", "channel": "a", "role": "releng", "signoffs_required": 2, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.productRequiredSignoffs.select({'product': 'fake', 'channel': 'a', 'role': 'releng'})[0],
                 },
                 {
                     "sc_id": 4, "when": 400000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "product": "fake", "channel": "j", "role": "releng", "signoffs_required": None, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.productRequiredSignoffs.select({'product': 'fake', 'channel': 'j', 'role': 'releng'})[0],
                 },
             ],
         }
@@ -214,16 +216,19 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 200000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "product": "fake", "channel": "a", "role": "releng", "signoffs_required": 2, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.productRequiredSignoffs.select({'product': 'fake', 'channel': 'a', 'role': 'releng'})[0],
                 },
                 {
                     "sc_id": 3, "when": 300000000, "scheduled_by": "bill", "change_type": "insert", "complete": True, "sc_data_version": 2,
                     "product": "fake", "channel": "e", "role": "releng", "signoffs_required": 1, "data_version": None,
                     "signoffs": {}, "required_signoffs": {},
+                    # No original_row for completed changes.
                 },
                 {
                     "sc_id": 4, "when": 400000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "product": "fake", "channel": "j", "role": "releng", "signoffs_required": None, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.productRequiredSignoffs.select({'product': 'fake', 'channel': 'j', 'role': 'releng'})[0],
                 },
             ],
         }
@@ -656,11 +661,13 @@ class TestPermissionsRequiredSignoffsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 200000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "product": "fake", "role": "releng", "signoffs_required": 2, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissionsRequiredSignoffs.select({'product': 'fake', 'role': 'releng'})[0],
                 },
                 {
                     "sc_id": 4, "when": 400000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "product": "blah", "role": "releng", "signoffs_required": None, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissionsRequiredSignoffs.select({'product': 'blah', 'role': 'releng'})[0],
                 },
             ],
         }
@@ -680,6 +687,7 @@ class TestPermissionsRequiredSignoffsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 200000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "product": "fake", "role": "releng", "signoffs_required": 2, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissionsRequiredSignoffs.select({'product': 'fake', 'role': 'releng'})[0],
                 },
                 {
                     "sc_id": 3, "when": 300000000, "scheduled_by": "bill", "change_type": "insert", "complete": True, "sc_data_version": 2,
@@ -690,6 +698,7 @@ class TestPermissionsRequiredSignoffsScheduledChanges(ViewTest):
                     "sc_id": 4, "when": 400000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "product": "blah", "role": "releng", "signoffs_required": None, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissionsRequiredSignoffs.select({'product': 'blah', 'role': 'releng'})[0],
                 },
             ],
         }

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1041,6 +1041,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
+                    "original_row": dbo.rules.getRule(1),
                 },
                 {
                     "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
@@ -1065,6 +1066,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": 1, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.rules.getRule(4),
                 },
                 {
                     "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
@@ -1081,6 +1083,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.rules.getRule(6),
                 },
             ],
         }
@@ -1098,6 +1101,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
+                    "original_row": dbo.rules.getRule(1),
                 },
                 {
                     "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
@@ -1122,6 +1126,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
+                    # No original row on "complete"
                 },
                 {
                     "sc_id": 5, "when": 600000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 4, "priority": None,
@@ -1130,6 +1135,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": 1, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.rules.getRule(4),
                 },
                 {
                     "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
@@ -1146,6 +1152,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.rules.getRule(6),
                 },
             ],
         }

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -444,7 +444,13 @@ paths:
                 type: array
                 minItems: 0
                 items:
-                  $ref: '#/definitions/ReleaseGET'
+                  allOf:
+                    - $ref: '#/definitions/ReleaseGET'
+                    - properties:
+                        required_signoffs:
+                          description: Object mapping roles to the number of signoffs required to change the release
+                          type: object
+
               names:
                 description: List of release names
                 type: array
@@ -1848,6 +1854,9 @@ paths:
                       allOf:
                         - $ref: '#/definitions/SCSignoffsModel'
                         - $ref: '#/definitions/SCRulesItemBase'
+                        - properties:
+                            original_row:
+                              $ref: '#/definitions/RuleObject'
     post:
       summary: create scheduled change for rules.
       description: >
@@ -2074,6 +2083,12 @@ paths:
                         - $ref: '#/definitions/DataVersionNullable'
                         - $ref: '#/definitions/OptionsModel'
                         - $ref: '#/definitions/PermissionsModel'
+                        - properties:
+                            original_row:
+                              allOf:
+                                - $ref: '#/definitions/DataVersionNullable'
+                                - $ref: '#/definitions/PermissionsModel'
+                                - $ref: '#/definitions/OptionsModel'
                       required:
                         - change_type
                         - data_version
@@ -2314,6 +2329,14 @@ paths:
                         - $ref: '#/definitions/ReleaseReadOnly'
                         - $ref: '#/definitions/ReleaseDataObject'
                         - $ref: '#/definitions/ReleaseName'
+                        - properties:
+                            original_row:
+                              allOf:
+                                - $ref: '#/definitions/ReleaseDataObject'
+                                - $ref: '#/definitions/ReleaseName'
+                                - $ref: '#/definitions/DataVersionNullable'
+                                - $ref: '#/definitions/ProductNullable'
+                                - $ref: '#/definitions/ReleaseReadOnly'
                       required:
                         - change_type
                         - data_version
@@ -2561,6 +2584,14 @@ paths:
                         - $ref: '#/definitions/ProductModel'
                         - $ref: '#/definitions/RoleModel'
                         - $ref: '#/definitions/ChannelModel'
+                        - properties:
+                            original_row:
+                              allOf:
+                                - $ref: '#/definitions/DataVersionNullable'
+                                - $ref: '#/definitions/SignoffsRequiredNullable'
+                                - $ref: '#/definitions/ProductModel'
+                                - $ref: '#/definitions/RoleModel'
+                                - $ref: '#/definitions/ChannelModel'
                       required:
                         - change_type
                         - data_version
@@ -2812,6 +2843,13 @@ paths:
                         - $ref: '#/definitions/SignoffsRequiredNullable'
                         - $ref: '#/definitions/ProductModel'
                         - $ref: '#/definitions/RoleModel'
+                        - properties:
+                            original_row:
+                              allOf:
+                                - $ref: '#/definitions/DataVersionNullable'
+                                - $ref: '#/definitions/SignoffsRequiredNullable'
+                                - $ref: '#/definitions/ProductModel'
+                                - $ref: '#/definitions/RoleModel'
                       required:
                         - change_type
                         - data_version

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -409,7 +409,7 @@ paths:
         Returns a JSON object containing metadata about Releases in Balrog's database. Due to its size, the actual Release 'blob' is never returned from this endpoint. There are a few query arguments that affect its response. If no arguments are provided, it returns all information about all of the Releases in the database. [Docs](http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#releases)
       tags:
         - Releases
-      operationId: auslib.web.common.releases.get_releases
+      operationId: auslib.web.admin.views.mapper.release_get
       consumes: []
       produces:
         - application/json

--- a/auslib/web/admin/views/base.py
+++ b/auslib/web/admin/views/base.py
@@ -83,3 +83,12 @@ class AdminView(MethodView):
         self.log.debug("processing DELETE request to %s" % request.path)
         with dbo.begin() as trans:
             return self._delete(*args, transaction=trans, **kwargs)
+
+
+def serialize_signoff_requirements(requirements):
+    dct = {}
+    for rs in requirements:
+        signoffs_required = max(dct.get(rs["role"], 0), rs["signoffs_required"])
+        dct[rs["role"]] = signoffs_required
+
+    return dct

--- a/auslib/web/admin/views/mapper.py
+++ b/auslib/web/admin/views/mapper.py
@@ -123,6 +123,11 @@ def release_view_history_get(change_id, field):
     return ReleaseFieldView().get(change_id, field)
 
 
+def release_get():
+    """GET /releases"""
+    return ReleasesAPIView().get()
+
+
 def release_post():
     """POST /releases"""
     return ReleasesAPIView().post()

--- a/auslib/web/admin/views/releases.py
+++ b/auslib/web/admin/views/releases.py
@@ -9,7 +9,7 @@ from auslib.global_state import dbo
 from auslib.blobs.base import createBlob, BlobValidationError
 from auslib.db import OutdatedDataError, ReadOnlyError
 from auslib.web.admin.views.base import (
-    requirelogin, AdminView
+    requirelogin, AdminView, serialize_signoff_requirements
 )
 from auslib.web.admin.views.scheduled_changes import ScheduledChangesView, \
     ScheduledChangeView, EnactScheduledChangeView, ScheduledChangeHistoryView, \

--- a/auslib/web/admin/views/releases.py
+++ b/auslib/web/admin/views/releases.py
@@ -363,6 +363,9 @@ class ReleasesAPIView(AdminView):
 
     def get(self, **kwargs):
         releases = release_list(connexion.request)
+        for release in releases:
+            requirements = dbo.releases.getPotentialRequiredSignoffs([release])
+            release['required_signoffs'] = serialize_signoff_requirements(requirements)
         return serialize_releases(connexion.request, releases)
 
     @requirelogin

--- a/auslib/web/admin/views/releases.py
+++ b/auslib/web/admin/views/releases.py
@@ -16,6 +16,7 @@ from auslib.web.admin.views.scheduled_changes import ScheduledChangesView, \
     SignoffsView
 from auslib.web.admin.views.history import HistoryView
 from auslib.web.admin.views.problem import problem
+from auslib.web.common.releases import release_list, serialize_releases
 
 
 __all__ = ["SingleReleaseView", "SingleLocaleView"]
@@ -358,6 +359,12 @@ class ReleaseHistoryView(HistoryView):
 
 
 class ReleasesAPIView(AdminView):
+    """/releases"""
+
+    def get(self, **kwargs):
+        releases = release_list(connexion.request)
+        return serialize_releases(connexion.request, releases)
+
     @requirelogin
     def _post(self, changed_by, transaction):
         if dbo.releases.getReleaseInfo(name=connexion.request.get_json().get("name"), transaction=transaction, nameOnly=True,

--- a/auslib/web/admin/views/scheduled_changes.py
+++ b/auslib/web/admin/views/scheduled_changes.py
@@ -50,7 +50,9 @@ class ScheduledChangesView(AdminView):
                 # We don't need to consider the existing version of a row for
                 # inserts, because it doesn't exist yet!
                 if row["change_type"] != "insert":
-                    affected_rows.append(self.table.select(where=base_pk)[0])
+                    base_row = self.table.select(where=base_pk)[0]
+                    scheduled_change["base_row"] = base_row
+                    affected_rows.append(base_row)
                 # We don't need to consider the future version of the row when
                 # looking for required signoffs, because it won't exist when
                 # enacted.

--- a/auslib/web/admin/views/scheduled_changes.py
+++ b/auslib/web/admin/views/scheduled_changes.py
@@ -50,9 +50,9 @@ class ScheduledChangesView(AdminView):
                 # We don't need to consider the existing version of a row for
                 # inserts, because it doesn't exist yet!
                 if row["change_type"] != "insert":
-                    base_row = self.table.select(where=base_pk)[0]
-                    scheduled_change["base_row"] = base_row
-                    affected_rows.append(base_row)
+                    original_row = self.table.select(where=base_pk)[0]
+                    scheduled_change["original_row"] = original_row
+                    affected_rows.append(original_row)
                 # We don't need to consider the future version of the row when
                 # looking for required signoffs, because it won't exist when
                 # enacted.

--- a/auslib/web/admin/views/scheduled_changes.py
+++ b/auslib/web/admin/views/scheduled_changes.py
@@ -3,7 +3,7 @@ from sqlalchemy.sql.expression import null
 
 from flask import jsonify, Response
 
-from auslib.web.admin.views.base import AdminView, requirelogin
+from auslib.web.admin.views.base import AdminView, requirelogin, serialize_signoff_requirements
 from auslib.web.admin.views.history import HistoryView
 from auslib.web.admin.views.problem import problem
 from auslib.web.admin.views.validators import is_when_present_and_in_past_validator
@@ -58,9 +58,8 @@ class ScheduledChangesView(AdminView):
                 # enacted.
                 if row["change_type"] != "delete":
                     affected_rows.append(base_row)
-                for rs in self.table.getPotentialRequiredSignoffs(affected_rows):
-                    signoffs_required = max(scheduled_change["required_signoffs"].get(rs["role"], 0), rs["signoffs_required"])
-                    scheduled_change["required_signoffs"][rs["role"]] = signoffs_required
+                signoff_requirements = self.table.getPotentialRequiredSignoffs(affected_rows)
+                scheduled_change["required_signoffs"] = serialize_signoff_requirements(signoff_requirements)
 
             ret["scheduled_changes"].append(scheduled_change)
         return jsonify(ret)

--- a/auslib/web/common/releases.py
+++ b/auslib/web/common/releases.py
@@ -24,7 +24,7 @@ def strip_data(release):
     )
 
 
-def get_releases():
+def release_list(request):
     kwargs = {}
     if request.args.get('product'):
         kwargs['product'] = request.args.get('product')
@@ -32,7 +32,10 @@ def get_releases():
         kwargs['name_prefix'] = request.args.get('name_prefix')
     if request.args.get('names_only'):
         kwargs['nameOnly'] = True
-    releases = dbo.releases.getReleaseInfo(**kwargs)
+    return dbo.releases.getReleaseInfo(**kwargs)
+
+
+def serialize_releases(request, releases):
     if request.args.get('names_only'):
         names = []
         for release in releases:
@@ -43,6 +46,11 @@ def get_releases():
             'releases': map(strip_data, releases),
         }
     return jsonify(data)
+
+
+def get_releases():
+    releases = release_list(request)
+    return serialize_releases(request, releases)
 
 
 def _get_release(release):

--- a/ui/app/js/controllers/permission_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/permission_scheduled_change_edit_controller.js
@@ -24,7 +24,6 @@ function ($scope, $modalInstance, CSRF, Permissions, sc) {
   $scope.is_edit = true;
   $scope.saving = false;
 
-
   $scope.updateScheduledPermission = function() {
 
     $scope.date = new Date();

--- a/ui/app/js/controllers/permission_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/permission_scheduled_change_new_controller.js
@@ -38,7 +38,7 @@ function ($scope, $modalInstance, CSRF, Permissions, scheduled_changes, sc, perm
     return permission;
   }
 
-  $scope.permissionSignoffsRequired = function(currentPermission, newPermission) {
+  function permissionSignoffsRequired(currentPermission, newPermission) {
     if (currentPermission) {
       currentPermission = fromFormData(currentPermission);
     }
@@ -46,7 +46,17 @@ function ($scope, $modalInstance, CSRF, Permissions, scheduled_changes, sc, perm
       newPermission = fromFormData(newPermission);
     }
     return Permissions.permissionSignoffsRequired(currentPermission, newPermission, permissionSignoffRequirements);
-  };
+  }
+
+  $scope.$watch("permission", function(permission) {
+    $scope.permissionSignoffsRequired = permissionSignoffsRequired(permission);
+  }, true);
+  $scope.scPermissionsSignoffRequirements = [];
+  $scope.$watch("sc.permissions", function(permissions) {
+    $scope.scPermissionsSignoffRequirements = permissions.map(function(permission, i) {
+      return permissionSignoffsRequired($scope.originalPermissions[i], permission);
+    });
+  }, true);
 
   $scope.sc.permissions = [];
   Permissions.getUserPermissions(sc.username)
@@ -55,8 +65,8 @@ function ($scope, $modalInstance, CSRF, Permissions, scheduled_changes, sc, perm
       if (p.options) {
         p.options = JSON.stringify(p['options']);
       }
-      p.originalPermission = p;
     });
+    $scope.originalPermissions = angular.copy(permissions);
     $scope.sc.permissions = permissions;
     $scope.loading = false;
   });

--- a/ui/app/js/controllers/permission_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/permission_scheduled_change_new_controller.js
@@ -1,6 +1,6 @@
 /*global sweetAlert swal */
 angular.module('app').controller('NewPermissionScheduledChangeCtrl',
-function ($scope, $modalInstance, CSRF, Permissions, scheduled_changes, sc) {
+function ($scope, $modalInstance, CSRF, Permissions, scheduled_changes, sc, permissionSignoffRequirements) {
 
   $scope.loading = true;
   $scope.scheduled_changes = scheduled_changes;
@@ -28,6 +28,26 @@ function ($scope, $modalInstance, CSRF, Permissions, scheduled_changes, sc) {
   ];
 
 
+  function fromFormData(permission) {
+    permission = angular.copy(permission);
+    try {
+      permission.options = permission.options && JSON.parse(permission.options);
+    } catch(e) {
+      // No options, I guess
+    }
+    return permission;
+  }
+
+  $scope.permissionSignoffsRequired = function(currentPermission, newPermission) {
+    if (currentPermission) {
+      currentPermission = fromFormData(currentPermission);
+    }
+    if (newPermission) {
+      newPermission = fromFormData(newPermission);
+    }
+    return Permissions.permissionSignoffsRequired(currentPermission, newPermission, permissionSignoffRequirements);
+  };
+
   $scope.sc.permissions = [];
   Permissions.getUserPermissions(sc.username)
   .then(function(permissions) {
@@ -35,6 +55,7 @@ function ($scope, $modalInstance, CSRF, Permissions, scheduled_changes, sc) {
       if (p.options) {
         p.options = JSON.stringify(p['options']);
       }
+      p.originalPermission = p;
     });
     $scope.sc.permissions = permissions;
     $scope.loading = false;

--- a/ui/app/js/controllers/permissions_controller.js
+++ b/ui/app/js/controllers/permissions_controller.js
@@ -1,5 +1,5 @@
 angular.module("app").controller('PermissionsController',
-function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal, Page) {
+function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal, Page, PermissionsRequiredSignoffs) {
 
   Page.setTitle('Permissions');
 
@@ -27,6 +27,11 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
       $scope.loading = false;
     });
   }
+
+  PermissionsRequiredSignoffs.getRequiredSignoffs()
+    .then(function(payload) {
+      $scope.signoffRequirements = payload.data.required_signoffs;
+    });
 
   $scope.ordering = ['username'];
 
@@ -92,6 +97,9 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
         user: function () {
           return user;
         },
+        permissionSignoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
   };
@@ -113,6 +121,9 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
         },
         user: function () {
           return $scope.user;
+        },
+        permissionSignoffRequirements: function() {
+          return $scope.signoffRequirements;
         },
       }
     });
@@ -136,7 +147,10 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
           sc = angular.copy(user);
           sc["change_type"] = "insert";
           return sc;
-        }
+        },
+        permissionSignoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
   };

--- a/ui/app/js/controllers/permissions_controller.js
+++ b/ui/app/js/controllers/permissions_controller.js
@@ -28,6 +28,7 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
     });
   }
 
+  $scope.signoffRequirements = [];
   PermissionsRequiredSignoffs.getRequiredSignoffs()
     .then(function(payload) {
       $scope.signoffRequirements = payload.data.required_signoffs;

--- a/ui/app/js/controllers/releases_controller.js
+++ b/ui/app/js/controllers/releases_controller.js
@@ -36,6 +36,13 @@ function($scope, $routeParams, $location, $timeout, Releases, Search, $modal, Pa
     Releases.getReleases()
     .success(function(response) {
       $scope.releases = response.releases;
+      $scope.releases.forEach(function(release) {
+        // Ideally we'd convert this field to a Map, but we can't use
+        // Maps, so let's match the structure returned by
+        // RulesService#ruleSignoffsRequired.
+        var oldSignoffs = release.required_signoffs;
+        release.required_signoffs = {length: Object.keys(oldSignoffs).length, roles: oldSignoffs};
+      });
       $scope.releases_count = response.releases.length;
     })
     .error(function() {

--- a/ui/app/js/controllers/rule_edit_controller.js
+++ b/ui/app/js/controllers/rule_edit_controller.js
@@ -1,6 +1,6 @@
 /*global sweetAlert */
 angular.module('app').controller('RuleEditCtrl',
-function ($scope, $modalInstance, CSRF, Rules, Releases, rule, pr_ch_options) {
+function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequirements, pr_ch_options) {
 
   $scope.names = [];
   Releases.getNames().then(function(names) {
@@ -19,6 +19,13 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, pr_ch_options) {
   $scope.is_edit = true;
   $scope.original_rule = rule;
   $scope.rule = angular.copy(rule);
+  $scope.signoffRequirements = signoffRequirements;
+  $scope.ruleSignoffsRequired = function() {
+    if ($scope.signoffRequirements) {
+      return Rules.ruleSignoffsRequired($scope.original_rule, $scope.rule, $scope.signoffRequirements);
+    }
+  };
+
 
   $scope.saving = false;
   $scope.pr_ch_options = pr_ch_options;

--- a/ui/app/js/controllers/rule_edit_controller.js
+++ b/ui/app/js/controllers/rule_edit_controller.js
@@ -20,11 +20,11 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
   $scope.original_rule = rule;
   $scope.rule = angular.copy(rule);
   $scope.signoffRequirements = signoffRequirements;
-  $scope.ruleSignoffsRequired = function() {
-    if ($scope.signoffRequirements) {
-      return Rules.ruleSignoffsRequired($scope.original_rule, $scope.rule, $scope.signoffRequirements);
+  $scope.$watch('rule', function() {
+    if (signoffRequirements) {
+      $scope.ruleSignoffsRequired = Rules.ruleSignoffsRequired($scope.original_rule, $scope.rule, $scope.signoffRequirements);
     }
-  };
+  }, true);
 
 
   $scope.saving = false;

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -1,5 +1,5 @@
 angular.module('app').controller('NewRuleCtrl',
-function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_ch_options) {
+function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_ch_options, signoffRequirements) {
 
   $scope.names = [];
   Releases.getNames().then(function(names) {
@@ -21,6 +21,11 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
   $scope.errors = {};
   $scope.saving = false;
   $scope.pr_ch_options = pr_ch_options;
+  $scope.$watch('rule', function() {
+    if (signoffRequirements) {
+      $scope.ruleSignoffsRequired = Rules.ruleSignoffsRequired($scope.original_rule, $scope.rule, signoffRequirements);
+    }
+  }, true);
 
   $scope.saveChanges = function () {
     $scope.saving = true;

--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -29,7 +29,7 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements
       if ($scope.sc.change_type === "delete") {
         target = undefined;
       }
-      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired(sc.base_row, target, signoffRequirements);
+      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired(sc.original_row, target, signoffRequirements);
     }
   }, true);
 

--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -1,6 +1,6 @@
 /*global sweetAlert */
 angular.module('app').controller('EditRuleScheduledChangeCtrl',
-function ($scope, $modalInstance, CSRF, Rules, Releases, sc) {
+function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements) {
 
   $scope.names = [];
   Releases.getNames().then(function(names) {
@@ -22,6 +22,16 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc) {
   $scope.saving = false;
   $scope.calendar_is_open = false;
   $scope.sc_type = "time";
+
+  $scope.$watch('sc', function() {
+    if (signoffRequirements) {
+      var target = $scope.sc;
+      if ($scope.sc.change_type === "delete") {
+        target = undefined;
+      }
+      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired(sc.base_row, target, signoffRequirements);
+    }
+  }, true);
 
   $scope.auto_time = false;
   $scope.toggleAutoTime = function(){

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -1,5 +1,5 @@
 angular.module("app").controller("NewRuleScheduledChangeCtrl",
-function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes, sc) {
+function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes, sc, signoffRequirements) {
   $scope.names = [];
   Releases.getNames().then(function(names) {
     $scope.names = names;
@@ -29,6 +29,16 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
           $('#btn__auto-time').removeClass('active');
       }
   };
+
+  $scope.$watch('sc', function() {
+    if (signoffRequirements) {
+      var target = $scope.sc;
+      if ($scope.sc.change_type === "delete") {
+        target = undefined;
+      }
+      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired($scope.sc.base_row, target, signoffRequirements);
+    }
+  }, true);
 
   $scope.toggleType = function(newType) {
     $scope.sc_type = newType;

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -36,7 +36,7 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
       if ($scope.sc.change_type === "delete") {
         target = undefined;
       }
-      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired($scope.sc.base_row, target, signoffRequirements);
+      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired($scope.sc.original_row, target, signoffRequirements);
     }
   }, true);
 

--- a/ui/app/js/controllers/rule_scheduled_changes_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_changes_controller.js
@@ -1,5 +1,5 @@
 angular.module("app").controller("RuleScheduledChangesController",
-function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $route, Releases, Permissions, Page) {
+function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $route, Releases, Permissions, Page, ProductRequiredSignoffs) {
 
   Page.setTitle('Scheduled Rule Changes');
 
@@ -21,6 +21,11 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
       response
     );
   });
+
+  ProductRequiredSignoffs.getRequiredSignoffs()
+    .then(function(payload) {
+      $scope.signoffRequirements = payload.data.required_signoffs;
+    });
 
   function loadPage(newPage) {
     Rules.getScheduledChangeHistory($scope.sc_id, $scope.pageSize, newPage)
@@ -139,7 +144,10 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
             when: null,
             change_type: 'insert',
           };
-        }
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
   };
@@ -230,7 +238,10 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         sc: function() {
           sc.when = new Date(sc.when);
           return sc;
-        }
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
   };

--- a/ui/app/js/controllers/rules_controller.js
+++ b/ui/app/js/controllers/rules_controller.js
@@ -290,7 +290,7 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         },
         sc: function() {
           sc = angular.copy(rule);
-          sc.base_row = rule;
+          sc.original_row = rule;
           sc["change_type"] = "update";
           return sc;
         },
@@ -341,7 +341,7 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
       resolve: {
         sc: function() {
           var sc = angular.copy(rule.scheduled_change);
-          sc.base_row = rule;
+          sc.original_row = rule;
           return sc;
         },
         signoffRequirements: function() {

--- a/ui/app/js/controllers/rules_controller.js
+++ b/ui/app/js/controllers/rules_controller.js
@@ -387,6 +387,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
             _duplicate: false,
           };
         },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
         pr_ch_options: function() {
           return $scope.pr_ch_options;
         }
@@ -411,6 +414,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
           delete copy.rule_id;
           copy._duplicate = true;
           return copy;
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
         },
         pr_ch_options: function() {
           return $scope.pr_ch_options;

--- a/ui/app/js/controllers/rules_controller.js
+++ b/ui/app/js/controllers/rules_controller.js
@@ -1,5 +1,5 @@
 angular.module("app").controller('RulesController',
-function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $route, Releases, Page, Permissions) {
+function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $route, Releases, Page, Permissions, ProductRequiredSignoffs) {
 
   Page.setTitle('Rules');
 
@@ -102,6 +102,16 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
           }
         });
       });
+
+      ProductRequiredSignoffs.getRequiredSignoffs()
+        .then(function(payload) {
+        $scope.signoffRequirements = payload.data.required_signoffs;
+      });
+      $scope.ruleSignoffsRequired = function(rule) {
+        if ($scope.signoffRequirements) {
+          return Rules.ruleSignoffsRequired(rule, undefined, $scope.signoffRequirements);
+        }
+      };
     })
     .error(function() {
       console.error(arguments);
@@ -210,6 +220,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         // },
         rule: function () {
           return rule;
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
         },
         pr_ch_options: function() {
           return $scope.pr_ch_options;

--- a/ui/app/js/controllers/rules_controller.js
+++ b/ui/app/js/controllers/rules_controller.js
@@ -256,6 +256,7 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         sc: function() {
           // blank new default rule
           return {
+            base_row: undefined,
             product: product,
             channel: channel,
             backgroundRate: 0,
@@ -264,7 +265,10 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
             when: null,
             change_type: 'insert',
           };
-        }
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
     modalInstance.result.then(function(sc) {
@@ -286,9 +290,13 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         },
         sc: function() {
           sc = angular.copy(rule);
+          sc.base_row = rule;
           sc["change_type"] = "update";
           return sc;
-        }
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
     modalInstance.result.then(function(sc) {
@@ -308,11 +316,15 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         },
         sc: function() {
           return {
+            "base_row": rule,
             "rule_id": rule.rule_id,
             "data_version": rule.data_version,
             "change_type": "delete"
           };
-        }
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
     modalInstance.result.then(function(sc) {
@@ -328,8 +340,16 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
       backdrop: 'static',
       resolve: {
         sc: function() {
-          return rule.scheduled_change;
-        }
+          var sc = angular.copy(rule.scheduled_change);
+          sc.base_row = rule;
+          return sc;
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
+        rule: function() {
+          return rule;
+        },
       }
     });
     modalInstance.result.then(function(action) {

--- a/ui/app/js/controllers/user_edit_controller.js
+++ b/ui/app/js/controllers/user_edit_controller.js
@@ -293,14 +293,14 @@ function ($scope, $modalInstance, CSRF, Permissions, users, is_edit, user) {
           if(permission_found.length){
             sweetAlert(
               "Form submission error",
-              "This persmission has already been granted",
+              "This permission has already been granted",
               "error"
             );
           }
           else{
             sweetAlert(
               "Form submission error",
-              "Persmissions must be selected",
+              "Permissions must be selected",
               "error"
             );
           }

--- a/ui/app/js/directives/show_signoff_requirements_directive.js
+++ b/ui/app/js/directives/show_signoff_requirements_directive.js
@@ -7,7 +7,8 @@ angular.module("app").directive('showSignoffRequirements', function() {
     },
     template: '<div ng-show="requirements.length" class="has-error">' +
       '<p class="help-block">' +
-      'Making this change requires signoffs and therefore must be a scheduled change.' +
+      'This change requires signoffs: ' +
+      "<span ng-repeat=\"(key, value) in requirements.roles\">{{ value }} from {{ key }}{{$last ? '.' : ', '}}</span>" +
       '</p>' +
       '</div>',
   };

--- a/ui/app/js/directives/show_signoff_requirements_directive.js
+++ b/ui/app/js/directives/show_signoff_requirements_directive.js
@@ -1,0 +1,14 @@
+angular.module("app").directive('showSignoffRequirements', function() {
+  return {
+    restrict: 'E',
+    replace: true,
+    scope: {
+      requirements: '=',
+    },
+    template: '<div ng-show="requirements.length" class="has-error">' +
+      '<p class="help-block">' +
+      'Making this change requires signoffs and therefore must be a scheduled change.' +
+      '</p>' +
+      '</div>',
+  };
+});

--- a/ui/app/js/services/permissions_service.js
+++ b/ui/app/js/services/permissions_service.js
@@ -1,4 +1,4 @@
-angular.module("app").factory('Permissions', function($http, $q, ScheduledChanges, Helpers) {
+angular.module("app").factory('Permissions', function($http, $q, ScheduledChanges, Helpers, PermissionsRequiredSignoffs) {
   var service = {
     getUsers: function() {
       return $http.get('/api/users');
@@ -101,6 +101,24 @@ angular.module("app").factory('Permissions', function($http, $q, ScheduledChange
       var url = ScheduledChanges.signoffsUrl("permissions", sc_id);
       url += "?csrf_token=" + encodeURIComponent(data["csrf_token"]);
       return $http.delete(url, data);
+    },
+    permissionSignoffsRequired: function(oldPermission, newPermission, permissionSignoffRequirements) {
+      function matchesPermission(permission, permissionSignoffRequirement) {
+        var options = permission.options;
+        var hasProducts = options && options.products && options.products.length > 0;
+        var matchesProduct = options && options.products && options.products.indexOf(permissionSignoffRequirement.product) !== -1;
+        return !hasProducts || matchesProduct;
+      }
+
+      function matchesPermissions(permissionSignoffRequirement) {
+        // oldPermission is undefined during create. newPermission is
+        // undefined during delete.
+        var permissions = [oldPermission, newPermission].filter(function(permission) { return permission; });
+        return permissions.some(function(permission) { return matchesPermission(permission, permissionSignoffRequirement); });
+      }
+
+      var relevantRequirements = permissionSignoffRequirements.filter(matchesPermissions);
+      return PermissionsRequiredSignoffs.convertToMap(relevantRequirements);
     },
   };
   return service;

--- a/ui/app/js/services/required_signoffs.js
+++ b/ui/app/js/services/required_signoffs.js
@@ -42,6 +42,27 @@ var RequiredSignoffBase = (function() {
       url += "?csrf_token=" + encodeURIComponent(data["csrf_token"]);
       return this.http.delete(url, data);
     },
+    /**
+     * Convert a list of {role, signoffs_required} objects into a
+     * Map-like object that is easy to deal with in templates even
+     * though we can't actually use Map.
+     *
+     * Returns {length, roles}, where roles is an object with keys
+     * being role names and values being the number of signoffs
+     * required, and length is the number of keys in roles.
+     *
+     * FIXME: Not actually a Map
+     */
+    convertToMap: function(signoffRequirements) {
+      var merged = {};
+      signoffRequirements.map(function(requirement) {
+        if (!merged[requirement.role] || merged[requirement.role] < requirement.signoffs_required) {
+          merged[requirement.role] = requirement.signoffs_required;
+        }
+      });
+      return {length: Object.keys(merged).length, roles: merged};
+
+    }
   };
   return service;
 }());

--- a/ui/app/js/services/rules_service.js
+++ b/ui/app/js/services/rules_service.js
@@ -1,4 +1,4 @@
-angular.module("app").factory('Rules', function($http, ScheduledChanges, Helpers) {
+angular.module("app").factory('Rules', function($http, ScheduledChanges, Helpers, ProductRequiredSignoffs) {
   // these routes map to stubbed API endpoints in config/server.js
   var service = {
     getRules: function() {
@@ -122,14 +122,7 @@ angular.module("app").factory('Rules', function($http, ScheduledChanges, Helpers
       }
 
       var relevantRequirements = productSignoffRequirements.filter(matchesRules);
-      // FIXME: Use a Map here instead of a simple object
-      var merged = {};
-      relevantRequirements.map(function(requirement) {
-        if (!merged[requirement.role] || merged[requirement.role] < requirement.signoffs_required) {
-          merged[requirement.role] = requirement.signoffs_required;
-        }
-      });
-      return {length: Object.keys(merged).length, roles: merged};
+      return ProductRequiredSignoffs.convertToMap(relevantRequirements);
     },
   };
   return service;

--- a/ui/app/templates/permissions_modal.html
+++ b/ui/app/templates/permissions_modal.html
@@ -48,7 +48,7 @@
           </div>
         </form>
           <!-- connexion catches and throws exception without invoking API method-->
-          <show-signoff-requirements requirements="permissionSignoffsRequired(permission)"></show-signoff-requirements>
+          <show-signoff-requirements requirements="permissionSignoffsRequired"></show-signoff-requirements>
           <div class="form-group" ng-class="{'has-error': errors.detail}">
             <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
           </div>
@@ -61,8 +61,8 @@
              ng-repeat="permission in user.permissions">
           <div class="panel-heading">
               <div style="float: right">
-                <button class="btn btn-primary btn-xs" ng-show="!saving && !permissionSignoffsRequired(permission.originalPermission, permission).length" ng-click="updatePermission(permission)">Save changes</button>
-                <button class="btn btn-primary btn-xs" ng-show="!saving && !permissionSignoffsRequired(permission).length" ng-click="deletePermission(permission)">Delete</button>
+                <button class="btn btn-primary btn-xs" ng-show="!saving && !userPermissionsSignoffRequirements[$index].signoffRequirements.length" ng-click="updatePermission(permission)">Save changes</button>
+                <button class="btn btn-primary btn-xs" ng-show="!saving && !userPermissionsSignoffRequirements[$index].deleteSignoffRequirements.length" ng-click="deletePermission(permission)">Delete</button>
               </div>
             <h3 class="panel-title">
               {{ permission.permission }}

--- a/ui/app/templates/permissions_modal.html
+++ b/ui/app/templates/permissions_modal.html
@@ -48,6 +48,7 @@
           </div>
         </form>
           <!-- connexion catches and throws exception without invoking API method-->
+          <show-signoff-requirements requirements="permissionSignoffsRequired(permission)"></show-signoff-requirements>
           <div class="form-group" ng-class="{'has-error': errors.detail}">
             <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
           </div>
@@ -60,8 +61,8 @@
              ng-repeat="permission in user.permissions">
           <div class="panel-heading">
               <div style="float: right">
-                <button class="btn btn-primary btn-xs" ng-show="!saving" ng-click="updatePermission(permission)">Save changes</button>
-                <button class="btn btn-primary btn-xs" ng-show="!saving" ng-click="deletePermission(permission)">Delete</button>
+                <button class="btn btn-primary btn-xs" ng-show="!saving && !permissionSignoffsRequired(permission.originalPermission, permission).length" ng-click="updatePermission(permission)">Save changes</button>
+                <button class="btn btn-primary btn-xs" ng-show="!saving && !permissionSignoffsRequired(permission).length" ng-click="deletePermission(permission)">Delete</button>
               </div>
             <h3 class="panel-title">
               {{ permission.permission }}

--- a/ui/app/templates/permissions_scheduled_change_modal.html
+++ b/ui/app/templates/permissions_scheduled_change_modal.html
@@ -22,7 +22,7 @@
             <textarea id="id_options" ng-model="permission.options" class="options-as-json"></textarea>
             <p class="help-block" ng-show="errors.options">{{ errors.options.join(', ') }}</p>
           </div>
-        <show-signoff-requirements requirements="permissionSignoffsRequired(permission)"></show-signoff-requirements>
+        <show-signoff-requirements requirements="permissionSignoffsRequired"></show-signoff-requirements>
         <div class="form-group" ng-class="{'has-error': errors.detail}">
             <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
         </div>
@@ -52,7 +52,7 @@
           <div class="panel-body">
             <textarea ng-model="permission.options" class="options-as-json"></textarea>
             <p class="help-block" ng-show="errors.permissions[permission.permission]">{{ errors.permissions[permission.permission].options.join(', ') }}</p>
-            <show-signoff-requirements requirements="permissionSignoffsRequired(permission.originalPermission, permission)"></show-signoff-requirements>
+            <show-signoff-requirements requirements="scPermissionsSignoffRequirements[$index]"></show-signoff-requirements>
           </div>
       </div>
 

--- a/ui/app/templates/permissions_scheduled_change_modal.html
+++ b/ui/app/templates/permissions_scheduled_change_modal.html
@@ -22,6 +22,7 @@
             <textarea id="id_options" ng-model="permission.options" class="options-as-json"></textarea>
             <p class="help-block" ng-show="errors.options">{{ errors.options.join(', ') }}</p>
           </div>
+        <show-signoff-requirements requirements="permissionSignoffsRequired(permission)"></show-signoff-requirements>
         <div class="form-group" ng-class="{'has-error': errors.detail}">
             <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
         </div>
@@ -51,6 +52,7 @@
           <div class="panel-body">
             <textarea ng-model="permission.options" class="options-as-json"></textarea>
             <p class="help-block" ng-show="errors.permissions[permission.permission]">{{ errors.permissions[permission.permission].options.join(', ') }}</p>
+            <show-signoff-requirements requirements="permissionSignoffsRequired(permission.originalPermission, permission)"></show-signoff-requirements>
           </div>
       </div>
 

--- a/ui/app/templates/release_scheduled_change_modal.html
+++ b/ui/app/templates/release_scheduled_change_modal.html
@@ -55,6 +55,8 @@
       <p class="help-block" ng-show="errors.product">{{ errors.product.join(', ') }}</p>
     </div>
 
+    <show-signoff-requirements requirements="sc.required_signoffs"></show-signoff-requirements>
+
     <div class="form-group" ng-class="{'has-error': errors.detail}">
       <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
     </div>

--- a/ui/app/templates/release_scheduled_delete_modal.html
+++ b/ui/app/templates/release_scheduled_delete_modal.html
@@ -30,6 +30,7 @@
     </div>
     </div>
 
+    <show-signoff-requirements requirements="sc.required_signoffs"></show-signoff-requirements>
     <div class="form-group" ng-class="{'has-error': errors.exception}">
       <p class="help-block" ng-show="errors.exception">{{ errors.exception }}</p>
     </div>

--- a/ui/app/templates/releases.html
+++ b/ui/app/templates/releases.html
@@ -76,8 +76,8 @@
         <button ng-show="!rule_id" class="btn btn-danger btn-xs" ng-click="openNewScheduledDeleteModal(release)">Schedule for Deletion</button>
         <button class="btn btn-default btn-xs" ng-click="openDataModal(release)">View Data</button>
         <a ng-show="!release_name" class="btn btn-default btn-xs" download="{{ release.name | uriencode }}.json" target="_self" ng-href="/api/releases/{{ release.name | uriencode }}?pretty=1">Download</a>
-        <button ng-show="!release_name" class="btn btn-default btn-xs" ng-click="openUpdateModal(release)">Update</button>
-        <button ng-show="!release_name" class="btn btn-default btn-xs" ng-click="openDeleteModal(release)">Delete</button>
+        <button ng-show="!release_name && !release.required_signoffs.length" class="btn btn-default btn-xs" ng-click="openUpdateModal(release)">Update</button>
+        <button ng-show="!release_name && !release.required_signoffs.length" class="btn btn-default btn-xs" ng-click="openDeleteModal(release)">Delete</button>
         <a ng-show="!release_name" class="btn btn-default btn-xs" ng-href="/releases/{{ release.name }}">History</a>
         <button ng-show="!release_name && !release.read_only" class="btn btn-xs btn-success" ng-click="openReadOnlyModal(release)">Modifiable</button>
         <button ng-show="!release_name && release.read_only" class="btn btn-xs btn-danger" ng-click="openReadOnlyModal(release)">Read Only</button>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -187,6 +187,10 @@
     <input type="hidden" name="data_version" ng-model="rule.data_version">
   </form>
 
+  <div ng-show="ruleSignoffsRequired().length">
+    Making this change requires signoffs and therefore must be a scheduled change.
+  </div>
+
   <div class="form-group" ng-class="{'has-error': errors.detail}">
     <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
   </div>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -187,7 +187,7 @@
     <input type="hidden" name="data_version" ng-model="rule.data_version">
   </form>
 
-  <show-signoff-requirements requirements="ruleSignoffsRequired()"></show-signoff-requirements>
+  <show-signoff-requirements requirements="ruleSignoffsRequired"></show-signoff-requirements>
 
   <div class="form-group" ng-class="{'has-error': errors.detail}">
     <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
@@ -199,6 +199,6 @@
 </div>
 <div class="modal-footer">
   <div ng-show="saving" small-loader></div>
-  <button class="btn btn-primary" ng-class="{'disabled': ruleSignoffsRequired().length}" ng-show="!saving" ng-click="saveChanges()">Save Changes</button>
+  <button class="btn btn-primary" ng-class="{'disabled': ruleSignoffsRequired.length}" ng-show="!saving" ng-click="saveChanges()">Save Changes</button>
   <button class="btn btn-default" ng-show="!saving" ng-click="cancel()">Cancel</button>
 </div>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -187,8 +187,10 @@
     <input type="hidden" name="data_version" ng-model="rule.data_version">
   </form>
 
-  <div ng-show="ruleSignoffsRequired().length">
-    Making this change requires signoffs and therefore must be a scheduled change.
+  <div ng-show="ruleSignoffsRequired().length" class="has-error">
+    <p class="help-block">
+      Making this change requires signoffs and therefore must be a scheduled change.
+    </p>
   </div>
 
   <div class="form-group" ng-class="{'has-error': errors.detail}">
@@ -201,6 +203,6 @@
 </div>
 <div class="modal-footer">
   <div ng-show="saving" small-loader></div>
-  <button class="btn btn-primary" ng-show="!saving" ng-click="saveChanges()">Save Changes</button>
+  <button class="btn btn-primary" ng-class="{'disabled': ruleSignoffsRequired().length}" ng-show="!saving" ng-click="saveChanges()">Save Changes</button>
   <button class="btn btn-default" ng-show="!saving" ng-click="cancel()">Cancel</button>
 </div>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -187,11 +187,7 @@
     <input type="hidden" name="data_version" ng-model="rule.data_version">
   </form>
 
-  <div ng-show="ruleSignoffsRequired().length" class="has-error">
-    <p class="help-block">
-      Making this change requires signoffs and therefore must be a scheduled change.
-    </p>
-  </div>
+  <show-signoff-requirements requirements="ruleSignoffsRequired()"></show-signoff-requirements>
 
   <div class="form-group" ng-class="{'has-error': errors.detail}">
     <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -242,6 +242,8 @@
       </div>
     </div>
 
+    <show-signoff-requirements requirements="scheduledChangeSignoffsRequired"></show-signoff-requirements>
+
         <div class="form-group" ng-class="{'has-error': errors.exception}">
             <p class="help-block" ng-show="errors.exception">{{ errors.exception }}</p>
         </div>

--- a/ui/app/templates/rule_scheduled_delete_modal.html
+++ b/ui/app/templates/rule_scheduled_delete_modal.html
@@ -27,6 +27,7 @@
         </ul>
         <p class="help-block" ng-show="errors.when">{{ errors.when.join(', ') }}</p>
       </div>
+      <show-signoff-requirements requirements="scheduledChangeSignoffsRequired"></show-signoff-requirements>
       <div class="form-group" ng-class="{'has-error': errors.exception}">
         <p class="help-block" ng-show="errors.exception">{{ errors.exception }}</p>
       </div>

--- a/ui/app/templates/rules.html
+++ b/ui/app/templates/rules.html
@@ -89,11 +89,11 @@
                 ng-click="openNewScheduledDeleteModal(rule)">
             Schedule for Deletion
         </button>
-        <button ng-show="rule.scheduled_change === null || rule.scheduled_change.change_type !== 'insert'"
+        <button ng-show="ruleSignoffsRequired(rule).length === 0 && (rule.scheduled_change === null || rule.scheduled_change.change_type !== 'insert')"
                 class="btn btn-default btn-xs" ng-click="openUpdateModal(rule)">
             Update
         </button>
-        <button ng-show="rule.scheduled_change === null" class="btn btn-default btn-xs" ng-click="openDeleteModal(rule)">
+        <button ng-show="ruleSignoffsRequired(rule).length === 0 && rule.scheduled_change === null" class="btn btn-default btn-xs" ng-click="openDeleteModal(rule)">
             Delete
         </button>
         <button ng-show="rule.scheduled_change === null || rule.scheduled_change.change_type !== 'insert'"

--- a/ui/spec/controllers/permissions_controller_spec.js
+++ b/ui/spec/controllers/permissions_controller_spec.js
@@ -49,6 +49,8 @@ describe("controller: PermissionsController", function() {
     it("should return all rules empty", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, '{"users": []}');
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
       expect(this.scope.users).toEqual([]);
     });
@@ -56,6 +58,8 @@ describe("controller: PermissionsController", function() {
     it("should return all rules some", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, JSON.stringify(sample_users));
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
       expect(this.scope.users.length).toEqual(2);
       expect(this.scope.users).toEqual([
@@ -70,6 +74,8 @@ describe("controller: PermissionsController", function() {
     it("should return true always if no filters active", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, '{"users": []}');
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
 
       var item = {
@@ -81,6 +87,8 @@ describe("controller: PermissionsController", function() {
     it("should filter when only one search word name", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, '{"users": []}');
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
 
       var $scope = this.scope;
@@ -97,6 +105,8 @@ describe("controller: PermissionsController", function() {
     it("should notice if filters are on", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, JSON.stringify(sample_users));
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
 
       var $scope = this.scope;
@@ -111,6 +121,8 @@ describe("controller: PermissionsController", function() {
     it("should be possible to open the add modal", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, JSON.stringify(sample_users));
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.expectGET('/api/users/roles')
       .respond(200, JSON.stringify(sample_all_roles));
       this.scope.openNewModal();
@@ -119,6 +131,8 @@ describe("controller: PermissionsController", function() {
     it("should be possible to open the edit modal", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, JSON.stringify(sample_users));
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.expectGET('/api/users/peterbe/permissions')
       .respond(200, JSON.stringify(sample_permissions));
       this.$httpBackend.expectGET('/api/users/peterbe/roles')
@@ -175,6 +189,8 @@ describe("controller: PermissionsController by username", function() {
         expect($route.current).toBeUndefined();
         this.$httpBackend.expectGET('/api/users/peterbe/permissions')
         .respond(200, JSON.stringify(sample_permissions));
+        this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+        .respond(200, '{"required_signoffs": []}');
 
         $location.path('/permissions/peterbe');
         $rootScope.$digest();

--- a/ui/spec/controllers/releases_controller_spec.js
+++ b/ui/spec/controllers/releases_controller_spec.js
@@ -35,19 +35,22 @@ var sample_releases = {
       "data_version": 2,
       "product": "B2G",
       "version": "34.0a2",
-      "name": "B2G-mozilla-aurora-kitkat-nightly-20140923151000"
+      "name": "B2G-mozilla-aurora-kitkat-nightly-20140923151000",
+      "required_signoffs": {},
     },
     {
       "data_version": 2,
       "product": "B2G",
       "version": "34.0a2",
-      "name": "B2G-mozilla-aurora-kitkat-nightly-20140923160203"
+      "name": "B2G-mozilla-aurora-kitkat-nightly-20140923160203",
+      "required_signoffs": {},
     },
     {
       "data_version": 4,
       "product": "Fennec",
       "version": "30.0a2",
-      "name": "Fennec-mozilla-aurora-nightly-20140410004003"
+      "name": "Fennec-mozilla-aurora-nightly-20140410004003",
+      "required_signoffs": {},
     }
   ],
   "count": 3
@@ -91,7 +94,11 @@ describe("controller: ReleasesController", function() {
       .respond(200, JSON.stringify(sample_releases));
       this.$httpBackend.flush();
       expect(this.scope.releases.length).toEqual(3);
-      expect(this.scope.releases).toEqual(sample_releases.releases);
+      var transformedReleases = angular.copy(sample_releases.releases);
+      transformedReleases.forEach(function(release) {
+        release.required_signoffs = {length: 0, roles: {}};
+      });
+      expect(this.scope.releases).toEqual(transformedReleases);
     });
 
   });
@@ -241,7 +248,6 @@ describe("controller: ReleasesController", function() {
       .respond(200, JSON.stringify(sample_releases));
       this.scope.openRevertModal(sample_revisions.revisions[0]);
     });
-
   });
 
 });

--- a/ui/spec/controllers/rule_edit_controller_spec.js
+++ b/ui/spec/controllers/rule_edit_controller_spec.js
@@ -61,7 +61,7 @@ describe("controller: RuleEditCtrl", function() {
 
   describe("opening the edit rule modal", function() {
 
-    it("should should all defaults", function() {
+    it("should set all defaults", function() {
       this.$httpBackend.expectGET('/api/releases?names_only=1')
       .respond(200, JSON.stringify({names: ['Name1', 'Name2']}));
       this.$httpBackend.expectGET('/api/rules/columns/channel')
@@ -79,7 +79,7 @@ describe("controller: RuleEditCtrl", function() {
       expect(this.scope.is_edit).toEqual(true);
     });
 
-    it("should should be able to save changes", function() {
+    it("should be able to save changes", function() {
       this.$httpBackend.expectGET('/api/releases?names_only=1')
       .respond(200, JSON.stringify({names: ['Name1', 'Name2']}));
       this.$httpBackend.expectGET('/api/rules/columns/channel')
@@ -104,7 +104,7 @@ describe("controller: RuleEditCtrl", function() {
       expect(this.scope.errors).toEqual({});
     });
 
-    it("should should notice errors", function() {
+    it("should notice errors", function() {
       this.$httpBackend.expectGET('/api/releases?names_only=1')
       .respond(200, JSON.stringify({names: ['Name1', 'Name2']}));
       this.$httpBackend.expectGET('/api/rules/columns/channel')

--- a/ui/spec/controllers/rule_edit_controller_spec.js
+++ b/ui/spec/controllers/rule_edit_controller_spec.js
@@ -77,6 +77,23 @@ describe("controller: RuleEditCtrl", function() {
       expect(this.scope.rule).toEqual(rule);
       expect(this.scope.rule.product).toEqual('Firefox');
       expect(this.scope.is_edit).toEqual(true);
+      expect(this.scope.ruleSignoffsRequired.length).toEqual(0);
+    });
+
+    it("should update signoff requirements when rule changes", function() {
+      this.$httpBackend.expectGET('/api/releases?names_only=1')
+      .respond(200, JSON.stringify({names: ['Name1', 'Name2']}));
+      this.$httpBackend.expectGET('/api/rules/columns/channel')
+      .respond(200, JSON.stringify({channel: ['Channel1', 'Channel2'], count: 2}));
+      this.$httpBackend.expectGET('/api/rules/columns/product')
+      .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
+      this.$httpBackend.flush();
+
+      this.scope.rule.channel = 'aurora';
+      this.scope.$digest();
+
+      expect(this.scope.ruleSignoffsRequired.length).toEqual(1);
+      expect(this.scope.ruleSignoffsRequired.roles['releng']).toEqual(2);
     });
 
     it("should be able to save changes", function() {

--- a/ui/spec/controllers/rule_edit_controller_spec.js
+++ b/ui/spec/controllers/rule_edit_controller_spec.js
@@ -30,6 +30,9 @@ describe("controller: RuleEditCtrl", function() {
     "whitelist": null
   };
   var pr_ch_options = ['GMP'];
+  var signoffRequirements = [
+    {product: "Firefox", channel: "aurora", role: "releng", signoffs_required: 2}
+  ];
 
   beforeEach(inject(function($controller, $rootScope, $location, $modal, Rules, Releases, $httpBackend) {
     this.$location = $location;
@@ -47,6 +50,7 @@ describe("controller: RuleEditCtrl", function() {
       Releases: Releases,
       rule: rule,
       pr_ch_options: pr_ch_options,
+      signoffRequirements: signoffRequirements,
     });
   }));
 

--- a/ui/spec/controllers/rule_new_controller_spec.js
+++ b/ui/spec/controllers/rule_new_controller_spec.js
@@ -128,6 +128,12 @@ describe("controller: NewRuleController", function() {
     _duplicate: false,
   };
   var pr_ch_options = ['GMP'];
+  var signoffRequirements = [{
+    product: "Firefox",
+    channel: "nightly",
+    role: "releng",
+    signoffs_required: 2,
+  }];
 
   beforeEach(inject(function($controller, $rootScope, $location, $modal, Rules, Releases, $httpBackend) {
     this.$location = $location;
@@ -146,6 +152,7 @@ describe("controller: NewRuleController", function() {
       rules: rules,
       rule: rule,
       pr_ch_options: pr_ch_options,
+      signoffRequirements: signoffRequirements,
     });
   }));
 
@@ -174,6 +181,9 @@ describe("controller: NewRuleController", function() {
       expect(this.scope.rules).toEqual(rules);
       expect(this.scope.is_edit).toEqual(false);
       expect(this.scope.is_duplicate).toEqual(false);
+      // An empty rule affects all products.
+      expect(this.scope.ruleSignoffsRequired.length).toEqual(1);
+      expect(this.scope.ruleSignoffsRequired.roles['releng']).toEqual(2);
     });
 
     it("should be able to save changes", function() {
@@ -221,6 +231,20 @@ describe("controller: NewRuleController", function() {
       expect(this.scope.saving).toEqual(false);
     });
 
+    it("should update signoff requirements when rule changes", function() {
+      this.$httpBackend.expectGET('/api/releases?names_only=1')
+      .respond(200, JSON.stringify({names: ['Name1', 'Name2']}));
+      this.$httpBackend.expectGET('/api/rules/columns/channel')
+      .respond(200, JSON.stringify({channel: ['Channel1', 'Channel2'], count: 2}));
+      this.$httpBackend.expectGET('/api/rules/columns/product')
+      .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
+      this.$httpBackend.flush();
+
+      this.scope.rule.product = 'Fennec';
+
+      this.scope.$digest();
+      expect(this.scope.ruleSignoffsRequired.length).toEqual(0);
+    });
   });
 
 });

--- a/ui/spec/controllers/rule_new_controller_spec.js
+++ b/ui/spec/controllers/rule_new_controller_spec.js
@@ -156,7 +156,7 @@ describe("controller: NewRuleController", function() {
 
   describe("opening the new rule modal", function() {
 
-    it("should should all defaults", function() {
+    it("should set all defaults", function() {
       this.$httpBackend.expectGET('/api/releases?names_only=1')
       .respond(200, JSON.stringify({names: ['Name1', 'Name2']}));
       this.$httpBackend.expectGET('/api/rules/columns/channel')
@@ -176,7 +176,7 @@ describe("controller: NewRuleController", function() {
       expect(this.scope.is_duplicate).toEqual(false);
     });
 
-    it("should should be able to save changes", function() {
+    it("should be able to save changes", function() {
       this.$httpBackend.expectGET('/api/releases?names_only=1')
       .respond(200, JSON.stringify({names: ['Name1', 'Name2']}));
       this.$httpBackend.expectGET('/api/rules/columns/channel')
@@ -200,7 +200,7 @@ describe("controller: NewRuleController", function() {
       expect(this.scope.errors).toEqual({});
     });
 
-    it("should should throw sweetAlert on error", function() {
+    it("should throw sweetAlert on error", function() {
       this.$httpBackend.expectGET('/api/releases?names_only=1')
       .respond(200, JSON.stringify({names: ['Name1', 'Name2']}));
       this.$httpBackend.expectGET('/api/rules/columns/channel')

--- a/ui/spec/controllers/rule_scheduled_changes_controller_spec.js
+++ b/ui/spec/controllers/rule_scheduled_changes_controller_spec.js
@@ -131,6 +131,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should find all scheduled changes", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -143,6 +145,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should filter active scheduled changes correctly", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -156,6 +160,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should filter completed scheduled changes correctly", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -171,6 +177,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should be possible to open the add modal", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -187,6 +195,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should be possible to open the update modal for time based change", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -203,6 +213,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should be possible to open the update modal for telemetry change", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -219,6 +231,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should be possible to open the delete modal", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();

--- a/ui/spec/controllers/rules_controller_spec.js
+++ b/ui/spec/controllers/rules_controller_spec.js
@@ -87,6 +87,8 @@ describe("controller: RulesController", function() {
       .respond(200, '{"scheduled_changes": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/product')
       .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
+      this.$httpBackend.expectGET('/api/required_signoffs/product')
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/channel')
       .respond(200, JSON.stringify({channel: ['Channel1', 'Channel2'], count: 2}));
       this.$httpBackend.flush();
@@ -102,6 +104,8 @@ describe("controller: RulesController", function() {
       .respond(200, '{"scheduled_changes": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/product')
       .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
+      this.$httpBackend.expectGET('/api/required_signoffs/product')
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/channel')
       .respond(200, JSON.stringify({channel: ['Channel1', 'Channel2'], count: 2}));
       this.$httpBackend.flush();
@@ -121,6 +125,8 @@ describe("controller: RulesController", function() {
       .respond(200, '{"scheduled_changes": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/product')
       .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
+      this.$httpBackend.expectGET('/api/required_signoffs/product')
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/channel')
       .respond(200, JSON.stringify({channel: ['Channel1', 'Channel2'], count: 2}));
       this.$httpBackend.flush();

--- a/ui/spec/controllers/user_edit_controller_spec.js
+++ b/ui/spec/controllers/user_edit_controller_spec.js
@@ -22,6 +22,7 @@ describe("controller: UserPermissionsCtrl", function() {
       {'role':'releng', 'data_version':1}
     ]};
   var sample_all_roles = {'roles': ['qa', 'releng']};
+  var signoffRequirements = [];
 
   beforeEach(inject(function($controller, $rootScope, $location, $modal, Permissions, $httpBackend) {
     this.$location = $location;
@@ -39,6 +40,7 @@ describe("controller: UserPermissionsCtrl", function() {
       user: user,
       is_edit: true,
       users: [user],
+      permissionSignoffRequirements: signoffRequirements,
     });
   }));
 

--- a/ui/spec/services/permissions_service_spec.js
+++ b/ui/spec/services/permissions_service_spec.js
@@ -102,4 +102,47 @@ describe("Service: Permissions", function() {
     this.$httpBackend.flush();
   }));
 
+  it("should respect both old and new permissions", inject(function(Permissions) {
+    var signoffRequirements = [
+      {product: "Firefox", role: "releng", signoffs_required: 2},
+      {product: "Fennec", role: "relman", signoffs_required: 4},
+    ];
+    var oldPerm = {options: {products: ["Firefox"]}, permission: "release_locale"};
+    var newPerm = {options: {products: ["Fennec"]}, permission: "release_locale"};
+    var signoffsRequired = Permissions.permissionSignoffsRequired(oldPerm, newPerm, signoffRequirements);
+    expect(signoffsRequired.length).toBe(2);
+    expect(signoffsRequired.roles['releng']).toBe(2);
+    expect(signoffsRequired.roles['relman']).toBe(4);
+  }));
+
+  it("should not require signoffs for unrelated product", inject(function(Permissions) {
+    var signoffRequirements = [
+      {product: "Firefox", role: "releng", signoffs_required: 2},
+    ];
+    var oldPerm = {options: {products: ["Thunderbird"]}, permission: "release_locale"};
+    var newPerm = {options: {products: ["Thunderbird", "Fennec"]}, permission: "release_locale"};
+    var signoffsRequired = Permissions.permissionSignoffsRequired(oldPerm, newPerm, signoffRequirements);
+    expect(signoffsRequired.length).toBe(0);
+  }));
+
+  it("should require signoffs for adding unrelated product", inject(function(Permissions) {
+    var signoffRequirements = [
+      {product: "Firefox", role: "releng", signoffs_required: 2},
+    ];
+    var oldPerm = {options: {products: ["Firefox"]}, permission: "release_locale"};
+    var newPerm = {options: {products: ["Firefox", "Fennec"]}, permission: "release_locale"};
+    var signoffsRequired = Permissions.permissionSignoffsRequired(oldPerm, newPerm, signoffRequirements);
+    expect(signoffsRequired.length).toBe(1);
+    expect(signoffsRequired.roles['releng']).toBe(2);
+  }));
+
+  it("should match if no product is present in perm", inject(function(Permissions) {
+    var signoffRequirements = [
+      {product: "Firefox", role: "releng", signoffs_required: 2},
+    ];
+    var perm = {permission: "release_locale"};
+    var signoffsRequired = Permissions.permissionSignoffsRequired(undefined, perm, signoffRequirements);
+    expect(signoffsRequired.length).toBe(1);
+    expect(signoffsRequired.roles['releng']).toBe(2);
+  }));
 });


### PR DESCRIPTION
This is a WIP attempt to try to solve https://bugzilla.mozilla.org/show_bug.cgi?id=1355076 and https://bugzilla.mozilla.org/show_bug.cgi?id=1355074.

This takes the approach of disabling buttons for immediate actions as well as adding notes to modals where it makes sense. I've never written anything in Angular before so I'm hoping to get some "30% review" feedback on the UI approach as well as the implementation approach.

- [x] Implement signoff requirements logic in the client
- [x] Fetch product signoff requirements and use them on
  - [x] Rules list page
  - [x] Edit rule modal
  - (n/a) Delete rule modal -- as far as I know, it's impossible to trigger the delete rule modal except through the (now hidden) button for an existing rule
  - [x] New rule modal (incl. Duplicate rule modal)
  - [x] Rule scheduled change/delete modal
  - [x] Releases list page
  - [x] Edit release modal
  - (n/a) New release modal
  - [x] Releases scheduled change/delete modal
- [x] Fetch permission signoff requirements and use them on
  - [x] Permissions list page
  - [x] Permissions update modal
  - [x] Permissions scheduled update modal

