### PR TITLE
1365658 fix priority background rate validators

### DIFF
--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -396,11 +396,13 @@ class TestPermissionsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 20000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "permission": "release_locale", "username": "ashanti", "options": None, "data_version": 1,
                     "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.permissions.select({"permission": "release_locale", "username": "ashanti"})[0],
                 },
                 {
                     "sc_id": 4, "when": 76000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "permission": "scheduled_change", "username": "mary", "options": None, "data_version": 1,
                     "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.permissions.select({"permission": "scheduled_change", "username": "mary"})[0],
                 },
                 {
                     "sc_id": 5, "when": 98000000, "scheduled_by": "bill", "change_type": "insert", "complete": False, "sc_data_version": 1,
@@ -411,6 +413,7 @@ class TestPermissionsScheduledChanges(ViewTest):
                     "sc_id": 6, "when": 38000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "permission": "release", "username": "bob", "options": {"products": ["a", "b"]}, "data_version": 1,
                     "signoffs": {}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissions.select({"permission": "release", "username": "bob"})[0],
                 },
             ],
         }
@@ -430,16 +433,19 @@ class TestPermissionsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 20000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "permission": "release_locale", "username": "ashanti", "options": None, "data_version": 1,
                     "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.permissions.select({"permission": "release_locale", "username": "ashanti"})[0],
                 },
                 {
                     "sc_id": 3, "when": 30000000, "scheduled_by": "bill", "change_type": "insert", "complete": True, "sc_data_version": 2,
                     "permission": "permission", "username": "bob", "options": None, "data_version": None, "signoffs": {},
                     "required_signoffs": {},
+                    # No original_row on completed changes.
                 },
                 {
                     "sc_id": 4, "when": 76000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "permission": "scheduled_change", "username": "mary", "options": None, "data_version": 1,
                     "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.permissions.select({"permission": "scheduled_change", "username": "mary"})[0],
                 },
                 {
                     "sc_id": 5, "when": 98000000, "scheduled_by": "bill", "change_type": "insert", "complete": False, "sc_data_version": 1,
@@ -450,6 +456,7 @@ class TestPermissionsScheduledChanges(ViewTest):
                     "sc_id": 6, "when": 38000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "permission": "release", "username": "bob", "options": {"products": ["a", "b"]}, "data_version": 1,
                     "signoffs": {}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissions.select({"permission": "release", "username": "bob"})[0],
                 },
             ],
         }

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1004,8 +1004,8 @@ cbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbda
         self.assertEquals(ret_data, json.loads("""
 {
     "releases": [
-        {"data_version": 1, "name": "a", "product": "a", "read_only": false, "rule_ids": [3, 4, 6, 7, 8]},
-        {"data_version": 1, "name": "ab", "product": "a", "read_only": false, "rule_ids": []}
+        {"data_version": 1, "name": "a", "product": "a", "read_only": false, "rule_ids": [3, 4, 6, 7, 8], "required_signoffs": {"releng": 1}},
+        {"data_version": 1, "name": "ab", "product": "a", "read_only": false, "rule_ids": [], "required_signoffs": {}}
     ]
 }
 """))
@@ -1129,11 +1129,13 @@ class TestReleasesScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 6000000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "name": "a", "product": "a", "data": {"name": "a", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"},
                     "read_only": False, "data_version": 1, "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.releases.select({'name': 'a'})[0],
                 },
                 {
                     "sc_id": 4, "when": 230000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "name": "ab", "product": None, "data": None, "read_only": False, "data_version": 1, "signoffs": {"ben": "releng", "bill": "releng"},
                     "required_signoffs": {},
+                    "original_row": dbo.releases.select({'name': 'ab'})[0],
                 },
             ]
         }
@@ -1153,16 +1155,19 @@ class TestReleasesScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 6000000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "name": "a", "product": "a", "data": {"name": "a", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"},
                     "read_only": False, "data_version": 1, "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.releases.select({'name': 'a'})[0],
                 },
                 {
                     "sc_id": 3, "when": 10000000, "scheduled_by": "bill", "change_type": "update", "complete": True, "sc_data_version": 2,
                     "name": "b", "product": "b", "data": {"name": "b", "hashFunction": "sha512", "schema_version": 1}, "read_only": False,
                     "data_version": 1, "signoffs": {}, "required_signoffs": {},
+                    # No original_row for complete changes.
                 },
                 {
                     "sc_id": 4, "when": 230000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "name": "ab", "product": None, "data": None, "read_only": False, "data_version": 1, "signoffs": {"ben": "releng", "bill": "releng"},
                     "required_signoffs": {},
+                    "original_row": dbo.releases.select({'name': 'ab'})[0],
                 },
             ]
         }

--- a/auslib/test/admin/views/test_required_signoffs.py
+++ b/auslib/test/admin/views/test_required_signoffs.py
@@ -190,11 +190,13 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 200000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "product": "fake", "channel": "a", "role": "releng", "signoffs_required": 2, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.productRequiredSignoffs.select({'product': 'fake', 'channel': 'a', 'role': 'releng'})[0],
                 },
                 {
                     "sc_id": 4, "when": 400000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "product": "fake", "channel": "j", "role": "releng", "signoffs_required": None, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.productRequiredSignoffs.select({'product': 'fake', 'channel': 'j', 'role': 'releng'})[0],
                 },
             ],
         }
@@ -214,16 +216,19 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 200000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "product": "fake", "channel": "a", "role": "releng", "signoffs_required": 2, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.productRequiredSignoffs.select({'product': 'fake', 'channel': 'a', 'role': 'releng'})[0],
                 },
                 {
                     "sc_id": 3, "when": 300000000, "scheduled_by": "bill", "change_type": "insert", "complete": True, "sc_data_version": 2,
                     "product": "fake", "channel": "e", "role": "releng", "signoffs_required": 1, "data_version": None,
                     "signoffs": {}, "required_signoffs": {},
+                    # No original_row for completed changes.
                 },
                 {
                     "sc_id": 4, "when": 400000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "product": "fake", "channel": "j", "role": "releng", "signoffs_required": None, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.productRequiredSignoffs.select({'product': 'fake', 'channel': 'j', 'role': 'releng'})[0],
                 },
             ],
         }
@@ -656,11 +661,13 @@ class TestPermissionsRequiredSignoffsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 200000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "product": "fake", "role": "releng", "signoffs_required": 2, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissionsRequiredSignoffs.select({'product': 'fake', 'role': 'releng'})[0],
                 },
                 {
                     "sc_id": 4, "when": 400000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "product": "blah", "role": "releng", "signoffs_required": None, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissionsRequiredSignoffs.select({'product': 'blah', 'role': 'releng'})[0],
                 },
             ],
         }
@@ -680,6 +687,7 @@ class TestPermissionsRequiredSignoffsScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 200000000, "scheduled_by": "bill", "change_type": "update", "complete": False, "sc_data_version": 1,
                     "product": "fake", "role": "releng", "signoffs_required": 2, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissionsRequiredSignoffs.select({'product': 'fake', 'role': 'releng'})[0],
                 },
                 {
                     "sc_id": 3, "when": 300000000, "scheduled_by": "bill", "change_type": "insert", "complete": True, "sc_data_version": 2,
@@ -690,6 +698,7 @@ class TestPermissionsRequiredSignoffsScheduledChanges(ViewTest):
                     "sc_id": 4, "when": 400000000, "scheduled_by": "bill", "change_type": "delete", "complete": False, "sc_data_version": 1,
                     "product": "blah", "role": "releng", "signoffs_required": None, "data_version": 1,
                     "signoffs": {"bill": "releng"}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.permissionsRequiredSignoffs.select({'product': 'blah', 'role': 'releng'})[0],
                 },
             ],
         }

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1041,6 +1041,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
+                    "original_row": dbo.rules.getRule(1),
                 },
                 {
                     "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
@@ -1065,6 +1066,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": 1, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.rules.getRule(4),
                 },
                 {
                     "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
@@ -1081,6 +1083,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.rules.getRule(6),
                 },
             ],
         }
@@ -1098,6 +1101,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
+                    "original_row": dbo.rules.getRule(1),
                 },
                 {
                     "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
@@ -1122,6 +1126,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
+                    # No original row on "complete"
                 },
                 {
                     "sc_id": 5, "when": 600000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 4, "priority": None,
@@ -1130,6 +1135,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": 1, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "delete", "signoffs": {}, "required_signoffs": {"releng": 1},
+                    "original_row": dbo.rules.getRule(4),
                 },
                 {
                     "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
@@ -1146,6 +1152,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {"releng": 1, "relman": 1},
+                    "original_row": dbo.rules.getRule(6),
                 },
             ],
         }

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -409,7 +409,7 @@ paths:
         Returns a JSON object containing metadata about Releases in Balrog's database. Due to its size, the actual Release 'blob' is never returned from this endpoint. There are a few query arguments that affect its response. If no arguments are provided, it returns all information about all of the Releases in the database. [Docs](http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#releases)
       tags:
         - Releases
-      operationId: auslib.web.common.releases.get_releases
+      operationId: auslib.web.admin.views.mapper.release_get
       consumes: []
       produces:
         - application/json
@@ -444,7 +444,13 @@ paths:
                 type: array
                 minItems: 0
                 items:
-                  $ref: '#/definitions/ReleaseGET'
+                  allOf:
+                    - $ref: '#/definitions/ReleaseGET'
+                    - properties:
+                        required_signoffs:
+                          description: Object mapping roles to the number of signoffs required to change the release
+                          type: object
+
               names:
                 description: List of release names
                 type: array
@@ -1848,6 +1854,9 @@ paths:
                       allOf:
                         - $ref: '#/definitions/SCSignoffsModel'
                         - $ref: '#/definitions/SCRulesItemBase'
+                        - properties:
+                            original_row:
+                              $ref: '#/definitions/RuleObject'
     post:
       summary: create scheduled change for rules.
       description: >
@@ -2074,6 +2083,12 @@ paths:
                         - $ref: '#/definitions/DataVersionNullable'
                         - $ref: '#/definitions/OptionsModel'
                         - $ref: '#/definitions/PermissionsModel'
+                        - properties:
+                            original_row:
+                              allOf:
+                                - $ref: '#/definitions/DataVersionNullable'
+                                - $ref: '#/definitions/PermissionsModel'
+                                - $ref: '#/definitions/OptionsModel'
                       required:
                         - change_type
                         - data_version
@@ -2314,6 +2329,14 @@ paths:
                         - $ref: '#/definitions/ReleaseReadOnly'
                         - $ref: '#/definitions/ReleaseDataObject'
                         - $ref: '#/definitions/ReleaseName'
+                        - properties:
+                            original_row:
+                              allOf:
+                                - $ref: '#/definitions/ReleaseDataObject'
+                                - $ref: '#/definitions/ReleaseName'
+                                - $ref: '#/definitions/DataVersionNullable'
+                                - $ref: '#/definitions/ProductNullable'
+                                - $ref: '#/definitions/ReleaseReadOnly'
                       required:
                         - change_type
                         - data_version
@@ -2561,6 +2584,14 @@ paths:
                         - $ref: '#/definitions/ProductModel'
                         - $ref: '#/definitions/RoleModel'
                         - $ref: '#/definitions/ChannelModel'
+                        - properties:
+                            original_row:
+                              allOf:
+                                - $ref: '#/definitions/DataVersionNullable'
+                                - $ref: '#/definitions/SignoffsRequiredNullable'
+                                - $ref: '#/definitions/ProductModel'
+                                - $ref: '#/definitions/RoleModel'
+                                - $ref: '#/definitions/ChannelModel'
                       required:
                         - change_type
                         - data_version
@@ -2812,6 +2843,13 @@ paths:
                         - $ref: '#/definitions/SignoffsRequiredNullable'
                         - $ref: '#/definitions/ProductModel'
                         - $ref: '#/definitions/RoleModel'
+                        - properties:
+                            original_row:
+                              allOf:
+                                - $ref: '#/definitions/DataVersionNullable'
+                                - $ref: '#/definitions/SignoffsRequiredNullable'
+                                - $ref: '#/definitions/ProductModel'
+                                - $ref: '#/definitions/RoleModel'
                       required:
                         - change_type
                         - data_version

--- a/auslib/web/admin/views/base.py
+++ b/auslib/web/admin/views/base.py
@@ -83,3 +83,12 @@ class AdminView(MethodView):
         self.log.debug("processing DELETE request to %s" % request.path)
         with dbo.begin() as trans:
             return self._delete(*args, transaction=trans, **kwargs)
+
+
+def serialize_signoff_requirements(requirements):
+    dct = {}
+    for rs in requirements:
+        signoffs_required = max(dct.get(rs["role"], 0), rs["signoffs_required"])
+        dct[rs["role"]] = signoffs_required
+
+    return dct

--- a/auslib/web/admin/views/mapper.py
+++ b/auslib/web/admin/views/mapper.py
@@ -123,6 +123,11 @@ def release_view_history_get(change_id, field):
     return ReleaseFieldView().get(change_id, field)
 
 
+def release_get():
+    """GET /releases"""
+    return ReleasesAPIView().get()
+
+
 def release_post():
     """POST /releases"""
     return ReleasesAPIView().post()

--- a/auslib/web/admin/views/rules.py
+++ b/auslib/web/admin/views/rules.py
@@ -31,6 +31,10 @@ def process_rule_form(form_data):
         else:
             rule_form_dict[key] = form_data[key]
 
+    for i in ["priority", "backgroundRate", "data_version"]:
+        if rule_form_dict.get(i, None):
+            rule_form_dict[i] = int(rule_form_dict[i])
+
     mapping_values = [y for x, y in mapping_choices if x == rule_form_dict.get("mapping")]
     fallback_mapping_values = [y for x, y in mapping_choices if x == rule_form_dict.get("fallbackMapping")]
 

--- a/auslib/web/admin/views/rules.py
+++ b/auslib/web/admin/views/rules.py
@@ -31,10 +31,6 @@ def process_rule_form(form_data):
         else:
             rule_form_dict[key] = form_data[key]
 
-    for i in ["priority", "backgroundRate", "data_version"]:
-        if rule_form_dict.get(i, None):
-            rule_form_dict[i] = int(rule_form_dict[i])
-
     mapping_values = [y for x, y in mapping_choices if x == rule_form_dict.get("mapping")]
     fallback_mapping_values = [y for x, y in mapping_choices if x == rule_form_dict.get("fallbackMapping")]
 

--- a/auslib/web/admin/views/validators.py
+++ b/auslib/web/admin/views/validators.py
@@ -146,6 +146,20 @@ def rule_id_validator(field_value):
     return integer_and_range_validator("rule_id", field_value, 0)
 
 
+@draft4_format_checker.checks(format="data_version", raises=JsonSchemaValidationError)
+def data_version_validator(field_value):
+    if field_value is not None and field_value != '':
+        logger.debug('starting in data_version_validator: data_version is %s' % field_value)
+    return integer_and_range_validator("data_version", field_value, 1)
+
+
+@draft4_format_checker.checks(format="rule_id", raises=JsonSchemaValidationError)
+def rule_id_validator(field_value):
+    if field_value is not None and field_value != '':
+        logger.debug('starting in rule_id_validator: rule_id is %s' % field_value)
+    return integer_and_range_validator("rule_id", field_value, 0)
+
+
 @draft4_format_checker.checks(format="signoffs_required", raises=JsonSchemaValidationError)
 def signoffs_required_validator(field_value):
     if field_value is not None and field_value != '':

--- a/auslib/web/admin/views/validators.py
+++ b/auslib/web/admin/views/validators.py
@@ -132,18 +132,18 @@ def sc_when_validator(field_value):
     return integer_and_range_validator("when", field_value, 0)
 
 
-@draft4_format_checker.checks(format="data_version", raises=JsonSchemaValidationError)
-def data_version_validator(field_value):
+@draft4_format_checker.checks(format="priority", raises=JsonSchemaValidationError)
+def priority_validator(field_value):
     if field_value is not None and field_value != '':
-        logger.debug('starting in data_version_validator: data_version is %s' % field_value)
-    return integer_and_range_validator("data_version", field_value, 1)
+        logger.debug('starting in priority_validator: priority is %s' % field_value)
+    return integer_and_range_validator("priority", field_value, 0)
 
 
-@draft4_format_checker.checks(format="rule_id", raises=JsonSchemaValidationError)
-def rule_id_validator(field_value):
+@draft4_format_checker.checks(format="backgroundRate", raises=JsonSchemaValidationError)
+def background_rate_validator(field_value):
     if field_value is not None and field_value != '':
-        logger.debug('starting in rule_id_validator: rule_id is %s' % field_value)
-    return integer_and_range_validator("rule_id", field_value, 0)
+        logger.debug('starting in backgroundRate_validator: backgroundRate is %s' % field_value)
+    return integer_and_range_validator("backgroundRate", field_value, 0, 100)
 
 
 @draft4_format_checker.checks(format="data_version", raises=JsonSchemaValidationError)

--- a/auslib/web/admin/views/validators.py
+++ b/auslib/web/admin/views/validators.py
@@ -132,20 +132,6 @@ def sc_when_validator(field_value):
     return integer_and_range_validator("when", field_value, 0)
 
 
-@draft4_format_checker.checks(format="priority", raises=JsonSchemaValidationError)
-def priority_validator(field_value):
-    if field_value is not None and field_value != '':
-        logger.debug('starting in priority_validator: priority is %s' % field_value)
-    return integer_and_range_validator("priority", field_value, 0)
-
-
-@draft4_format_checker.checks(format="backgroundRate", raises=JsonSchemaValidationError)
-def background_rate_validator(field_value):
-    if field_value is not None and field_value != '':
-        logger.debug('starting in backgroundRate_validator: backgroundRate is %s' % field_value)
-    return integer_and_range_validator("backgroundRate", field_value, 0, 100)
-
-
 @draft4_format_checker.checks(format="data_version", raises=JsonSchemaValidationError)
 def data_version_validator(field_value):
     if field_value is not None and field_value != '':

--- a/auslib/web/common/releases.py
+++ b/auslib/web/common/releases.py
@@ -24,7 +24,7 @@ def strip_data(release):
     )
 
 
-def get_releases():
+def release_list(request):
     kwargs = {}
     if request.args.get('product'):
         kwargs['product'] = request.args.get('product')
@@ -32,7 +32,10 @@ def get_releases():
         kwargs['name_prefix'] = request.args.get('name_prefix')
     if request.args.get('names_only'):
         kwargs['nameOnly'] = True
-    releases = dbo.releases.getReleaseInfo(**kwargs)
+    return dbo.releases.getReleaseInfo(**kwargs)
+
+
+def serialize_releases(request, releases):
     if request.args.get('names_only'):
         names = []
         for release in releases:
@@ -43,6 +46,11 @@ def get_releases():
             'releases': map(strip_data, releases),
         }
     return jsonify(data)
+
+
+def get_releases():
+    releases = release_list(request)
+    return serialize_releases(request, releases)
 
 
 def _get_release(release):

--- a/ui/app/css/main.less
+++ b/ui/app/css/main.less
@@ -107,6 +107,9 @@ div.xor-group > div {
 .validation_errors {
     border-color: red !important;
 }
+p.has-error {
+    color: #a94442 !important;
+}
 
 @import 'loader';
 @import 'smallloader';

--- a/ui/app/css/main.less
+++ b/ui/app/css/main.less
@@ -104,5 +104,9 @@ div.xor-group > div {
   }
 }
 
+.digit_evaluator {
+    border-color: red !important;
+}
+
 @import 'loader';
 @import 'smallloader';

--- a/ui/app/css/main.less
+++ b/ui/app/css/main.less
@@ -104,9 +104,6 @@ div.xor-group > div {
   }
 }
 
-.validation_errors {
-    border-color: red !important;
-}
 p.has-error {
     color: #a94442 !important;
 }

--- a/ui/app/css/main.less
+++ b/ui/app/css/main.less
@@ -104,7 +104,7 @@ div.xor-group > div {
   }
 }
 
-.digit_evaluator {
+.validation_errors {
     border-color: red !important;
 }
 

--- a/ui/app/js/controllers/permission_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/permission_scheduled_change_edit_controller.js
@@ -24,7 +24,6 @@ function ($scope, $modalInstance, CSRF, Permissions, sc) {
   $scope.is_edit = true;
   $scope.saving = false;
 
-
   $scope.updateScheduledPermission = function() {
 
     $scope.date = new Date();

--- a/ui/app/js/controllers/permission_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/permission_scheduled_change_new_controller.js
@@ -1,6 +1,6 @@
 /*global sweetAlert swal */
 angular.module('app').controller('NewPermissionScheduledChangeCtrl',
-function ($scope, $modalInstance, CSRF, Permissions, scheduled_changes, sc) {
+function ($scope, $modalInstance, CSRF, Permissions, scheduled_changes, sc, permissionSignoffRequirements) {
 
   $scope.loading = true;
   $scope.scheduled_changes = scheduled_changes;
@@ -28,6 +28,36 @@ function ($scope, $modalInstance, CSRF, Permissions, scheduled_changes, sc) {
   ];
 
 
+  function fromFormData(permission) {
+    permission = angular.copy(permission);
+    try {
+      permission.options = permission.options && JSON.parse(permission.options);
+    } catch(e) {
+      // No options, I guess
+    }
+    return permission;
+  }
+
+  function permissionSignoffsRequired(currentPermission, newPermission) {
+    if (currentPermission) {
+      currentPermission = fromFormData(currentPermission);
+    }
+    if (newPermission) {
+      newPermission = fromFormData(newPermission);
+    }
+    return Permissions.permissionSignoffsRequired(currentPermission, newPermission, permissionSignoffRequirements);
+  }
+
+  $scope.$watch("permission", function(permission) {
+    $scope.permissionSignoffsRequired = permissionSignoffsRequired(permission);
+  }, true);
+  $scope.scPermissionsSignoffRequirements = [];
+  $scope.$watch("sc.permissions", function(permissions) {
+    $scope.scPermissionsSignoffRequirements = permissions.map(function(permission, i) {
+      return permissionSignoffsRequired($scope.originalPermissions[i], permission);
+    });
+  }, true);
+
   $scope.sc.permissions = [];
   Permissions.getUserPermissions(sc.username)
   .then(function(permissions) {
@@ -36,6 +66,7 @@ function ($scope, $modalInstance, CSRF, Permissions, scheduled_changes, sc) {
         p.options = JSON.stringify(p['options']);
       }
     });
+    $scope.originalPermissions = angular.copy(permissions);
     $scope.sc.permissions = permissions;
     $scope.loading = false;
   });

--- a/ui/app/js/controllers/permissions_controller.js
+++ b/ui/app/js/controllers/permissions_controller.js
@@ -1,5 +1,5 @@
 angular.module("app").controller('PermissionsController',
-function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal, Page) {
+function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal, Page, PermissionsRequiredSignoffs) {
 
   Page.setTitle('Permissions');
 
@@ -27,6 +27,12 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
       $scope.loading = false;
     });
   }
+
+  $scope.signoffRequirements = [];
+  PermissionsRequiredSignoffs.getRequiredSignoffs()
+    .then(function(payload) {
+      $scope.signoffRequirements = payload.data.required_signoffs;
+    });
 
   $scope.ordering = ['username'];
 
@@ -92,6 +98,9 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
         user: function () {
           return user;
         },
+        permissionSignoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
   };
@@ -113,6 +122,9 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
         },
         user: function () {
           return $scope.user;
+        },
+        permissionSignoffRequirements: function() {
+          return $scope.signoffRequirements;
         },
       }
     });
@@ -136,7 +148,10 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
           sc = angular.copy(user);
           sc["change_type"] = "insert";
           return sc;
-        }
+        },
+        permissionSignoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
   };

--- a/ui/app/js/controllers/releases_controller.js
+++ b/ui/app/js/controllers/releases_controller.js
@@ -36,6 +36,13 @@ function($scope, $routeParams, $location, $timeout, Releases, Search, $modal, Pa
     Releases.getReleases()
     .success(function(response) {
       $scope.releases = response.releases;
+      $scope.releases.forEach(function(release) {
+        // Ideally we'd convert this field to a Map, but we can't use
+        // Maps, so let's match the structure returned by
+        // RulesService#ruleSignoffsRequired.
+        var oldSignoffs = release.required_signoffs;
+        release.required_signoffs = {length: Object.keys(oldSignoffs).length, roles: oldSignoffs};
+      });
       $scope.releases_count = response.releases.length;
     })
     .error(function() {

--- a/ui/app/js/controllers/rule_edit_controller.js
+++ b/ui/app/js/controllers/rule_edit_controller.js
@@ -34,9 +34,9 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
     $scope.saving = true;
 
     // Evaluate the values entered for priority and background rate.
-    $scope.integer_validation_errors = Helpers.integerValidator({'priority': $scope.rule.priority, 'rate': $scope.rule.backgroundRate});
+    $scope.errors = Helpers.integerValidator({'priority': $scope.rule.priority, 'rate': $scope.rule.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.rate) {
+    if($scope.errors.priority || $scope.errors.rate) {
       $scope.saving = false;
       return;
     }

--- a/ui/app/js/controllers/rule_edit_controller.js
+++ b/ui/app/js/controllers/rule_edit_controller.js
@@ -75,6 +75,7 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
       .error(function(response) {
         if (typeof response === 'object') {
           $scope.errors = response;
+          Helpers.addErrorFields($scope.errors);
           sweetAlert(
             "Form submission error",
             "See fields highlighted in red.",

--- a/ui/app/js/controllers/rule_edit_controller.js
+++ b/ui/app/js/controllers/rule_edit_controller.js
@@ -34,9 +34,9 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
     $scope.saving = true;
 
     // Evaluate the values entered for priority and background rate.
-    $scope.errors = Helpers.integerValidator({'priority': $scope.rule.priority, 'backgroundRate': $scope.rule.backgroundRate});
+    $scope.integer_validation_errors = Helpers.integerValidator({'priority': $scope.rule.priority, 'backgroundRate': $scope.rule.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.errors.priority || $scope.errors.backgroundRate) {
+    if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.backgroundRate) {
       $scope.saving = false;
       sweetAlert(
         "Form submission error",
@@ -44,10 +44,8 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
         "error"
       );
       return;
-    } else {
-      // Re-initialise the 'error' variable if no validation errors found in UI validation.
-      $scope.errors = {};
     }
+    
     CSRF.getToken()
     .then(function(csrf_token) {
       // The data we need to submit is a tweaked version of just the Rule fields, so

--- a/ui/app/js/controllers/rule_edit_controller.js
+++ b/ui/app/js/controllers/rule_edit_controller.js
@@ -1,7 +1,7 @@
 /*global sweetAlert */
 angular.module('app').controller('RuleEditCtrl',
-function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequirements, pr_ch_options) {
-
+function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequirements, pr_ch_options, Helpers) {
+  
   $scope.names = [];
   Releases.getNames().then(function(names) {
     $scope.names = names;
@@ -33,6 +33,13 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
   $scope.saveChanges = function () {
     $scope.saving = true;
 
+    // Evaluate the values entered for priority and background rate.
+    $scope.digit_validation_errors = Helpers.numberValidator({'priority': $scope.rule.priority, 'rate': $scope.rule.backgroundRate});
+    // Stop sending the request if any number validation errors.
+    if($scope.digit_validation_errors.priority || $scope.digit_validation_errors.rate) {
+      $scope.saving = false;
+      return;
+    }
     CSRF.getToken()
     .then(function(csrf_token) {
       // The data we need to submit is a tweaked version of just the Rule fields, so
@@ -45,7 +52,6 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
       .success(function(response) {
         $scope.rule.data_version = response.new_data_version;
         angular.copy($scope.rule, $scope.original_rule);
-
         if(rule.product) {
           // The first entry is special, and we want to avoid it getting sorted later.
           first_entry = $scope.pr_ch_options.shift();

--- a/ui/app/js/controllers/rule_edit_controller.js
+++ b/ui/app/js/controllers/rule_edit_controller.js
@@ -34,9 +34,9 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
     $scope.saving = true;
 
     // Evaluate the values entered for priority and background rate.
-    $scope.errors = Helpers.integerValidator({'priority': $scope.rule.priority, 'rate': $scope.rule.backgroundRate});
+    $scope.errors = Helpers.integerValidator({'priority': $scope.rule.priority, 'backgroundRate': $scope.rule.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.errors.priority || $scope.errors.rate) {
+    if($scope.errors.priority || $scope.errors.backgroundRate) {
       $scope.saving = false;
       return;
     } else {

--- a/ui/app/js/controllers/rule_edit_controller.js
+++ b/ui/app/js/controllers/rule_edit_controller.js
@@ -34,9 +34,9 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
     $scope.saving = true;
 
     // Evaluate the values entered for priority and background rate.
-    $scope.digit_validation_errors = Helpers.numberValidator({'priority': $scope.rule.priority, 'rate': $scope.rule.backgroundRate});
+    $scope.integer_validation_errors = Helpers.integerValidator({'priority': $scope.rule.priority, 'rate': $scope.rule.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.digit_validation_errors.priority || $scope.digit_validation_errors.rate) {
+    if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.rate) {
       $scope.saving = false;
       return;
     }

--- a/ui/app/js/controllers/rule_edit_controller.js
+++ b/ui/app/js/controllers/rule_edit_controller.js
@@ -38,6 +38,11 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
     // Stop sending the request if any number validation errors.
     if($scope.errors.priority || $scope.errors.backgroundRate) {
       $scope.saving = false;
+      sweetAlert(
+        "Form submission error",
+        "See fields highlighted in red.",
+        "error"
+      );
       return;
     } else {
       // Re-initialise the 'error' variable if no validation errors found in UI validation.

--- a/ui/app/js/controllers/rule_edit_controller.js
+++ b/ui/app/js/controllers/rule_edit_controller.js
@@ -39,6 +39,9 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
     if($scope.errors.priority || $scope.errors.rate) {
       $scope.saving = false;
       return;
+    } else {
+      // Re-initialise the 'error' variable if no validation errors found in UI validation.
+      $scope.errors = {};
     }
     CSRF.getToken()
     .then(function(csrf_token) {

--- a/ui/app/js/controllers/rule_edit_controller.js
+++ b/ui/app/js/controllers/rule_edit_controller.js
@@ -1,6 +1,6 @@
 /*global sweetAlert */
 angular.module('app').controller('RuleEditCtrl',
-function ($scope, $modalInstance, CSRF, Rules, Releases, rule, pr_ch_options) {
+function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequirements, pr_ch_options) {
 
   $scope.names = [];
   Releases.getNames().then(function(names) {
@@ -19,6 +19,13 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, pr_ch_options) {
   $scope.is_edit = true;
   $scope.original_rule = rule;
   $scope.rule = angular.copy(rule);
+  $scope.signoffRequirements = signoffRequirements;
+  $scope.$watch('rule', function() {
+    if (signoffRequirements) {
+      $scope.ruleSignoffsRequired = Rules.ruleSignoffsRequired($scope.original_rule, $scope.rule, $scope.signoffRequirements);
+    }
+  }, true);
+
 
   $scope.saving = false;
   $scope.pr_ch_options = pr_ch_options;

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -33,7 +33,7 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
     CSRF.getToken()
     .then(function(csrf_token) {
       rule = angular.copy($scope.rule);
-      if(isNaN(parseInt(rule.priority, 10)) || isNaN(parseInt(rule.backgroundRate, 10))) {
+      if(isNaN(parseInt(rule.priority, 10))|| isNaN(parseInt(rule.backgroundRate, 10))) {
         var error_source = [];
         if(isNaN(parseInt(rule.priority, 10))) {
           error_source.push('Priority');
@@ -43,13 +43,13 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
         }
         sweetAlert(
           "Type Error",
-          "Value for " + error_source.join(', ') + " should be a number.",
+          "Value for " + error_source.join(', ') + " should be a positive number.",
           "error"
         );
         $scope.saving = false;
         return;
       }
-      if(rule.backgroundRate > 100) {
+      if (!( 0 < rule.backgroundRate > 100)) {
         sweetAlert(
           "Value Error",
           "Value for Rate should be between 0 and 100",

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -31,16 +31,15 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
   $scope.saveChanges = function () {
     $scope.saving = true;
     $scope.errors = {};
-    $scope.rate_error = {};
     CSRF.getToken()
     .then(function(csrf_token) {
       rule = angular.copy($scope.rule);
       
       // Evaluate the values entered for priority and background rate.
-      $scope.integer_validation_errors = Helpers.integerValidator({'priority': rule.priority, 'rate': rule.backgroundRate});
-      
+      $scope.errors = Helpers.integerValidator({'priority': rule.priority, 'rate': rule.backgroundRate});
+
       // Stop sending the request if any number validation errors.
-      if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.rate) {
+      if($scope.errors.priority || $scope.errors.rate) {
         $scope.saving = false;
         return;
       }

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -38,7 +38,7 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
       
       // Function to evaluate for valid numbers.
       var evaluate = function (value, max) {
-          if(isNaN(value)) {
+        if(isNaN(value)) {
           return 'Value must be a number';
         }
         // Filter negative numbers and maximum, if specified.

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -35,17 +35,17 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
     .then(function(csrf_token) {
       rule = angular.copy($scope.rule);
       
-//      // Evaluate the values entered for priority and background rate.
-//      $scope.errors = Helpers.integerValidator({'priority': rule.priority, 'rate': rule.backgroundRate});
-//
-//      // Stop sending the request if any number validation errors.
-//      if($scope.errors.priority || $scope.errors.rate) {
-//        $scope.saving = false;
-//        return;
-//      } else {
-//        // Re-initialise the 'error' variable if no validation errors found in UI validation.
-//        $scope.errors = {};
-//      }
+      // Evaluate the values entered for priority and background rate.
+      $scope.errors = Helpers.integerValidator({'priority': rule.priority, 'rate': rule.backgroundRate});
+
+      // Stop sending the request if any number validation errors.
+      if($scope.errors.priority || $scope.errors.rate) {
+        $scope.saving = false;
+        return;
+      } else {
+        // Re-initialise the 'error' variable if no validation errors found in UI validation.
+        $scope.errors = {};
+      }
 
       Rules.addRule(rule, csrf_token)
       .success(function(response) {

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -1,5 +1,6 @@
 angular.module('app').controller('NewRuleCtrl',
-function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_ch_options, signoffRequirements) {
+function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequirements, pr_ch_options, Helpers) {
+
 
   $scope.names = [];
   Releases.getNames().then(function(names) {
@@ -34,24 +35,9 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
     CSRF.getToken()
     .then(function(csrf_token) {
       rule = angular.copy($scope.rule);
-      $scope.digit_validation_errors = {'priority': '', 'rate': ''};
       
-      // Function to evaluate for valid numbers.
-      var evaluate = function (value, max) {
-        if(isNaN(value)) {
-          return 'Value must be a number';
-        }
-        // Filter negative numbers and maximum, if specified.
-        if (value < 0 ) {
-          return 'Value must be a positive number';
-        } else if (max !== 'undefined' && value > max){
-          return 'Value should not be more than ' + max;
-        } else {
-          return false;
-        }
-      };
-      $scope.digit_validation_errors.priority = evaluate(rule.priority);
-      $scope.digit_validation_errors.rate = evaluate(rule.backgroundRate, 100);
+      // Evaluate the values entered for priority and background rate.
+      $scope.digit_validation_errors = Helpers.numberValidator({'priority': rule.priority, 'rate': rule.backgroundRate});
       
       // Stop sending the request if any number validation errors.
       if($scope.digit_validation_errors.priority || $scope.digit_validation_errors.rate) {
@@ -99,7 +85,6 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
     });
   };
   
-
   $scope.cancel = function () {
     $modalInstance.dismiss('cancel');
   };

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -86,7 +86,6 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
       .error(function(response, status) {
         if (typeof response === 'object') {
           $scope.errors = response;
-          console.log('ERRORS: ', $scope.errors);
           sweetAlert(
             "Form submission error",
             "See fields highlighted in red.",

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -41,6 +41,11 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
       // Stop sending the request if any number validation errors.
       if($scope.errors.priority || $scope.errors.backgroundRate) {
         $scope.saving = false;
+        sweetAlert(
+          "Form submission error",
+          "See fields highlighted in red.",
+          "error"
+        );
         return;
       } else {
         // Re-initialise the 'error' variable if no validation errors found in UI validation.

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -35,17 +35,17 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
     .then(function(csrf_token) {
       rule = angular.copy($scope.rule);
       
-//      // Evaluate the values entered for priority and background rate.
-//      $scope.errors = Helpers.integerValidator({'priority': rule.priority, 'backgroundRate': rule.backgroundRate});
-//
-//      // Stop sending the request if any number validation errors.
-//      if($scope.errors.priority || $scope.errors.backgroundRate) {
-//        $scope.saving = false;
-//        return;
-//      } else {
-//        // Re-initialise the 'error' variable if no validation errors found in UI validation.
-//        $scope.errors = {};
-//      }
+      // Evaluate the values entered for priority and background rate.
+      $scope.errors = Helpers.integerValidator({'priority': rule.priority, 'backgroundRate': rule.backgroundRate});
+
+      // Stop sending the request if any number validation errors.
+      if($scope.errors.priority || $scope.errors.backgroundRate) {
+        $scope.saving = false;
+        return;
+      } else {
+        // Re-initialise the 'error' variable if no validation errors found in UI validation.
+        $scope.errors = {};
+      }
 
       Rules.addRule(rule, csrf_token)
       .success(function(response) {

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -1,5 +1,5 @@
 angular.module('app').controller('NewRuleCtrl',
-function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_ch_options) {
+function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_ch_options, signoffRequirements) {
 
   $scope.names = [];
   Releases.getNames().then(function(names) {
@@ -21,6 +21,11 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
   $scope.errors = {};
   $scope.saving = false;
   $scope.pr_ch_options = pr_ch_options;
+  $scope.$watch('rule', function() {
+    if (signoffRequirements) {
+      $scope.ruleSignoffsRequired = Rules.ruleSignoffsRequired($scope.original_rule, $scope.rule, signoffRequirements);
+    }
+  }, true);
 
   $scope.saveChanges = function () {
     $scope.saving = true;

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -37,10 +37,10 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
       rule = angular.copy($scope.rule);
       
       // Evaluate the values entered for priority and background rate.
-      $scope.digit_validation_errors = Helpers.numberValidator({'priority': rule.priority, 'rate': rule.backgroundRate});
+      $scope.integer_validation_errors = Helpers.integerValidator({'priority': rule.priority, 'rate': rule.backgroundRate});
       
       // Stop sending the request if any number validation errors.
-      if($scope.digit_validation_errors.priority || $scope.digit_validation_errors.rate) {
+      if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.rate) {
         $scope.saving = false;
         return;
       }

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -33,6 +33,22 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
     CSRF.getToken()
     .then(function(csrf_token) {
       rule = angular.copy($scope.rule);
+      if(isNaN(parseInt(rule.priority, 10)) || isNaN(parseInt(rule.backgroundRate, 10))) {
+        var error_source = [];
+        if(isNaN(parseInt(rule.priority, 10))) {
+          error_source.push('Priority');
+        }
+        if(isNaN(parseInt(rule.backgroundRate, 10))) {
+          error_source.push('Rate');
+        }
+        sweetAlert(
+          "Type Error",
+          "Value for " + error_source.join(', ') + " should be a number.",
+          "error"
+        );
+        $scope.saving = false;
+        return;
+      }
       // rule.priority = '' + rule.priority;
       Rules.addRule(rule, csrf_token)
       .success(function(response) {
@@ -61,6 +77,7 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
       .error(function(response, status) {
         if (typeof response === 'object') {
           $scope.errors = response;
+          console.log('ERRORS: ', $scope.errors);
           sweetAlert(
             "Form submission error",
             "See fields highlighted in red.",

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -35,17 +35,17 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
     .then(function(csrf_token) {
       rule = angular.copy($scope.rule);
       
-      // Evaluate the values entered for priority and background rate.
-      $scope.errors = Helpers.integerValidator({'priority': rule.priority, 'rate': rule.backgroundRate});
-
-      // Stop sending the request if any number validation errors.
-      if($scope.errors.priority || $scope.errors.rate) {
-        $scope.saving = false;
-        return;
-      } else {
-        // Re-initialise the 'error' variable if no validation errors found in UI validation.
-        $scope.errors = {};
-      }
+//      // Evaluate the values entered for priority and background rate.
+//      $scope.errors = Helpers.integerValidator({'priority': rule.priority, 'rate': rule.backgroundRate});
+//
+//      // Stop sending the request if any number validation errors.
+//      if($scope.errors.priority || $scope.errors.rate) {
+//        $scope.saving = false;
+//        return;
+//      } else {
+//        // Re-initialise the 'error' variable if no validation errors found in UI validation.
+//        $scope.errors = {};
+//      }
 
       Rules.addRule(rule, csrf_token)
       .success(function(response) {
@@ -74,6 +74,7 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
       .error(function(response, status) {
         if (typeof response === 'object') {
           $scope.errors = response;
+          Helpers.addErrorFields($scope.errors);
           sweetAlert(
             "Form submission error",
             "See fields highlighted in red.",

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -42,6 +42,9 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
       if($scope.errors.priority || $scope.errors.rate) {
         $scope.saving = false;
         return;
+      } else {
+        // Re-initialise the 'error' variable if no validation errors found in UI validation.
+        $scope.errors = {};
       }
 
       Rules.addRule(rule, csrf_token)

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -35,17 +35,17 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
     .then(function(csrf_token) {
       rule = angular.copy($scope.rule);
       
-      // Evaluate the values entered for priority and background rate.
-      $scope.errors = Helpers.integerValidator({'priority': rule.priority, 'rate': rule.backgroundRate});
-
-      // Stop sending the request if any number validation errors.
-      if($scope.errors.priority || $scope.errors.rate) {
-        $scope.saving = false;
-        return;
-      } else {
-        // Re-initialise the 'error' variable if no validation errors found in UI validation.
-        $scope.errors = {};
-      }
+//      // Evaluate the values entered for priority and background rate.
+//      $scope.errors = Helpers.integerValidator({'priority': rule.priority, 'backgroundRate': rule.backgroundRate});
+//
+//      // Stop sending the request if any number validation errors.
+//      if($scope.errors.priority || $scope.errors.backgroundRate) {
+//        $scope.saving = false;
+//        return;
+//      } else {
+//        // Re-initialise the 'error' variable if no validation errors found in UI validation.
+//        $scope.errors = {};
+//      }
 
       Rules.addRule(rule, csrf_token)
       .success(function(response) {

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -36,10 +36,12 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
       rule = angular.copy($scope.rule);
       $scope.digit_validation_errors = {'priority': '', 'rate': ''};
       
+      // Function to evaluate for valid numbers.
       var evaluate = function (value, max) {
           if(isNaN(value)) {
           return 'Value must be a number';
         }
+        // Filter negative numbers and maximum, if specified.
         if (value < 0 ) {
           return 'Value must be a positive number';
         } else if (max !== 'undefined' && value > max){
@@ -50,7 +52,8 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
       };
       $scope.digit_validation_errors.priority = evaluate(rule.priority);
       $scope.digit_validation_errors.rate = evaluate(rule.backgroundRate, 100);
-
+      
+      // Stop sending the request if any number validation errors.
       if($scope.digit_validation_errors.priority || $scope.digit_validation_errors.rate) {
         $scope.saving = false;
         return;

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -49,6 +49,15 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
         $scope.saving = false;
         return;
       }
+      if(rule.backgroundRate > 100) {
+        sweetAlert(
+          "Value Error",
+          "Value for Rate should be between 0 and 100",
+          "error"
+        );
+        $scope.saving = false;
+        return;
+      }
       // rule.priority = '' + rule.priority;
       Rules.addRule(rule, csrf_token)
       .success(function(response) {

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -45,6 +45,7 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
           "See fields highlighted in red.",
           "error"
         );
+        return;
       }
 
       Rules.addRule(rule, csrf_token)

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -36,20 +36,16 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequiremen
       rule = angular.copy($scope.rule);
       
       // Evaluate the values entered for priority and background rate.
-      $scope.errors = Helpers.integerValidator({'priority': rule.priority, 'backgroundRate': rule.backgroundRate});
+      $scope.integer_validation_errors = Helpers.integerValidator({'priority': rule.priority, 'backgroundRate': rule.backgroundRate});
 
       // Stop sending the request if any number validation errors.
-      if($scope.errors.priority || $scope.errors.backgroundRate) {
+      if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.backgroundRate) {
         $scope.saving = false;
         sweetAlert(
           "Form submission error",
           "See fields highlighted in red.",
           "error"
         );
-        return;
-      } else {
-        // Re-initialise the 'error' variable if no validation errors found in UI validation.
-        $scope.errors = {};
       }
 
       Rules.addRule(rule, csrf_token)

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -1,6 +1,5 @@
 angular.module('app').controller('NewRuleCtrl',
-function ($scope, $modalInstance, CSRF, Rules, Releases, rule, signoffRequirements, pr_ch_options, Helpers) {
-
+function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_ch_options, signoffRequirements, Helpers) {
 
   $scope.names = [];
   Releases.getNames().then(function(names) {

--- a/ui/app/js/controllers/rule_new_controller.js
+++ b/ui/app/js/controllers/rule_new_controller.js
@@ -30,35 +30,32 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
   $scope.saveChanges = function () {
     $scope.saving = true;
     $scope.errors = {};
+    $scope.rate_error = {};
     CSRF.getToken()
     .then(function(csrf_token) {
       rule = angular.copy($scope.rule);
-      if(isNaN(parseInt(rule.priority, 10))|| isNaN(parseInt(rule.backgroundRate, 10))) {
-        var error_source = [];
-        if(isNaN(parseInt(rule.priority, 10))) {
-          error_source.push('Priority');
+      $scope.digit_validation_errors = {'priority': '', 'rate': ''};
+      
+      var evaluate = function (value, max) {
+          if(isNaN(value)) {
+          return 'Value must be a number';
         }
-        if(isNaN(parseInt(rule.backgroundRate, 10))) {
-          error_source.push('Rate');
+        if (value < 0 ) {
+          return 'Value must be a positive number';
+        } else if (max !== 'undefined' && value > max){
+          return 'Value should not be more than ' + max;
+        } else {
+          return false;
         }
-        sweetAlert(
-          "Type Error",
-          "Value for " + error_source.join(', ') + " should be a positive number.",
-          "error"
-        );
+      };
+      $scope.digit_validation_errors.priority = evaluate(rule.priority);
+      $scope.digit_validation_errors.rate = evaluate(rule.backgroundRate, 100);
+
+      if($scope.digit_validation_errors.priority || $scope.digit_validation_errors.rate) {
         $scope.saving = false;
         return;
       }
-      if (!( 0 < rule.backgroundRate > 100)) {
-        sweetAlert(
-          "Value Error",
-          "Value for Rate should be between 0 and 100",
-          "error"
-        );
-        $scope.saving = false;
-        return;
-      }
-      // rule.priority = '' + rule.priority;
+
       Rules.addRule(rule, csrf_token)
       .success(function(response) {
         $scope.rule.data_version = 1;
@@ -99,6 +96,7 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, rules, rule, pr_c
       });
     });
   };
+  
 
   $scope.cancel = function () {
     $modalInstance.dismiss('cancel');

--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -75,9 +75,9 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements
     $scope.sc.when = ($scope.auto_time) ? asap : $scope.sc.when;
     
     // Evaluate the values entered for priority and background rate.
-    $scope.integer_validation_errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
+    $scope.errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.rate) {
+    if($scope.errors.priority || $scope.errors.rate) {
       $scope.saving = false;
       return;
     }

--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -75,9 +75,9 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements
     $scope.sc.when = ($scope.auto_time) ? asap : $scope.sc.when;
     
     // Evaluate the values entered for priority and background rate.
-    $scope.errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
+    $scope.errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'backgroundRate': $scope.sc.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.errors.priority || $scope.errors.rate) {
+    if($scope.errors.priority || $scope.errors.backgroundRate) {
       $scope.saving = false;
       return;
     } else {

--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -75,9 +75,9 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements
     $scope.sc.when = ($scope.auto_time) ? asap : $scope.sc.when;
     
     // Evaluate the values entered for priority and background rate.
-    $scope.errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'backgroundRate': $scope.sc.backgroundRate});
+    $scope.integer_validation_errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'backgroundRate': $scope.sc.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.errors.priority || $scope.errors.backgroundRate) {
+    if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.backgroundRate) {
       $scope.saving = false;
       sweetAlert(
         "Form submission error",
@@ -85,10 +85,8 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements
         "error"
       );
       return;
-    } else {
-      // Re-initialise the 'error' variable if no validation errors found in UI validation.
-      $scope.errors = {};
     }
+    
     CSRF.getToken()
     .then(function(csrf_token) {
       sc = angular.copy($scope.sc);

--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -1,6 +1,6 @@
 /*global sweetAlert */
 angular.module('app').controller('EditRuleScheduledChangeCtrl',
-function ($scope, $modalInstance, CSRF, Rules, Releases, sc) {
+function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements) {
 
   $scope.names = [];
   Releases.getNames().then(function(names) {
@@ -22,6 +22,16 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc) {
   $scope.saving = false;
   $scope.calendar_is_open = false;
   $scope.sc_type = "time";
+
+  $scope.$watch('sc', function() {
+    if (signoffRequirements) {
+      var target = $scope.sc;
+      if ($scope.sc.change_type === "delete") {
+        target = undefined;
+      }
+      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired(sc.original_row, target, signoffRequirements);
+    }
+  }, true);
 
   $scope.auto_time = false;
   $scope.toggleAutoTime = function(){

--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -79,6 +79,11 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements
     // Stop sending the request if any number validation errors.
     if($scope.errors.priority || $scope.errors.backgroundRate) {
       $scope.saving = false;
+      sweetAlert(
+        "Form submission error",
+        "See fields highlighted in red.",
+        "error"
+      );
       return;
     } else {
       // Re-initialise the 'error' variable if no validation errors found in UI validation.

--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -106,6 +106,7 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements
       .error(function(response) {
         if (typeof response === 'object') {
           $scope.errors = response;
+          Helpers.addErrorFields($scope.errors);
           sweetAlert(
             "Form submission error",
             "See fields highlighted in red.",

--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -1,7 +1,7 @@
 /*global sweetAlert */
 angular.module('app').controller('EditRuleScheduledChangeCtrl',
-function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements) {
-
+function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements, Helpers) {
+  
   $scope.names = [];
   Releases.getNames().then(function(names) {
     $scope.names = names;
@@ -73,7 +73,14 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements
     asap = new Date();
     asap.setMinutes(asap.getMinutes() + 5);
     $scope.sc.when = ($scope.auto_time) ? asap : $scope.sc.when;
-
+    
+    // Evaluate the values entered for priority and background rate.
+    $scope.digit_validation_errors = Helpers.numberValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
+    // Stop sending the request if any number validation errors.
+    if($scope.digit_validation_errors.priority || $scope.digit_validation_errors.rate) {
+      $scope.saving = false;
+      return;
+    }
     CSRF.getToken()
     .then(function(csrf_token) {
       sc = angular.copy($scope.sc);

--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -75,9 +75,9 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements
     $scope.sc.when = ($scope.auto_time) ? asap : $scope.sc.when;
     
     // Evaluate the values entered for priority and background rate.
-    $scope.digit_validation_errors = Helpers.numberValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
+    $scope.integer_validation_errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.digit_validation_errors.priority || $scope.digit_validation_errors.rate) {
+    if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.rate) {
       $scope.saving = false;
       return;
     }

--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -80,6 +80,9 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements
     if($scope.errors.priority || $scope.errors.rate) {
       $scope.saving = false;
       return;
+    } else {
+      // Re-initialise the 'error' variable if no validation errors found in UI validation.
+      $scope.errors = {};
     }
     CSRF.getToken()
     .then(function(csrf_token) {

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -74,9 +74,9 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
     $scope.sc.when = ($scope.auto_time) ? asap : $scope.sc.when;
 
     // Evaluate the values entered for priority and background rate.
-    $scope.errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'backgroundRate': $scope.sc.backgroundRate});
+    $scope.integer_validation_errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'backgroundRate': $scope.sc.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.errors.priority || $scope.errors.backgroundRate) {
+    if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.backgroundRate) {
       $scope.saving = false;
       sweetAlert(
         "Form submission error",
@@ -84,10 +84,8 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
         "error"
       );
       return;
-    } else {
-      // Re-initialise the 'error' variable if no validation errors found in UI validation.
-      $scope.errors = {};
     }
+    
     CSRF.getToken()
     .then(function(csrf_token) {
       sc = angular.copy($scope.sc);

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -1,5 +1,5 @@
 angular.module("app").controller("NewRuleScheduledChangeCtrl",
-function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes, sc) {
+function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes, sc, signoffRequirements) {
   $scope.names = [];
   Releases.getNames().then(function(names) {
     $scope.names = names;
@@ -29,6 +29,16 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
           $('#btn__auto-time').removeClass('active');
       }
   };
+
+  $scope.$watch('sc', function() {
+    if (signoffRequirements) {
+      var target = $scope.sc;
+      if ($scope.sc.change_type === "delete") {
+        target = undefined;
+      }
+      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired($scope.sc.original_row, target, signoffRequirements);
+    }
+  }, true);
 
   $scope.toggleType = function(newType) {
     $scope.sc_type = newType;

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -105,6 +105,7 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
       .error(function(response, status) {
         if (typeof response === 'object') {
           $scope.errors = response;
+          Helpers.addErrorFields($scope.errors);
           sweetAlert(
             "Form submission error",
             "See fields highlighted in red.",

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -78,6 +78,11 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
     // Stop sending the request if any number validation errors.
     if($scope.errors.priority || $scope.errors.backgroundRate) {
       $scope.saving = false;
+      sweetAlert(
+        "Form submission error",
+        "See fields highlighted in red.",
+        "error"
+      );
       return;
     } else {
       // Re-initialise the 'error' variable if no validation errors found in UI validation.

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -74,9 +74,9 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
     $scope.sc.when = ($scope.auto_time) ? asap : $scope.sc.when;
 
     // Evaluate the values entered for priority and background rate.
-    $scope.errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
+    $scope.errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'backgroundRate': $scope.sc.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.errors.priority || $scope.errors.rate) {
+    if($scope.errors.priority || $scope.errors.backgroundRate) {
       $scope.saving = false;
       return;
     } else {

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -1,6 +1,6 @@
 angular.module("app").controller("NewRuleScheduledChangeCtrl",
 function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes, sc, signoffRequirements, Helpers) {
-  
+
   $scope.names = [];
   Releases.getNames().then(function(names) {
     $scope.names = names;

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -74,9 +74,9 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
     $scope.sc.when = ($scope.auto_time) ? asap : $scope.sc.when;
 
     // Evaluate the values entered for priority and background rate.
-    $scope.digit_validation_errors = Helpers.numberValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
+    $scope.integer_validation_errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.digit_validation_errors.priority || $scope.digit_validation_errors.rate) {
+    if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.rate) {
       $scope.saving = false;
       return;
     }

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -74,9 +74,9 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
     $scope.sc.when = ($scope.auto_time) ? asap : $scope.sc.when;
 
     // Evaluate the values entered for priority and background rate.
-    $scope.integer_validation_errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
+    $scope.errors = Helpers.integerValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
     // Stop sending the request if any number validation errors.
-    if($scope.integer_validation_errors.priority || $scope.integer_validation_errors.rate) {
+    if($scope.errors.priority || $scope.errors.rate) {
       $scope.saving = false;
       return;
     }

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -79,6 +79,9 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
     if($scope.errors.priority || $scope.errors.rate) {
       $scope.saving = false;
       return;
+    } else {
+      // Re-initialise the 'error' variable if no validation errors found in UI validation.
+      $scope.errors = {};
     }
     CSRF.getToken()
     .then(function(csrf_token) {

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -1,5 +1,6 @@
 angular.module("app").controller("NewRuleScheduledChangeCtrl",
-function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes, sc, signoffRequirements) {
+function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes, sc, signoffRequirements, Helpers) {
+  
   $scope.names = [];
   Releases.getNames().then(function(names) {
     $scope.names = names;
@@ -72,6 +73,13 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
     asap.setMinutes(asap.getMinutes() + 5);
     $scope.sc.when = ($scope.auto_time) ? asap : $scope.sc.when;
 
+    // Evaluate the values entered for priority and background rate.
+    $scope.digit_validation_errors = Helpers.numberValidator({'priority': $scope.sc.priority, 'rate': $scope.sc.backgroundRate});
+    // Stop sending the request if any number validation errors.
+    if($scope.digit_validation_errors.priority || $scope.digit_validation_errors.rate) {
+      $scope.saving = false;
+      return;
+    }
     CSRF.getToken()
     .then(function(csrf_token) {
       sc = angular.copy($scope.sc);

--- a/ui/app/js/controllers/rule_scheduled_changes_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_changes_controller.js
@@ -1,5 +1,5 @@
 angular.module("app").controller("RuleScheduledChangesController",
-function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $route, Releases, Permissions, Page) {
+function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $route, Releases, Permissions, Page, ProductRequiredSignoffs) {
 
   Page.setTitle('Scheduled Rule Changes');
 
@@ -21,6 +21,11 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
       response
     );
   });
+
+  ProductRequiredSignoffs.getRequiredSignoffs()
+    .then(function(payload) {
+      $scope.signoffRequirements = payload.data.required_signoffs;
+    });
 
   function loadPage(newPage) {
     Rules.getScheduledChangeHistory($scope.sc_id, $scope.pageSize, newPage)
@@ -139,7 +144,10 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
             when: null,
             change_type: 'insert',
           };
-        }
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
   };
@@ -230,7 +238,10 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         sc: function() {
           sc.when = new Date(sc.when);
           return sc;
-        }
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
   };

--- a/ui/app/js/controllers/rules_controller.js
+++ b/ui/app/js/controllers/rules_controller.js
@@ -1,5 +1,5 @@
 angular.module("app").controller('RulesController',
-function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $route, Releases, Page, Permissions) {
+function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $route, Releases, Page, Permissions, ProductRequiredSignoffs) {
 
   Page.setTitle('Rules');
 
@@ -102,6 +102,16 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
           }
         });
       });
+
+      ProductRequiredSignoffs.getRequiredSignoffs()
+        .then(function(payload) {
+        $scope.signoffRequirements = payload.data.required_signoffs;
+      });
+      $scope.ruleSignoffsRequired = function(rule) {
+        if ($scope.signoffRequirements) {
+          return Rules.ruleSignoffsRequired(rule, undefined, $scope.signoffRequirements);
+        }
+      };
     })
     .error(function() {
       console.error(arguments);
@@ -211,6 +221,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         rule: function () {
           return rule;
         },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
         pr_ch_options: function() {
           return $scope.pr_ch_options;
         }
@@ -243,6 +256,7 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         sc: function() {
           // blank new default rule
           return {
+            base_row: undefined,
             product: product,
             channel: channel,
             backgroundRate: 0,
@@ -251,7 +265,10 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
             when: null,
             change_type: 'insert',
           };
-        }
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
     modalInstance.result.then(function(sc) {
@@ -273,9 +290,13 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         },
         sc: function() {
           sc = angular.copy(rule);
+          sc.original_row = rule;
           sc["change_type"] = "update";
           return sc;
-        }
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
     modalInstance.result.then(function(sc) {
@@ -295,11 +316,15 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         },
         sc: function() {
           return {
+            "base_row": rule,
             "rule_id": rule.rule_id,
             "data_version": rule.data_version,
             "change_type": "delete"
           };
-        }
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
       }
     });
     modalInstance.result.then(function(sc) {
@@ -315,8 +340,16 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
       backdrop: 'static',
       resolve: {
         sc: function() {
-          return rule.scheduled_change;
-        }
+          var sc = angular.copy(rule.scheduled_change);
+          sc.original_row = rule;
+          return sc;
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
+        rule: function() {
+          return rule;
+        },
       }
     });
     modalInstance.result.then(function(action) {
@@ -374,6 +407,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
             _duplicate: false,
           };
         },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
+        },
         pr_ch_options: function() {
           return $scope.pr_ch_options;
         }
@@ -398,6 +434,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
           delete copy.rule_id;
           copy._duplicate = true;
           return copy;
+        },
+        signoffRequirements: function() {
+          return $scope.signoffRequirements;
         },
         pr_ch_options: function() {
           return $scope.pr_ch_options;

--- a/ui/app/js/directives/show_signoff_requirements_directive.js
+++ b/ui/app/js/directives/show_signoff_requirements_directive.js
@@ -1,0 +1,15 @@
+angular.module("app").directive('showSignoffRequirements', function() {
+  return {
+    restrict: 'E',
+    replace: true,
+    scope: {
+      requirements: '=',
+    },
+    template: '<div ng-show="requirements.length" class="has-error">' +
+      '<p class="help-block">' +
+      'This change requires signoffs: ' +
+      "<span ng-repeat=\"(key, value) in requirements.roles\">{{ value }} from {{ key }}{{$last ? '.' : ', '}}</span>" +
+      '</p>' +
+      '</div>',
+  };
+});

--- a/ui/app/js/services/helper_service.js
+++ b/ui/app/js/services/helper_service.js
@@ -10,7 +10,7 @@ angular.module("app").factory('Helpers', function() {
       }
       return object;
     },
-    numberValidator: function (validation_fields) {
+    integerValidator: function (validation_fields) {
       var validation_results = {};
       for (var key in validation_fields) {
         var value = validation_fields[key];

--- a/ui/app/js/services/helper_service.js
+++ b/ui/app/js/services/helper_service.js
@@ -15,7 +15,7 @@ angular.module("app").factory('Helpers', function() {
       for (var key in validation_fields) {
         var value = validation_fields[key];
         if (isNaN(value)) {
-          validation_results[key] = 'Invalid input for '+ key +'. Not an integer. '+ key +': "'+ value + '" is not a "'+ key + '"';
+          validation_results[key] = key + ' field value must be an integer. "' + value + '" is not an integer.';
           continue;
         }
         // Filter negative numbers and maximum, if specified.

--- a/ui/app/js/services/helper_service.js
+++ b/ui/app/js/services/helper_service.js
@@ -29,6 +29,21 @@ angular.module("app").factory('Helpers', function() {
       }
       return validation_results;
     },
+    addErrorFields: function (error_object) {
+      // method to add to the $scope.errors object with {field: field error} if the fields are present in the error details.
+      var error_details = error_object.detail;
+      var fields = ['priority', 'backgroundRate', 'mapping', 'channel', 'product', 'fallbackMapping', 'alias',
+        'product', 'version', 'buildID', 'locale', 'distribution', 'buildTarget', 'osVersion', 'instructionSet',
+        'memory', 'distVersion', 'comment', 'update_type', 'headerArchitecture', 'telemetry_product',
+        'telemetry_channel', 'telemetry_uptake'];
+      if (error_details) {
+        for (var x = 0; x < fields.length; x++) {
+          if (error_details.indexOf(fields[x]) >= 0) {
+            error_object[fields[x]] = error_details;
+          }
+        }
+      }
+    },
   };
   return service;
 });

--- a/ui/app/js/services/helper_service.js
+++ b/ui/app/js/services/helper_service.js
@@ -20,9 +20,9 @@ angular.module("app").factory('Helpers', function() {
         }
         // Filter negative numbers and maximum, if specified.
         if (value < 0) {
-          validation_results[key] = 'Value must be a positive number';
-        } else if (key === 'rate' && value > 100) {
-          validation_results[key] = 'Value should not be more than 100';
+          validation_results[key] = key + ' field value should be an integer >= 0 '+ key +': '+ value +' is not a "'+ key +'"';
+        } else if (key === 'backgroundRate' && value > 100) {
+          validation_results[key] = 'backgroundRate field value should be an integer <= 100 backgroundRate: '+ value + ' is not a "backgroundRate"';
         } else {
           validation_results[key] = false;
         }

--- a/ui/app/js/services/helper_service.js
+++ b/ui/app/js/services/helper_service.js
@@ -15,7 +15,7 @@ angular.module("app").factory('Helpers', function() {
       for (var key in validation_fields) {
         var value = validation_fields[key];
         if (isNaN(value)) {
-          validation_results[key] = 'Value must be a number';
+          validation_results[key] = 'Invalid input for '+ key +'. Not an integer. '+ key +': "'+ value + '" is not a "'+ key + '"';
           continue;
         }
         // Filter negative numbers and maximum, if specified.

--- a/ui/app/js/services/helper_service.js
+++ b/ui/app/js/services/helper_service.js
@@ -10,6 +10,25 @@ angular.module("app").factory('Helpers', function() {
       }
       return object;
     },
+    numberValidator: function (validation_fields) {
+      var validation_results = {};
+      for (var key in validation_fields) {
+        var value = validation_fields[key];
+        if (isNaN(value)) {
+          validation_results[key] = 'Value must be a number';
+          continue;
+        }
+        // Filter negative numbers and maximum, if specified.
+        if (value < 0) {
+          validation_results[key] = 'Value must be a positive number';
+        } else if (key === 'rate' && value > 100) {
+          validation_results[key] = 'Value should not be more than 100';
+        } else {
+          validation_results[key] = false;
+        }
+      }
+      return validation_results;
+    },
   };
   return service;
 });

--- a/ui/app/js/services/permissions_service.js
+++ b/ui/app/js/services/permissions_service.js
@@ -1,4 +1,4 @@
-angular.module("app").factory('Permissions', function($http, $q, ScheduledChanges, Helpers) {
+angular.module("app").factory('Permissions', function($http, $q, ScheduledChanges, Helpers, PermissionsRequiredSignoffs) {
   var service = {
     getUsers: function() {
       return $http.get('/api/users');
@@ -101,6 +101,24 @@ angular.module("app").factory('Permissions', function($http, $q, ScheduledChange
       var url = ScheduledChanges.signoffsUrl("permissions", sc_id);
       url += "?csrf_token=" + encodeURIComponent(data["csrf_token"]);
       return $http.delete(url, data);
+    },
+    permissionSignoffsRequired: function(oldPermission, newPermission, permissionSignoffRequirements) {
+      function matchesPermission(permission, permissionSignoffRequirement) {
+        var options = permission.options;
+        var hasProducts = options && options.products && options.products.length > 0;
+        var matchesProduct = options && options.products && options.products.indexOf(permissionSignoffRequirement.product) !== -1;
+        return !hasProducts || matchesProduct;
+      }
+
+      function matchesPermissions(permissionSignoffRequirement) {
+        // oldPermission is undefined during create. newPermission is
+        // undefined during delete.
+        var permissions = [oldPermission, newPermission].filter(function(permission) { return permission; });
+        return permissions.some(function(permission) { return matchesPermission(permission, permissionSignoffRequirement); });
+      }
+
+      var relevantRequirements = permissionSignoffRequirements.filter(matchesPermissions);
+      return PermissionsRequiredSignoffs.convertToMap(relevantRequirements);
     },
   };
   return service;

--- a/ui/app/js/services/required_signoffs.js
+++ b/ui/app/js/services/required_signoffs.js
@@ -42,6 +42,27 @@ var RequiredSignoffBase = (function() {
       url += "?csrf_token=" + encodeURIComponent(data["csrf_token"]);
       return this.http.delete(url, data);
     },
+    /**
+     * Convert a list of {role, signoffs_required} objects into a
+     * Map-like object that is easy to deal with in templates even
+     * though we can't actually use Map.
+     *
+     * Returns {length, roles}, where roles is an object with keys
+     * being role names and values being the number of signoffs
+     * required, and length is the number of keys in roles.
+     *
+     * FIXME: Not actually a Map
+     */
+    convertToMap: function(signoffRequirements) {
+      var merged = {};
+      signoffRequirements.map(function(requirement) {
+        if (!merged[requirement.role] || merged[requirement.role] < requirement.signoffs_required) {
+          merged[requirement.role] = requirement.signoffs_required;
+        }
+      });
+      return {length: Object.keys(merged).length, roles: merged};
+
+    }
   };
   return service;
 }());

--- a/ui/app/templates/permissions_modal.html
+++ b/ui/app/templates/permissions_modal.html
@@ -48,6 +48,7 @@
           </div>
         </form>
           <!-- connexion catches and throws exception without invoking API method-->
+          <show-signoff-requirements requirements="permissionSignoffsRequired"></show-signoff-requirements>
           <div class="form-group" ng-class="{'has-error': errors.detail}">
             <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
           </div>
@@ -60,8 +61,8 @@
              ng-repeat="permission in user.permissions">
           <div class="panel-heading">
               <div style="float: right">
-                <button class="btn btn-primary btn-xs" ng-show="!saving" ng-click="updatePermission(permission)">Save changes</button>
-                <button class="btn btn-primary btn-xs" ng-show="!saving" ng-click="deletePermission(permission)">Delete</button>
+                <button class="btn btn-primary btn-xs" ng-show="!saving && !userPermissionsSignoffRequirements[$index].signoffRequirements.length" ng-click="updatePermission(permission)">Save changes</button>
+                <button class="btn btn-primary btn-xs" ng-show="!saving && !userPermissionsSignoffRequirements[$index].deleteSignoffRequirements.length" ng-click="deletePermission(permission)">Delete</button>
               </div>
             <h3 class="panel-title">
               {{ permission.permission }}

--- a/ui/app/templates/permissions_scheduled_change_modal.html
+++ b/ui/app/templates/permissions_scheduled_change_modal.html
@@ -22,6 +22,7 @@
             <textarea id="id_options" ng-model="permission.options" class="options-as-json"></textarea>
             <p class="help-block" ng-show="errors.options">{{ errors.options.join(', ') }}</p>
           </div>
+        <show-signoff-requirements requirements="permissionSignoffsRequired"></show-signoff-requirements>
         <div class="form-group" ng-class="{'has-error': errors.detail}">
             <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
         </div>
@@ -51,6 +52,7 @@
           <div class="panel-body">
             <textarea ng-model="permission.options" class="options-as-json"></textarea>
             <p class="help-block" ng-show="errors.permissions[permission.permission]">{{ errors.permissions[permission.permission].options.join(', ') }}</p>
+            <show-signoff-requirements requirements="scPermissionsSignoffRequirements[$index]"></show-signoff-requirements>
           </div>
       </div>
 

--- a/ui/app/templates/release_scheduled_change_modal.html
+++ b/ui/app/templates/release_scheduled_change_modal.html
@@ -55,6 +55,8 @@
       <p class="help-block" ng-show="errors.product">{{ errors.product.join(', ') }}</p>
     </div>
 
+    <show-signoff-requirements requirements="sc.required_signoffs"></show-signoff-requirements>
+
     <div class="form-group" ng-class="{'has-error': errors.detail}">
       <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
     </div>

--- a/ui/app/templates/release_scheduled_delete_modal.html
+++ b/ui/app/templates/release_scheduled_delete_modal.html
@@ -30,6 +30,7 @@
     </div>
     </div>
 
+    <show-signoff-requirements requirements="sc.required_signoffs"></show-signoff-requirements>
     <div class="form-group" ng-class="{'has-error': errors.exception}">
       <p class="help-block" ng-show="errors.exception">{{ errors.exception }}</p>
     </div>

--- a/ui/app/templates/releases.html
+++ b/ui/app/templates/releases.html
@@ -76,8 +76,8 @@
         <button ng-show="!rule_id" class="btn btn-danger btn-xs" ng-click="openNewScheduledDeleteModal(release)">Schedule for Deletion</button>
         <button class="btn btn-default btn-xs" ng-click="openDataModal(release)">View Data</button>
         <a ng-show="!release_name" class="btn btn-default btn-xs" download="{{ release.name | uriencode }}.json" target="_self" ng-href="/api/releases/{{ release.name | uriencode }}?pretty=1">Download</a>
-        <button ng-show="!release_name" class="btn btn-default btn-xs" ng-click="openUpdateModal(release)">Update</button>
-        <button ng-show="!release_name" class="btn btn-default btn-xs" ng-click="openDeleteModal(release)">Delete</button>
+        <button ng-show="!release_name && !release.required_signoffs.length" class="btn btn-default btn-xs" ng-click="openUpdateModal(release)">Update</button>
+        <button ng-show="!release_name && !release.required_signoffs.length" class="btn btn-default btn-xs" ng-click="openDeleteModal(release)">Delete</button>
         <a ng-show="!release_name" class="btn btn-default btn-xs" ng-href="/releases/{{ release.name }}">History</a>
         <button ng-show="!release_name && !release.read_only" class="btn btn-xs btn-success" ng-click="openReadOnlyModal(release)">Modifiable</button>
         <button ng-show="!release_name && release.read_only" class="btn btn-xs btn-danger" ng-click="openReadOnlyModal(release)">Read Only</button>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -12,7 +12,7 @@
           <label for="id_product">Product</label>
           <input type="text" class="form-control" id="id_product" ng-model="rule.product" autocomplete="off"
            typeahead="product for product in products | filter:$viewValue | limitTo:16">
-          <p class="help-block" ng-show="errors.product">{{ errors.product.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.product">{{ errors.product }}</p>
         </div>
       </div>
       <div class="col-md-6">
@@ -20,7 +20,7 @@
           <label for="id_channel">Channel</label>
           <input type="text" class="form-control" id="id_product" ng-model="rule.channel" autocomplete="off"
            typeahead="channel for channel in channels | filter:$viewValue | limitTo:16">
-          <p class="help-block" ng-show="errors.channel">{{ errors.channel.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.channel">{{ errors.channel }}</p>
         </div>
       </div>
     </div>
@@ -31,7 +31,7 @@
           <label for="id_mapping">Mapping</label>
           <input type="text" class="form-control" id="id_mapping" ng-model="rule.mapping" autocomplete="off"
            typeahead="name for name in names | filter:$viewValue | limitTo:16">
-          <p class="help-block" ng-show="errors.mapping">{{ errors.mapping.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.mapping">{{ errors.mapping }}</p>
         </div>
       </div>
       <div class="col-md-6">
@@ -39,7 +39,7 @@
           <label for="id_fallbackMapping">Fallback Mapping</label>
           <input type="text" class="form-control" id="id_mapping" ng-model="rule.fallbackMapping" autocomplete="off"
            typeahead="name for name in names | filter:$viewValue | limitTo:16">
-          <p class="help-block" ng-show="errors.fallbackMapping">{{ errors.fallbackMapping.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.fallbackMapping">{{ errors.fallbackMapping }}</p>
         </div>
       </div>
     </div>
@@ -49,13 +49,13 @@
           <label for="id_rate">Rate</label>
           <input type="text"
                  class="form-control"
-                 ng-class="{'validation_errors': errors.rate}"
+                 ng-class="{'validation_errors': errors.backgroundRate}"
                  name="rate"
                  id="id_rate"
                  ng-model="rule.backgroundRate"
                  required>
-            <p class="help-block has-error" ng-show="errors.rate">
-                {{ errors.rate }}
+            <p class="help-block has-error" ng-show="errors.backgroundRate">
+                {{ errors.backgroundRate }}
             </p>
         </div>
       </div>
@@ -78,14 +78,14 @@
         <div class="form-group" ng-class="{'has-error': errors.version}">
           <label for="id_version">Version</label>
           <input type="text" class="form-control" id="id_version" ng-model="rule.version">
-          <p class="help-block" ng-show="errors.version">{{ errors.version.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.version">{{ errors.version }}</p>
         </div>
       </div>
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.buildId}">
           <label for="id_buildID">Build ID</label>
           <input type="text" class="form-control" id="id_buildID" ng-model="rule.buildID">
-          <p class="help-block" ng-show="errors.buildID">{{ errors.buildID.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.buildID">{{ errors.buildID }}</p>
         </div>
       </div>
     </div>
@@ -94,14 +94,14 @@
         <div class="form-group" ng-class="{'has-error': errors.locale}">
           <label for="id_locale">Locale</label>
           <input type="text" class="form-control" id="id_locale" ng-model="rule.locale">
-          <p class="help-block" ng-show="errors.locale">{{ errors.locale.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.locale">{{ errors.locale }}</p>
         </div>
       </div>
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.distribution}">
           <label for="id_distribution">Distribution</label>
           <input type="text" class="form-control" id="id_distribution" ng-model="rule.distribution">
-          <p class="help-block" ng-show="errors.distribution">{{ errors.distribution.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.distribution">{{ errors.distribution }}</p>
         </div>
       </div>
     </div>
@@ -110,14 +110,14 @@
         <div class="form-group" ng-class="{'has-error': errors.buildTarget}">
           <label for="id_buildTarget">Build Target</label>
           <input type="text" class="form-control" id="id_buildTarget" ng-model="rule.buildTarget">
-          <p class="help-block" ng-show="errors.buildTarget">{{ errors.buildTarget.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.buildTarget">{{ errors.buildTarget }}</p>
         </div>
       </div>
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.osVersion}">
           <label for="id_osVersion">OS Version</label>
           <input type="text" class="form-control" id="id_osVersion" ng-model="rule.osVersion">
-          <p class="help-block" ng-show="errors.osVersion">{{ errors.osVersion.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.osVersion">{{ errors.osVersion }}</p>
         </div>
       </div>
     </div>
@@ -126,14 +126,14 @@
         <div class="form-group" ng-class="{'has-error': errors.instructionSet}">
           <label for="id_instructionSet">Instruction Set</label>
           <input type="text" class="form-control" id="id_instructionSet" ng-model="rule.instructionSet">
-          <p class="help-block" ng-show="errors.instructionSet">{{ errors.instructionSet.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.instructionSet">{{ errors.instructionSet }}</p>
         </div>
       </div>
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.memory}">
           <label for="id_memory">Memory</label>
           <input type="text" class="form-control" id="id_memory" ng-model="rule.memory">
-          <p class="help-block" ng-show="errors.memory">{{ errors.memory.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.memory">{{ errors.memory }}</p>
         </div>
       </div>
     </div>
@@ -142,14 +142,14 @@
         <div class="form-group" ng-class="{'has-error': errors.distVersion}">
           <label for="id_distVersion">Dist version</label>
           <input type="text" class="form-control" id="id_distribution" ng-model="rule.distVersion">
-          <p class="help-block" ng-show="errors.distVersion">{{ errors.distVersion.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.distVersion">{{ errors.distVersion }}</p>
         </div>
       </div>
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.update_type}">
           <label for="id_update_type">Update Type</label>
           <input type="text" class="form-control" id="id_update_type" ng-model="rule.update_type">
-          <p class="help-block" ng-show="errors.update_type">{{ errors.update_type.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.update_type">{{ errors.update_type }}</p>
         </div>
       </div>
     </div>
@@ -158,7 +158,7 @@
         <div class="form-group" ng-class="{'has-error': errors.headerArchitecture}">
           <label for="id_headerArchitecture">Header Architecture</label>
           <input type="text" class="form-control" id="id_headerArchitecture" ng-model="rule.headerArchitecture">
-          <p class="help-block" ng-show="errors.headerArchitecture">{{ errors.headerArchitecture.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.headerArchitecture">{{ errors.headerArchitecture }}</p>
         </div>
       </div>
       <div class="col-md-6">
@@ -184,7 +184,7 @@
         <div class="form-group" ng-class="{'has-error': errors.alias}">
           <label for="id_distribution">Alias</label>
           <input type="text" class="form-control" id="id_distribution" ng-model="rule.alias">
-          <p class="help-block" ng-show="errors.alias">{{ errors.alias.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.alias">{{ errors.alias }}</p>
         </div>
       </div>
     </div>
@@ -193,7 +193,7 @@
         <div class="form-group" ng-class="{'has-error': errors.comment}">
           <label for="id_comment">Comment</label>
           <input type="text" class="form-control" id="id_comment" ng-model="rule.comment">
-          <p class="help-block" ng-show="errors.comment">{{ errors.comment.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.comment">{{ errors.comment }}</p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -47,7 +47,13 @@
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.backgroundRate}">
           <label for="id_rate">Rate</label>
-          <input type="text" class="form-control" name="rate" id="id_rate" ng-model="rule.backgroundRate" required>
+          <input type="text"
+                 class="form-control"
+                 ng-class="{'digit_evaluator': digit_validation_errors.rate}"
+                 name="rate"
+                 id="id_rate"
+                 ng-model="rule.backgroundRate"
+                 required>
           <div class="form-group" ng-class="{'has-error': digit_validation_errors.rate}" ng-show="digit_validation_errors.rate">
             <p class="help-block" ng-show="digit_validation_errors.rate">{{ digit_validation_errors.rate }}</p>
           </div>
@@ -56,8 +62,14 @@
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.priority}">
           <label for="id_priority">Priority</label>
-          <input type="text" class="form-control" id="id_priority" ng-model="rule.priority">
-          <div class="form-group" ng-class="{'has-error': digit_validation_errors.priority}" ng-show="digit_validation_errors.priority">
+          <input type="text"
+                 class="form-control"
+                 id="id_priority"
+                 ng-model="rule.priority"
+                 ng-class="{'digit_evaluator': digit_validation_errors.priority}">
+          <div class="form-group"
+               ng-class="{'has-error': digit_validation_errors.priority}"
+               ng-show="digit_validation_errors.priority">
             <p class="help-block" ng-show="digit_validation_errors.priority">{{ digit_validation_errors.priority }}</p>
           </div>
         </div>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -45,31 +45,31 @@
     </div>
     <div class="row">
       <div class="col-md-6">
-        <div class="form-group" ng-class="{'has-error': errors.backgroundRate}">
+        <div class="form-group" ng-class="{'has-error': errors.backgroundRate || integer_validation_errors.backgroundRate }">
           <label for="id_rate">Rate</label>
           <input type="text"
                  class="form-control"
-                 ng-class="{'has-error': errors.backgroundRate}"
                  name="rate"
                  id="id_rate"
                  ng-model="rule.backgroundRate"
                  required>
-            <p class="help-block has-error" ng-show="errors.backgroundRate">
-                {{ errors.backgroundRate }}
+            <p class="help-block has-error" ng-show="integer_validation_errors.backgroundRate">
+                {{ integer_validation_errors.backgroundRate }}
             </p>
+            <p class="help-block" ng-show="errors.backgroundRate">{{ errors.backgroundRate.join(', ') }}</p>
         </div>
       </div>
       <div class="col-md-6">
-        <div class="form-group" ng-class="{'has-error': errors.priority}">
+        <div class="form-group" ng-class="{'has-error': errors.priority || integer_validation_errors.priority}">
           <label for="id_priority">Priority</label>
           <input type="text"
                  class="form-control"
                  id="id_priority"
-                 ng-model="rule.priority"
-                 ng-class="{'has-error': errors.priority}">
-            <p class="help-block has-error" ng-show="errors.priority">
-                {{ errors.priority }}
+                 ng-model="rule.priority">
+            <p class="help-block has-error" ng-show="integer_validation_errors.priority">
+                {{ integer_validation_errors.priority }}
             </p>
+            <p class="help-block" ng-show="errors.priority">{{ errors.priority.join(', ') }}</p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -200,6 +200,14 @@
 
     <input type="hidden" name="data_version" ng-model="rule.data_version">
   </form>
+  <show-signoff-requirements requirements="ruleSignoffsRequired"></show-signoff-requirements>
+
+  <div class="form-group" ng-class="{'has-error': errors.detail}">
+    <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
+  </div>
+  <div class="form-group" ng-class="{'has-error': errors.exception}">
+    <p class="help-block" ng-show="errors.exception">{{ errors.exception }}</p>
+  </div>
 
   <show-signoff-requirements requirements="ruleSignoffsRequired"></show-signoff-requirements>
 

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -49,13 +49,13 @@
           <label for="id_rate">Rate</label>
           <input type="text"
                  class="form-control"
-                 ng-class="{'validation_errors': digit_validation_errors.rate}"
+                 ng-class="{'validation_errors': integer_validation_errors.rate}"
                  name="rate"
                  id="id_rate"
                  ng-model="rule.backgroundRate"
                  required>
-          <div class="form-group" ng-class="{'has-error': digit_validation_errors.rate}" ng-show="digit_validation_errors.rate">
-            <p class="help-block" ng-show="digit_validation_errors.rate">{{ digit_validation_errors.rate }}</p>
+          <div class="form-group" ng-class="{'has-error': integer_validation_errors.rate}" ng-show="integer_validation_errors.rate">
+            <p class="help-block" ng-show="integer_validation_errors.rate">{{ integer_validation_errors.rate }}</p>
           </div>
         </div>
       </div>
@@ -66,11 +66,11 @@
                  class="form-control"
                  id="id_priority"
                  ng-model="rule.priority"
-                 ng-class="{'validation_errors': digit_validation_errors.priority}">
+                 ng-class="{'validation_errors': integer_validation_errors.priority}">
           <div class="form-group"
-               ng-class="{'has-error': digit_validation_errors.priority}"
-               ng-show="digit_validation_errors.priority">
-            <p class="help-block" ng-show="digit_validation_errors.priority">{{ digit_validation_errors.priority }}</p>
+               ng-class="{'has-error': integer_validation_errors.priority}"
+               ng-show="integer_validation_errors.priority">
+            <p class="help-block" ng-show="integer_validation_errors.priority">{{ integer_validation_errors.priority }}</p>
           </div>
         </div>
       </div>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -49,14 +49,14 @@
           <label for="id_rate">Rate</label>
           <input type="text"
                  class="form-control"
-                 ng-class="{'validation_errors': integer_validation_errors.rate}"
+                 ng-class="{'validation_errors': errors.rate}"
                  name="rate"
                  id="id_rate"
                  ng-model="rule.backgroundRate"
                  required>
-          <div class="form-group" ng-class="{'has-error': integer_validation_errors.rate}" ng-show="integer_validation_errors.rate">
-            <p class="help-block" ng-show="integer_validation_errors.rate">{{ integer_validation_errors.rate }}</p>
-          </div>
+            <p class="help-block has-error" ng-show="errors.rate">
+                {{ errors.rate }}
+            </p>
         </div>
       </div>
       <div class="col-md-6">
@@ -66,12 +66,10 @@
                  class="form-control"
                  id="id_priority"
                  ng-model="rule.priority"
-                 ng-class="{'validation_errors': integer_validation_errors.priority}">
-          <div class="form-group"
-               ng-class="{'has-error': integer_validation_errors.priority}"
-               ng-show="integer_validation_errors.priority">
-            <p class="help-block" ng-show="integer_validation_errors.priority">{{ integer_validation_errors.priority }}</p>
-          </div>
+                 ng-class="{'validation_errors': errors.priority}">
+            <p class="help-block has-error" ng-show="errors.priority">
+                {{ errors.priority }}
+            </p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -49,7 +49,7 @@
           <label for="id_rate">Rate</label>
           <input type="text"
                  class="form-control"
-                 ng-class="{'validation_errors': errors.backgroundRate}"
+                 ng-class="{'has-error': errors.backgroundRate}"
                  name="rate"
                  id="id_rate"
                  ng-model="rule.backgroundRate"
@@ -66,7 +66,7 @@
                  class="form-control"
                  id="id_priority"
                  ng-model="rule.priority"
-                 ng-class="{'validation_errors': errors.priority}">
+                 ng-class="{'has-error': errors.priority}">
             <p class="help-block has-error" ng-show="errors.priority">
                 {{ errors.priority }}
             </p>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -49,7 +49,7 @@
           <label for="id_rate">Rate</label>
           <input type="text"
                  class="form-control"
-                 ng-class="{'digit_evaluator': digit_validation_errors.rate}"
+                 ng-class="{'validation_errors': digit_validation_errors.rate}"
                  name="rate"
                  id="id_rate"
                  ng-model="rule.backgroundRate"
@@ -66,7 +66,7 @@
                  class="form-control"
                  id="id_priority"
                  ng-model="rule.priority"
-                 ng-class="{'digit_evaluator': digit_validation_errors.priority}">
+                 ng-class="{'validation_errors': digit_validation_errors.priority}">
           <div class="form-group"
                ng-class="{'has-error': digit_validation_errors.priority}"
                ng-show="digit_validation_errors.priority">

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -4,7 +4,7 @@
     <h3 class="modal-title" ng-show="!is_edit && is_duplicate">Duplicate Existing Rule</h3>
 </div>
 <div class="modal-body">
-  <form role="form">
+  <form role="form" name="rule_form">
     <div class="row">
 
       <div class="col-md-6">
@@ -47,15 +47,19 @@
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.backgroundRate}">
           <label for="id_rate">Rate</label>
-          <input type="text" class="form-control" id="id_rate" ng-model="rule.backgroundRate">
-          <p class="help-block" ng-show="errors.backgroundRate">{{ errors.backgroundRate.join(', ') }}</p>
+          <input type="text" class="form-control" name="rate" id="id_rate" ng-model="rule.backgroundRate" required>
+          <div class="form-group" ng-class="{'has-error': digit_validation_errors.rate}" ng-show="digit_validation_errors.rate">
+            <p class="help-block" ng-show="digit_validation_errors.rate">{{ digit_validation_errors.rate }}</p>
+          </div>
         </div>
       </div>
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.priority}">
           <label for="id_priority">Priority</label>
           <input type="text" class="form-control" id="id_priority" ng-model="rule.priority">
-          <p class="help-block" ng-show="errors.priority">{{ errors.priority.join(', ') }}</p>
+          <div class="form-group" ng-class="{'has-error': digit_validation_errors.priority}" ng-show="digit_validation_errors.priority">
+            <p class="help-block" ng-show="digit_validation_errors.priority">{{ digit_validation_errors.priority }}</p>
+          </div>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -187,6 +187,8 @@
     <input type="hidden" name="data_version" ng-model="rule.data_version">
   </form>
 
+  <show-signoff-requirements requirements="ruleSignoffsRequired"></show-signoff-requirements>
+
   <div class="form-group" ng-class="{'has-error': errors.detail}">
     <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
   </div>
@@ -197,6 +199,6 @@
 </div>
 <div class="modal-footer">
   <div ng-show="saving" small-loader></div>
-  <button class="btn btn-primary" ng-show="!saving" ng-click="saveChanges()">Save Changes</button>
+  <button class="btn btn-primary" ng-class="{'disabled': ruleSignoffsRequired.length}" ng-show="!saving" ng-click="saveChanges()">Save Changes</button>
   <button class="btn btn-default" ng-show="!saving" ng-click="cancel()">Cancel</button>
 </div>

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -105,15 +105,23 @@
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.backgroundRate}">
         <label for="id_rate">Rate</label>
-        <input type="number" class="form-control" id="id_rate" ng-model="sc.backgroundRate">
-        <p class="help-block" ng-show="errors.backgroundRate">{{ errors.backgroundRate.join(', ') }}</p>
+        <input type="number"
+               class="form-control"
+               id="id_rate"
+               ng-model="sc.backgroundRate"
+               ng-class="{'validation_errors': digit_validation_errors.rate}">
+        <p class="help-block" ng-show="digit_validation_errors.rate">{{ digit_validation_errors.rate }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.priority}">
         <label for="id_priority">Priority</label>
-        <input type="number" class="form-control" id="id_priority" ng-model="sc.priority">
-        <p class="help-block" ng-show="errors.priority">{{ errors.priority.join(', ') }}</p>
+        <input type="number"
+               class="form-control"
+               id="id_priority"
+               ng-model="sc.priority"
+               ng-class="{'validation_errors': digit_validation_errors.priority}">
+        <p class="help-block" ng-show="digit_validation_errors.priority">{{ digit_validation_errors.priority }}</p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -103,25 +103,25 @@
     </div>
     <div class="row">
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': digit_validation_errors.rate}">
+        <div class="form-group" ng-class="{'has-error': integer_validation_errors.rate}">
         <label for="id_rate">Rate</label>
         <input type="number"
                class="form-control"
                id="id_rate"
                ng-model="sc.backgroundRate"
-               ng-class="{'validation_errors': digit_validation_errors.rate}">
-        <p class="help-block" ng-show="digit_validation_errors.rate">{{ digit_validation_errors.rate }}</p>
+               ng-class="{'validation_errors': integer_validation_errors.rate}">
+        <p class="help-block" ng-show="integer_validation_errors.rate">{{ integer_validation_errors.rate }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': digit_validation_errors.priority}">
+        <div class="form-group" ng-class="{'has-error': integer_validation_errors.priority}">
         <label for="id_priority">Priority</label>
         <input type="number"
                class="form-control"
                id="id_priority"
                ng-model="sc.priority"
-               ng-class="{'validation_errors': digit_validation_errors.priority}">
-        <p class="help-block" ng-show="digit_validation_errors.priority">{{ digit_validation_errors.priority }}</p>
+               ng-class="{'validation_errors': integer_validation_errors.priority}">
+        <p class="help-block" ng-show="integer_validation_errors.priority">{{ integer_validation_errors.priority }}</p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -103,25 +103,25 @@
     </div>
     <div class="row">
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': integer_validation_errors.rate}">
+        <div class="form-group" ng-class="{'has-error': errors.rate}">
         <label for="id_rate">Rate</label>
         <input type="number"
                class="form-control"
                id="id_rate"
                ng-model="sc.backgroundRate"
-               ng-class="{'validation_errors': integer_validation_errors.rate}">
-        <p class="help-block" ng-show="integer_validation_errors.rate">{{ integer_validation_errors.rate }}</p>
+               ng-class="{'validation_errors': errors.rate}">
+        <p class="help-block" ng-show="errors.rate">{{ errors.rate }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': integer_validation_errors.priority}">
+        <div class="form-group" ng-class="{'has-error': errors.priority}">
         <label for="id_priority">Priority</label>
         <input type="number"
                class="form-control"
                id="id_priority"
                ng-model="sc.priority"
-               ng-class="{'validation_errors': integer_validation_errors.priority}">
-        <p class="help-block" ng-show="integer_validation_errors.priority">{{ integer_validation_errors.priority }}</p>
+               ng-class="{'validation_errors': errors.priority}">
+        <p class="help-block" ng-show="errors.priority">{{ errors.priority }}</p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -103,7 +103,7 @@
     </div>
     <div class="row">
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': errors.backgroundRate}">
+        <div class="form-group" ng-class="{'has-error': digit_validation_errors.rate}">
         <label for="id_rate">Rate</label>
         <input type="number"
                class="form-control"
@@ -114,7 +114,7 @@
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': errors.priority}">
+        <div class="form-group" ng-class="{'has-error': digit_validation_errors.priority}">
         <label for="id_priority">Priority</label>
         <input type="number"
                class="form-control"

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -109,7 +109,7 @@
                class="form-control"
                id="id_rate"
                ng-model="sc.backgroundRate"
-               ng-class="{'validation_errors': errors.backgroundRate}">
+               ng-class="{'has-error': errors.backgroundRate}">
         <p class="help-block" ng-show="errors.backgroundRate">{{ errors.backgroundRate }}</p>
         </div>
       </div>
@@ -120,7 +120,7 @@
                class="form-control"
                id="id_priority"
                ng-model="sc.priority"
-               ng-class="{'validation_errors': errors.priority}">
+               ng-class="{'has-error': errors.priority}">
         <p class="help-block" ng-show="errors.priority">{{ errors.priority }}</p>
         </div>
       </div>

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -242,6 +242,8 @@
       </div>
     </div>
 
+    <show-signoff-requirements requirements="scheduledChangeSignoffsRequired"></show-signoff-requirements>
+
         <div class="form-group" ng-class="{'has-error': errors.exception}">
             <p class="help-block" ng-show="errors.exception">{{ errors.exception }}</p>
         </div>

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -43,7 +43,7 @@
         <div class="form-group" ng-class="{'has-error': errors.telemetry_product}">
           <label for="id_telemetry_product">Telemetry Product</label>
           <input type="text" class="form-control" id="id_telemetry_product" ng-model="sc.telemetry_product">
-          <p class="help-block" ng-show="errors.telemetry_product">{{ errors.telemetry_product.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.telemetry_product">{{ errors.telemetry_product }}</p>
         </div>
       </div>
     </div>
@@ -52,14 +52,14 @@
         <div class="form-group" ng-class="{'has-error': errors.telemetry_channel}">
           <label for="id_telemetry_channel">Telemetry Channel</label>
           <input type="text" class="form-control" id="id_telemetry_channel" ng-model="sc.telemetry_channel">
-          <p class="help-block" ng-show="errors.telemetry_channel">{{ errors.telemetry_channel.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.telemetry_channel">{{ errors.telemetry_channel }}</p>
         </div>
       </div>
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.telemetry_uptake}">
           <label for="id_telemetry_uptake">Telemetry Uptake</label>
           <input type="text" class="form-control" id="id_telemetry_uptake" ng-model="sc.telemetry_uptake">
-          <p class="help-block" ng-show="errors.telemetry_uptake">{{ errors.telemetry_uptake.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.telemetry_uptake">{{ errors.telemetry_uptake }}</p>
         </div>
       </div>
     </div>
@@ -71,7 +71,7 @@
         <label for="id_product">Product</label>
         <input type="text" class="form-control" id="id_product" ng-model="sc.product" autocomplete="off"
         typeahead="product for product in products | filter:$viewValue | limitTo:16">
-        <p class="help-block" ng-show="errors.product">{{ errors.product.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.product">{{ errors.product }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
@@ -79,7 +79,7 @@
         <label for="id_channel">Channel</label>
         <input type="text" class="form-control" id="id_channel" ng-model="sc.channel" autocomplete="off"
         typeahead="channel for channel in channels | filter:$viewValue | limitTo:16">
-        <p class="help-block" ng-show="errors.channel">{{ errors.channel.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.channel">{{ errors.channel }}</p>
         </div>
         </div>
     </div>
@@ -89,7 +89,7 @@
         <label for="id_mapping">Mapping</label>
         <input type="text" class="form-control" id="id_mapping" ng-model="sc.mapping" autocomplete="off"
         typeahead="name for name in names | filter:$viewValue | limitTo:16">
-        <p class="help-block" ng-show="errors.mapping">{{ errors.mapping.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.mapping">{{ errors.mapping }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
@@ -97,20 +97,20 @@
         <label for="id_fallbackMapping">Fallback Mapping</label>
         <input type="text" class="form-control" id="id_fallbackMapping" ng-model="sc.fallbackMapping" autocomplete="off"
         typeahead="name for name in names | filter:$viewValue | limitTo:16">
-        <p class="help-block" ng-show="errors.fallbackMapping">{{ errors.fallbackMapping.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.fallbackMapping">{{ errors.fallbackMapping }}</p>
         </div>
       </div>
     </div>
     <div class="row">
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': errors.rate}">
+        <div class="form-group" ng-class="{'has-error': errors.backgroundRate}">
         <label for="id_rate">Rate</label>
         <input type="number"
                class="form-control"
                id="id_rate"
                ng-model="sc.backgroundRate"
-               ng-class="{'validation_errors': errors.rate}">
-        <p class="help-block" ng-show="errors.rate">{{ errors.rate }}</p>
+               ng-class="{'validation_errors': errors.backgroundRate}">
+        <p class="help-block" ng-show="errors.backgroundRate">{{ errors.backgroundRate }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
@@ -130,14 +130,14 @@
         <div class="form-group" ng-class="{'has-error': errors.version}">
         <label for="id_version">Version</label>
         <input type="text" class="form-control" id="id_version" ng-model="sc.version">
-        <p class="help-block" ng-show="errors.version">{{ errors.version.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.version">{{ errors.version }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.buildID}">
         <label for="id_buildID">Build ID</label>
         <input type="text" class="form-control" id="id_buildID" ng-model="sc.buildID">
-        <p class="help-block" ng-show="errors.buildID">{{ errors.buildID.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.buildID">{{ errors.buildID }}</p>
         </div>
       </div>
     </div>
@@ -146,14 +146,14 @@
         <div class="form-group" ng-class="{'has-error': errors.locale}">
         <label for="id_locale">Locale</label>
         <input type="text" class="form-control" id="id_locale" ng-model="sc.locale">
-        <p class="help-block" ng-show="errors.locale">{{ errors.locale.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.locale">{{ errors.locale }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.distribution}">
         <label for="id_distribution">Distribution</label>
         <input type="text" class="form-control" id="id_distribution" ng-model="sc.distribution">
-        <p class="help-block" ng-show="errors.distribution">{{ errors.distribution.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.distribution">{{ errors.distribution }}</p>
         </div>
       </div>
     </div>
@@ -162,14 +162,14 @@
         <div class="form-group" ng-class="{'has-error': errors.buildTarget}">
         <label for="id_buildTarget">Build Target</label>
         <input type="text" class="form-control" id="id_buildTarget" ng-model="sc.buildTarget">
-        <p class="help-block" ng-show="errors.buildTarget">{{ errors.buildTarget.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.buildTarget">{{ errors.buildTarget }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.osVersion}">
         <label for="id_osVersion">OS Version</label>
         <input type="text" class="form-control" id="id_osVersion" ng-model="sc.osVersion">
-        <p class="help-block" ng-show="errors.osVersion">{{ errors.osVersion.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.osVersion">{{ errors.osVersion }}</p>
         </div>
       </div>
     </div>
@@ -178,14 +178,14 @@
         <div class="form-group" ng-class="{'has-error': errors.instructionSet}">
         <label for="id_instructionSet">Instruction Set</label>
         <input type="text" class="form-control" id="id_instructionSet" ng-model="sc.instructionSet">
-        <p class="help-block" ng-show="errors.instructionSet">{{ errors.instructionSet.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.instructionSet">{{ errors.instructionSet }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.memory}">
         <label for="id_memory">Memory</label>
         <input type="text" class="form-control" id="id_memory" ng-model="sc.memory">
-        <p class="help-block" ng-show="errors.memory">{{ errors.memory.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.memory">{{ errors.memory }}</p>
         </div>
       </div>
     </div>
@@ -194,14 +194,14 @@
         <div class="form-group" ng-class="{'has-error': errors.distVersion}">
         <label for="id_distribution">Dist version</label>
         <input type="text" class="form-control" id="id_distribution" ng-model="sc.distVersion">
-        <p class="help-block" ng-show="errors.distVersion">{{ errors.distVersion.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.distVersion">{{ errors.distVersion }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.update_type}">
         <label for="id_update_type">Update Type</label>
         <input type="text" class="form-control" id="id_update_type" ng-model="sc.update_type">
-        <p class="help-block" ng-show="errors.update_type">{{ errors.update_type.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.update_type">{{ errors.update_type }}</p>
         </div>
       </div>
     </div>
@@ -210,7 +210,7 @@
         <div class="form-group" ng-class="{'has-error': errors.headerArchitecture}">
         <label for="id_headerArchitecture">Header Architecture</label>
         <input type="text" class="form-control" id="id_headerArchitecture" ng-model="sc.headerArchitecture">
-        <p class="help-block" ng-show="errors.headerArchitecture">{{ errors.headerArchitecture.join(', ') }}</p>
+        <p class="help-block" ng-show="errors.headerArchitecture">{{ errors.headerArchitecture }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
@@ -227,7 +227,7 @@
                  From https://stackoverflow.com/a/24321497 -->
             <option value="" ng-if="false"></option>
           </select>
-          <p class="help-block" ng-show="errors.mig64">{{ errors.mig64.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.mig64">{{ errors.mig64 }}</p>
         </div>
       </div>
     </div>
@@ -236,7 +236,7 @@
         <div class="form-group" ng-class="{'has-error': errors.alias}">
           <label for="id_distribution">Alias</label>
           <input type="text" class="form-control" id="id_distribution" ng-model="sc.alias">
-          <p class="help-block" ng-show="errors.alias">{{ errors.alias.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.alias">{{ errors.alias }}</p>
         </div>
       </div>
     </div>
@@ -245,7 +245,7 @@
         <div class="form-group" ng-class="{'has-error': errors.comment}">
           <label for="id_comment">Comment</label>
           <input type="text" class="form-control" id="id_comment" ng-model="sc.comment">
-          <p class="help-block" ng-show="errors.comment">{{ errors.comment.join(', ') }}</p>
+          <p class="help-block" ng-show="errors.comment">{{ errors.comment }}</p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -103,25 +103,25 @@
     </div>
     <div class="row">
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': errors.backgroundRate}">
-        <label for="id_rate">Rate</label>
-        <input type="number"
-               class="form-control"
-               id="id_rate"
-               ng-model="sc.backgroundRate"
-               ng-class="{'has-error': errors.backgroundRate}">
-        <p class="help-block" ng-show="errors.backgroundRate">{{ errors.backgroundRate }}</p>
+        <div class="form-group" ng-class="{'has-error': errors.backgroundRate || integer_validation_errors.backgroundRate }">
+            <label for="id_rate">Rate</label>
+            <input type="number"
+                   class="form-control"
+                   id="id_rate"
+                   ng-model="sc.backgroundRate">
+            <p class="help-block" ng-show="integer_validation_errors.backgroundRate">{{ integer_validation_errors.backgroundRate }}</p>
+            <p class="help-block" ng-show="errors.backgroundRate">{{ errors.backgroundRate.join(', ') }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': errors.priority}">
-        <label for="id_priority">Priority</label>
-        <input type="number"
-               class="form-control"
-               id="id_priority"
-               ng-model="sc.priority"
-               ng-class="{'has-error': errors.priority}">
-        <p class="help-block" ng-show="errors.priority">{{ errors.priority }}</p>
+        <div class="form-group" ng-class="{'has-error': errors.priority || integer_validation_errors.priority}">
+            <label for="id_priority">Priority</label>
+            <input type="number"
+                   class="form-control"
+                   id="id_priority"
+                   ng-model="sc.priority">
+            <p class="help-block" ng-show="integer_validation_errors.priority">{{ integer_validation_errors.priority }}</p>
+            <p class="help-block" ng-show="errors.priority">{{ errors.priority.join(', ') }}</p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_scheduled_delete_modal.html
+++ b/ui/app/templates/rule_scheduled_delete_modal.html
@@ -27,6 +27,7 @@
         </ul>
         <p class="help-block" ng-show="errors.when">{{ errors.when.join(', ') }}</p>
       </div>
+      <show-signoff-requirements requirements="scheduledChangeSignoffsRequired"></show-signoff-requirements>
       <div class="form-group" ng-class="{'has-error': errors.exception}">
         <p class="help-block" ng-show="errors.exception">{{ errors.exception }}</p>
       </div>

--- a/ui/app/templates/rules.html
+++ b/ui/app/templates/rules.html
@@ -89,11 +89,11 @@
                 ng-click="openNewScheduledDeleteModal(rule)">
             Schedule for Deletion
         </button>
-        <button ng-show="rule.scheduled_change === null || rule.scheduled_change.change_type !== 'insert'"
+        <button ng-show="ruleSignoffsRequired(rule).length === 0 && (rule.scheduled_change === null || rule.scheduled_change.change_type !== 'insert')"
                 class="btn btn-default btn-xs" ng-click="openUpdateModal(rule)">
             Update
         </button>
-        <button ng-show="rule.scheduled_change === null" class="btn btn-default btn-xs" ng-click="openDeleteModal(rule)">
+        <button ng-show="ruleSignoffsRequired(rule).length === 0 && rule.scheduled_change === null" class="btn btn-default btn-xs" ng-click="openDeleteModal(rule)">
             Delete
         </button>
         <button ng-show="rule.scheduled_change === null || rule.scheduled_change.change_type !== 'insert'"

--- a/ui/spec/controllers/permissions_controller_spec.js
+++ b/ui/spec/controllers/permissions_controller_spec.js
@@ -49,6 +49,8 @@ describe("controller: PermissionsController", function() {
     it("should return all rules empty", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, '{"users": []}');
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
       expect(this.scope.users).toEqual([]);
     });
@@ -56,6 +58,8 @@ describe("controller: PermissionsController", function() {
     it("should return all rules some", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, JSON.stringify(sample_users));
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
       expect(this.scope.users.length).toEqual(2);
       expect(this.scope.users).toEqual([
@@ -70,6 +74,8 @@ describe("controller: PermissionsController", function() {
     it("should return true always if no filters active", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, '{"users": []}');
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
 
       var item = {
@@ -81,6 +87,8 @@ describe("controller: PermissionsController", function() {
     it("should filter when only one search word name", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, '{"users": []}');
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
 
       var $scope = this.scope;
@@ -97,6 +105,8 @@ describe("controller: PermissionsController", function() {
     it("should notice if filters are on", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, JSON.stringify(sample_users));
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
 
       var $scope = this.scope;
@@ -111,6 +121,8 @@ describe("controller: PermissionsController", function() {
     it("should be possible to open the add modal", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, JSON.stringify(sample_users));
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.expectGET('/api/users/roles')
       .respond(200, JSON.stringify(sample_all_roles));
       this.scope.openNewModal();
@@ -119,6 +131,8 @@ describe("controller: PermissionsController", function() {
     it("should be possible to open the edit modal", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, JSON.stringify(sample_users));
+      this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+      .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.expectGET('/api/users/peterbe/permissions')
       .respond(200, JSON.stringify(sample_permissions));
       this.$httpBackend.expectGET('/api/users/peterbe/roles')
@@ -175,6 +189,8 @@ describe("controller: PermissionsController by username", function() {
         expect($route.current).toBeUndefined();
         this.$httpBackend.expectGET('/api/users/peterbe/permissions')
         .respond(200, JSON.stringify(sample_permissions));
+        this.$httpBackend.expectGET('/api/required_signoffs/permissions')
+        .respond(200, '{"required_signoffs": []}');
 
         $location.path('/permissions/peterbe');
         $rootScope.$digest();

--- a/ui/spec/controllers/releases_controller_spec.js
+++ b/ui/spec/controllers/releases_controller_spec.js
@@ -35,19 +35,22 @@ var sample_releases = {
       "data_version": 2,
       "product": "B2G",
       "version": "34.0a2",
-      "name": "B2G-mozilla-aurora-kitkat-nightly-20140923151000"
+      "name": "B2G-mozilla-aurora-kitkat-nightly-20140923151000",
+      "required_signoffs": {},
     },
     {
       "data_version": 2,
       "product": "B2G",
       "version": "34.0a2",
-      "name": "B2G-mozilla-aurora-kitkat-nightly-20140923160203"
+      "name": "B2G-mozilla-aurora-kitkat-nightly-20140923160203",
+      "required_signoffs": {},
     },
     {
       "data_version": 4,
       "product": "Fennec",
       "version": "30.0a2",
-      "name": "Fennec-mozilla-aurora-nightly-20140410004003"
+      "name": "Fennec-mozilla-aurora-nightly-20140410004003",
+      "required_signoffs": {},
     }
   ],
   "count": 3
@@ -91,7 +94,11 @@ describe("controller: ReleasesController", function() {
       .respond(200, JSON.stringify(sample_releases));
       this.$httpBackend.flush();
       expect(this.scope.releases.length).toEqual(3);
-      expect(this.scope.releases).toEqual(sample_releases.releases);
+      var transformedReleases = angular.copy(sample_releases.releases);
+      transformedReleases.forEach(function(release) {
+        release.required_signoffs = {length: 0, roles: {}};
+      });
+      expect(this.scope.releases).toEqual(transformedReleases);
     });
 
   });
@@ -241,7 +248,6 @@ describe("controller: ReleasesController", function() {
       .respond(200, JSON.stringify(sample_releases));
       this.scope.openRevertModal(sample_revisions.revisions[0]);
     });
-
   });
 
 });

--- a/ui/spec/controllers/rule_scheduled_changes_controller_spec.js
+++ b/ui/spec/controllers/rule_scheduled_changes_controller_spec.js
@@ -131,6 +131,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should find all scheduled changes", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -143,6 +145,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should filter active scheduled changes correctly", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -156,6 +160,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should filter completed scheduled changes correctly", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -171,6 +177,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should be possible to open the add modal", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -187,6 +195,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should be possible to open the update modal for time based change", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -203,6 +213,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should be possible to open the update modal for telemetry change", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();
@@ -219,6 +231,8 @@ describe("controller: RuleScheduledChangesController", function() {
     it("should be possible to open the delete modal", function() {
       this.$httpBackend.expectGET("/api/users/current")
       .respond(200, JSON.stringify(current_user));
+      this.$httpBackend.expectGET("/api/required_signoffs/product")
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET("/api/scheduled_changes/rules?all=1")
       .respond(200, JSON.stringify(sample_sc));
       this.$httpBackend.flush();

--- a/ui/spec/controllers/rules_controller_spec.js
+++ b/ui/spec/controllers/rules_controller_spec.js
@@ -87,6 +87,8 @@ describe("controller: RulesController", function() {
       .respond(200, '{"scheduled_changes": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/product')
       .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
+      this.$httpBackend.expectGET('/api/required_signoffs/product')
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/channel')
       .respond(200, JSON.stringify({channel: ['Channel1', 'Channel2'], count: 2}));
       this.$httpBackend.flush();
@@ -102,6 +104,8 @@ describe("controller: RulesController", function() {
       .respond(200, '{"scheduled_changes": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/product')
       .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
+      this.$httpBackend.expectGET('/api/required_signoffs/product')
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/channel')
       .respond(200, JSON.stringify({channel: ['Channel1', 'Channel2'], count: 2}));
       this.$httpBackend.flush();
@@ -121,6 +125,8 @@ describe("controller: RulesController", function() {
       .respond(200, '{"scheduled_changes": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/product')
       .respond(200, JSON.stringify({product: ['Product1', 'Product2'], count: 2}));
+      this.$httpBackend.expectGET('/api/required_signoffs/product')
+      .respond(200, '{"required_signoffs": [], "count": 0}');
       this.$httpBackend.expectGET('/api/rules/columns/channel')
       .respond(200, JSON.stringify({channel: ['Channel1', 'Channel2'], count: 2}));
       this.$httpBackend.flush();

--- a/ui/spec/controllers/user_edit_controller_spec.js
+++ b/ui/spec/controllers/user_edit_controller_spec.js
@@ -22,6 +22,7 @@ describe("controller: UserPermissionsCtrl", function() {
       {'role':'releng', 'data_version':1}
     ]};
   var sample_all_roles = {'roles': ['qa', 'releng']};
+  var signoffRequirements = [];
 
   beforeEach(inject(function($controller, $rootScope, $location, $modal, Permissions, $httpBackend) {
     this.$location = $location;
@@ -39,6 +40,7 @@ describe("controller: UserPermissionsCtrl", function() {
       user: user,
       is_edit: true,
       users: [user],
+      permissionSignoffRequirements: signoffRequirements,
     });
   }));
 

--- a/ui/spec/services/permissions_service_spec.js
+++ b/ui/spec/services/permissions_service_spec.js
@@ -102,4 +102,47 @@ describe("Service: Permissions", function() {
     this.$httpBackend.flush();
   }));
 
+  it("should respect both old and new permissions", inject(function(Permissions) {
+    var signoffRequirements = [
+      {product: "Firefox", role: "releng", signoffs_required: 2},
+      {product: "Fennec", role: "relman", signoffs_required: 4},
+    ];
+    var oldPerm = {options: {products: ["Firefox"]}, permission: "release_locale"};
+    var newPerm = {options: {products: ["Fennec"]}, permission: "release_locale"};
+    var signoffsRequired = Permissions.permissionSignoffsRequired(oldPerm, newPerm, signoffRequirements);
+    expect(signoffsRequired.length).toBe(2);
+    expect(signoffsRequired.roles['releng']).toBe(2);
+    expect(signoffsRequired.roles['relman']).toBe(4);
+  }));
+
+  it("should not require signoffs for unrelated product", inject(function(Permissions) {
+    var signoffRequirements = [
+      {product: "Firefox", role: "releng", signoffs_required: 2},
+    ];
+    var oldPerm = {options: {products: ["Thunderbird"]}, permission: "release_locale"};
+    var newPerm = {options: {products: ["Thunderbird", "Fennec"]}, permission: "release_locale"};
+    var signoffsRequired = Permissions.permissionSignoffsRequired(oldPerm, newPerm, signoffRequirements);
+    expect(signoffsRequired.length).toBe(0);
+  }));
+
+  it("should require signoffs for adding unrelated product", inject(function(Permissions) {
+    var signoffRequirements = [
+      {product: "Firefox", role: "releng", signoffs_required: 2},
+    ];
+    var oldPerm = {options: {products: ["Firefox"]}, permission: "release_locale"};
+    var newPerm = {options: {products: ["Firefox", "Fennec"]}, permission: "release_locale"};
+    var signoffsRequired = Permissions.permissionSignoffsRequired(oldPerm, newPerm, signoffRequirements);
+    expect(signoffsRequired.length).toBe(1);
+    expect(signoffsRequired.roles['releng']).toBe(2);
+  }));
+
+  it("should match if no product is present in perm", inject(function(Permissions) {
+    var signoffRequirements = [
+      {product: "Firefox", role: "releng", signoffs_required: 2},
+    ];
+    var perm = {permission: "release_locale"};
+    var signoffsRequired = Permissions.permissionSignoffsRequired(undefined, perm, signoffRequirements);
+    expect(signoffsRequired.length).toBe(1);
+    expect(signoffsRequired.roles['releng']).toBe(2);
+  }));
 });


### PR DESCRIPTION
#### What does this PR do?
This PR is to resolve [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1365658)
To supplement the backend validation hack that had been implemented earlier with front-end validation for Priority and Background Rate input fields with specific validation errors.
#### Description of Task to be completed?
Implement integer and range validation for Priority and Background rate inputs on the UI.
#### How should this be manually tested?
1. Once balrog is running on http://127.0.0.1:8080 navigate to `Rules` and click on `Add a New Rule` or `Update` on an existing rule. 
2. Test by inputting invalid data for `Rate`- either negative numbers(eg `-40`), over 100(eg 144) or non-digit characters(eg 'x', or '&').
3. Also, input invalid data for `Priority` - either negative numbers or non-digit characters. 
4. An error label will appear below the respective input with a relevant error message when the user clicks on the save changes button.
5. Repeat 2 - 3 after navigating to 'Rules/Scheduled Changes' and 'Rules/Scheduled Changes/Update'. 
 
#### What are the relevant bugzilla stories?
https://bugzilla.mozilla.org/show_bug.cgi?id=1365658
#### Screenshots (if appropriate)
<img width="1064" alt="screen shot 2017-10-03 at 14 35 00" src="https://user-images.githubusercontent.com/28535137/31123318-18e53bec-a848-11e7-8668-c14fcce2caf4.png">

