### PR TITLE
Bug 1335196: Role-centric view on Permissions page

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -2296,20 +2296,15 @@ class Permissions(AUSTable):
 
     def getAllUsers(self, transaction=None):
         res_users = self.select(columns=[self.username], distinct=True, transaction=transaction)
-        users_list = list(set([r['username'] for r in res_users]))
-        users = []
+        users_list = list([r['username'] for r in res_users])
+        users = {}
         for user in users_list:
             res_roles = self.user_roles.select(where=[
                 self.user_roles.username == user],
-                columns=[self.user_roles.role],
+                columns=[self.user_roles.role, self.user_roles.data_version],
                 transaction=transaction)
-            roles_list = list([r['role'] for r in res_roles])
-            roles = {}
-            roles["roles"] = roles_list
-            user_roles = {}
-            user_roles[user] = roles
-            users.append(user_roles)
-        return sorted(users)
+            users[user] = {"roles": res_roles}
+        return users
 
     def getAllPermissions(self, transaction=None):
         ret = defaultdict(dict)

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -2295,10 +2295,21 @@ class Permissions(AUSTable):
                 raise ValueError('Unknown option "%s" for permission "%s"' % (opt, permission))
 
     def getAllUsers(self, transaction=None):
-        res_permissions = self.select(columns=[self.username], distinct=True, transaction=transaction)
-        res_roles = self.user_roles.select(columns=[self.user_roles.username], transaction=transaction)
-        res = res_roles + res_permissions
-        return list(set([r['username'] for r in res]))
+        res_users = self.select(columns=[self.username], distinct=True, transaction=transaction)
+        users_list = list(set([r['username'] for r in res_users]))
+        users = []
+        for user in users_list:
+            res_roles = self.user_roles.select(where=[
+                self.user_roles.username == user],
+                columns=[self.user_roles.role],
+                transaction=transaction)
+            roles_list = list([r['role'] for r in res_roles])
+            roles = {}
+            roles["roles"] = roles_list
+            user_roles = {}
+            user_roles[user] = roles
+            users.append(user_roles)
+        return sorted(users)
 
     def getAllPermissions(self, transaction=None):
         ret = defaultdict(dict)
@@ -2422,10 +2433,6 @@ class Permissions(AUSTable):
                                      columns=[self.user_roles.role, self.user_roles.data_version],
                                      distinct=True, transaction=transaction)
         return [{"role": r["role"], "data_version": r["data_version"]} for r in res]
-
-    def getAllRoles(self, transaction=None):
-        res = self.user_roles.select(columns=[self.user_roles.role], distinct=True, transaction=transaction)
-        return [r["role"] for r in res]
 
     def isAdmin(self, username, transaction=None):
         return bool(self.getPermission(username, "admin", transaction))

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -397,14 +397,15 @@ class AUSTable(object):
         if self.versioned:
             data['data_version'] = 1
         query = self._insertStatement(**data)
-
-        if self.onInsert:
-            self.onInsert(self, "INSERT", changed_by, query, trans)
-
         ret = trans.execute(query)
         if self.history:
             for q in self.history.forInsert(ret.inserted_primary_key, data, changed_by):
                 trans.execute(q)
+        if self.onInsert:
+            pk_columns = self.t.primary_key.columns.keys()
+            pk_values = ret.inserted_primary_key
+            pk_args = dict(zip(pk_columns, pk_values))
+            self.onInsert(self, "INSERT", changed_by, query, trans, **pk_args)
         return ret
 
     def insert(self, changed_by=None, transaction=None, dryrun=False, **columns):
@@ -2533,7 +2534,7 @@ def send_email(relayhost, port, username, password, to_addr, from_addr, table, s
 
 
 def make_change_notifier(relayhost, port, username, password, to_addr, from_addr, use_tls):
-    def bleet(table, type_, changed_by, query, transaction):
+    def bleet(table, type_, changed_by, query, transaction, **pk_args):
         body = ["Changed by: %s" % changed_by]
         if type_ == "UPDATE":
             body.append("Row(s) to be updated as follows:")
@@ -2558,6 +2559,7 @@ def make_change_notifier(relayhost, port, username, password, to_addr, from_addr
                 body.append(UTF8PrettyPrinter().pformat(row))
         elif type_ == "INSERT":
             body.append("Row to be inserted:")
+            query.parameters.update(pk_args)
             body.append(UTF8PrettyPrinter().pformat(query.parameters))
 
         subj = "%s to %s detected %s" % (type_, table.t.name, generate_random_string(6))

--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -11,8 +11,19 @@ class TestUsersAPI_JSON(ViewTest):
         ret = self._get('/users')
         self.assertEqual(ret.status_code, 200)
         data = json.loads(ret.data)
-        data['users'] = set(data['users'])
-        self.assertEqual(data, dict(users=set(['bill', 'billy', 'bob', 'ashanti', 'mary', 'julie'])))
+        self.assertEqual(data, (
+            {'users': [{
+                'ashanti': {'roles': []}},
+                {
+                'bill': {'roles': ['qa', 'releng']}},
+                {
+                'billy': {'roles': []}},
+                {
+                'bob': {'roles': ['relman']}},
+                {
+                'julie': {'roles': ['releng']}},
+                {
+                'mary': {'roles': ['relman']}}]}))
 
 
 class TestCurrentUserAPI_JSON(ViewTest):
@@ -847,23 +858,6 @@ class TestPermissionsScheduledChanges(ViewTest):
 
 
 class TestUserRolesAPI_JSON(ViewTest):
-
-    def testGetRoles(self):
-        ret = self._get("/users/bill/roles")
-        self.assertStatusCode(ret, 200)
-        got = json.loads(ret.data)["roles"]
-        self.assertEquals(got, [{"role": "qa", "data_version": 1},
-                          {"role": "releng", "data_version": 1}])
-
-    def testGetAllRoles(self):
-        ret = self._get("/users/roles")
-        self.assertStatusCode(ret, 200)
-        got = json.loads(ret.data)["roles"]
-        self.assertEqual(got, ['releng', 'qa', 'relman'])
-
-    def testGetRolesMissingUserReturnsEmptyList(self):
-        ret = self.client.get("/users/dean/roles")
-        self.assertStatusCode(ret, 200)
 
     def testGrantRole(self):
         ret = self._put("/users/ashanti/roles/dev")

--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -11,19 +11,15 @@ class TestUsersAPI_JSON(ViewTest):
         ret = self._get('/users')
         self.assertEqual(ret.status_code, 200)
         data = json.loads(ret.data)
-        self.assertEqual(data, (
-            {'users': [{
-                'ashanti': {'roles': []}},
-                {
-                'bill': {'roles': ['qa', 'releng']}},
-                {
-                'billy': {'roles': []}},
-                {
-                'bob': {'roles': ['relman']}},
-                {
-                'julie': {'roles': ['releng']}},
-                {
-                'mary': {'roles': ['relman']}}]}))
+        self.assertEqual(data, ({
+            'ashanti': {'roles': []},
+            'bill': {'roles': [
+                {'role': 'qa', 'data_version': 1},
+                {'role': 'releng', 'data_version': 1}]},
+            'billy': {'roles': []},
+            'bob': {'roles': [{'role': 'relman', 'data_version': 1}]},
+            'julie': {'roles': [{'role': 'releng', 'data_version': 1}]},
+            'mary': {'roles': [{'role': 'relman', 'data_version': 1}]}}))
 
 
 class TestCurrentUserAPI_JSON(ViewTest):

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -4398,13 +4398,21 @@ class TestPermissions(unittest.TestCase, MemoryDatabaseMixin):
                                 self.permissions.revokeRole, "bob", "dev", "bill", old_data_version=1)
 
     def testGetAllUsers(self):
-        self.assertEquals(set(self.permissions.getAllUsers()), set(["bill",
-                                                                    "bob",
-                                                                    "cathy",
-                                                                    "fred",
-                                                                    "george",
-                                                                    "janet",
-                                                                    "sean"]))
+        self.assertEquals(self.permissions.getAllUsers(), (
+            [{
+                'bill': {'roles': []}},
+                {
+                'bob': {'roles': ['dev', 'releng']}},
+                {
+                'cathy': {'roles': ['releng']}},
+                {
+                'fred': {'roles': []}},
+                {
+                'george': {'roles': []}},
+                {
+                'janet': {'roles': ['releng']}},
+                {
+                'sean': {'roles': []}}]))
 
     def testCountAllUsers(self):
         self.assertEquals(self.permissions.countAllUsers(), 7)

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -4398,21 +4398,16 @@ class TestPermissions(unittest.TestCase, MemoryDatabaseMixin):
                                 self.permissions.revokeRole, "bob", "dev", "bill", old_data_version=1)
 
     def testGetAllUsers(self):
-        self.assertEquals(self.permissions.getAllUsers(), (
-            [{
-                'bill': {'roles': []}},
-                {
-                'bob': {'roles': ['dev', 'releng']}},
-                {
-                'cathy': {'roles': ['releng']}},
-                {
-                'fred': {'roles': []}},
-                {
-                'george': {'roles': []}},
-                {
-                'janet': {'roles': ['releng']}},
-                {
-                'sean': {'roles': []}}]))
+        self.assertEquals(self.permissions.getAllUsers(), ({
+            'bill': {'roles': []},
+            'bob': {'roles': [
+                {'data_version': 1, 'role': 'dev'},
+                {'data_version': 1, 'role': 'releng'}]},
+            'cathy': {'roles': [{'data_version': 1, 'role': 'releng'}]},
+            'fred': {'roles': []},
+            'george': {'roles': []},
+            'janet': {'roles': [{'data_version': 1, 'role': 'releng'}]},
+            'sean': {'roles': []}}))
 
     def testCountAllUsers(self):
         self.assertEquals(self.permissions.countAllUsers(), 7)

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -1189,7 +1189,7 @@ paths:
         description: "Returns all of Users in Balrog's DB."
       responses:
         '200':
-          description: Get all users inclusive of their roles
+          description: Get all Users and their Roles
           schema:
             type: object
             properties:
@@ -1201,16 +1201,18 @@ paths:
                 items:
                   type: object
                 example: {
-                  "balrogadmin": [
-                    {
-                      "data_version": 1,
-                      "role": "releng"
-                    },
-                    {
-                      "data_version": 1,
-                      "role": "relman"
-                    }]
-                         }
+                  "balrogadmin": {
+                    "roles":[
+                      {
+                        "data_version": 1,
+                        "role": "releng"
+                      },
+                      {
+                        "data_version": 1,
+                        "role": "relman"
+                      }]
+                  }
+                }
 
 
   /users/{username}:

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -1189,7 +1189,7 @@ paths:
         description: "Returns all of Users in Balrog's DB."
       responses:
         '200':
-          description: Get all Users
+          description: Get all users inclusive of their roles
           schema:
             type: object
             properties:
@@ -1199,37 +1199,19 @@ paths:
                 uniqueItems: true
                 minItems: 0
                 items:
-                  type: string
-                example: ["balrogadmin"]
+                  type: object
+                example: {
+                  "balrogadmin": [
+                    {
+                      "data_version": 1,
+                      "role": "releng"
+                    },
+                    {
+                      "data_version": 1,
+                      "role": "relman"
+                    }]
+                         }
 
-  /users/roles:
-    get:
-      summary: Returns all distinct user roles
-      description: >
-        Returns all unique roles defined for all users. [Docs](http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#users-username-roles).
-      tags:
-        - Users
-      operationId: auslib.web.admin.views.mapper.all_users_roles_get
-      consumes: []
-      produces:
-        - application/json
-      externalDocs:
-        url: "http://mozilla-balrog.readthedocs.io/en/latest/database.html#user-roles"
-        description: Returns all distinct user roles
-      responses:
-        '200':
-          description: Successfully fetched all user roles.
-          schema:
-            type: object
-            properties:
-              roles:
-                description: list of roles
-                type: array
-                uniqueItems: true
-                minItems: 0
-                items:
-                  type: string
-                example: ["releng", "qa"]
 
   /users/{username}:
     get:
@@ -1291,6 +1273,7 @@ paths:
         '403':
           $ref: '#/responses/unauthorizedUser'
 
+
   /users/{username}/permissions:
     get:
       summary: Returns all of the details about the user
@@ -1319,40 +1302,6 @@ paths:
                 options:
                   actions: ['create', 'modify']
 
-  /users/{username}/roles:
-    get:
-      summary: Returns list of user roles
-      description: >
-        Returns list of user roles as a json object. [Docs](http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#users-username-roles).
-      tags:
-        - Users
-      operationId: auslib.web.admin.views.mapper.user_get_roles
-      consumes: []
-      produces:
-        - application/json
-      externalDocs:
-        url: "http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#id26"
-        description: Returns list of user roles
-      parameters:
-        - $ref: '#/parameters/usernameParam'
-      responses:
-        '200':
-          description: Successfully fetched the list of user roles.
-          schema:
-            type: object
-            properties:
-              roles:
-                description: list of roles
-                type: array
-                uniqueItems: true
-                minItems: 0
-                items:
-                  allOf:
-                    - $ref: '#/definitions/DataVersionModel'
-                    - $ref: '#/definitions/RoleModel'
-                  required:
-                    - data_version
-                    - role
 
   /users/{username}/roles/{role}:
     put:

--- a/auslib/web/admin/views/mapper.py
+++ b/auslib/web/admin/views/mapper.py
@@ -4,8 +4,8 @@ from auslib.web.admin.views.rules import RulesAPIView, SingleRuleView, SingleRul
     RuleHistoryAPIView, RuleScheduledChangesView, EnactRuleScheduledChangeView, RuleScheduledChangeSignoffsView, \
     RuleScheduledChangeView, RuleScheduledChangeHistoryView
 
-from auslib.web.admin.views.permissions import UsersView, AllRolesView, SpecificUserView,\
-    PermissionsView, UserRolesView, UserRoleView, SpecificPermissionView, PermissionScheduledChangesView, \
+from auslib.web.admin.views.permissions import UsersView, SpecificUserView,\
+    PermissionsView, UserRoleView, SpecificPermissionView, PermissionScheduledChangesView, \
     EnactPermissionScheduledChangeView, PermissionScheduledChangeSignoffsView, PermissionScheduledChangeView, \
     PermissionScheduledChangeHistoryView
 
@@ -63,11 +63,6 @@ def users_get():
     return UsersView().get()
 
 
-def all_users_roles_get():
-    """GET /users/roles"""
-    return AllRolesView().get()
-
-
 def specific_user_get(username):
     """GET /users/:username"""
     return SpecificUserView().get(username)
@@ -76,11 +71,6 @@ def specific_user_get(username):
 def user_permissions_get(username):
     """GET /users/:username/permissions"""
     return PermissionsView().get(username)
-
-
-def user_get_roles(username):
-    """GET /users/:username/roles"""
-    return UserRolesView().get(username)
 
 
 def user_role_put(username, role):

--- a/auslib/web/admin/views/permissions.py
+++ b/auslib/web/admin/views/permissions.py
@@ -19,7 +19,8 @@ class UsersView(AdminView):
         self.log.debug("Found users: %s", users)
         # We don't return a plain jsonify'ed list here because of:
         # http://flask.pocoo.org/docs/security/#json-security
-        return jsonify(dict(users=users))
+        # return jsonify(dict(users=users))
+        return jsonify(users)
 
 
 class SpecificUserView(AdminView):

--- a/auslib/web/admin/views/permissions.py
+++ b/auslib/web/admin/views/permissions.py
@@ -261,22 +261,6 @@ class PermissionScheduledChangeHistoryView(ScheduledChangeHistoryView):
         return super(PermissionScheduledChangeHistoryView, self)._post(sc_id, transaction, changed_by)
 
 
-class UserRolesView(AdminView):
-    """/users/:username/roles"""
-
-    def get(self, username):
-        roles = dbo.permissions.getUserRoles(username)
-        return jsonify({"roles": roles})
-
-
-class AllRolesView(AdminView):
-    """/users/roles"""
-
-    def get(self):
-        roles = dbo.permissions.getAllRoles()
-        return jsonify({"roles": roles})
-
-
 class UserRoleView(AdminView):
     """/users/:username/roles/:role"""
 

--- a/ui/app/css/style.less
+++ b/ui/app/css/style.less
@@ -26,7 +26,14 @@ button {
   background-color: #fff !important;
 }
 
-.btn-asap{
+.btn-asap {
     background-image: linear-gradient(-180deg, #fafbfc 0%, #eff3f6 90%);
     z-index: 1 !important;
+}
+.role-dropdown {
+  margin-top: 30px;
+  margin-left: 80px;
+}
+#role-select-box{
+  width: 30%;
 }

--- a/ui/app/js/controllers/permissions_controller.js
+++ b/ui/app/js/controllers/permissions_controller.js
@@ -20,11 +20,11 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
     Permissions.getUsers()
       .success(function (response) {
         var users = [];
-        response.users.forEach(function (eachUser) {
-          var user = Object.keys(eachUser)[0];
+        var user = Object.keys(response);
+        user.forEach(function(eachUser){
           var eachElement = {};
-          eachElement['username'] = user;
-          eachElement['roles'] = eachUser[user].roles;
+          eachElement['roles'] = response[eachUser].roles;
+          eachElement['username'] = eachUser;
           users.push(eachElement);
         });
         $scope.users = users;
@@ -49,8 +49,8 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
     var roles = [];
     $scope.users.forEach(function (eachUser){
       eachUser.roles.forEach(function(role){
-        if(roles.indexOf(role)=== -1){
-            roles.push(role);
+        if(roles.indexOf(role.role)=== -1){
+            roles.push(role.role);
         }
       });
     });
@@ -60,7 +60,9 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
 
   $scope.filterUserByRole = function (role) {
     return function (user) {
-      return user.roles.indexOf(role) >= 0;
+      return user.roles.some(function(each){
+        return each.role === role;
+      });
     };
   };
 
@@ -208,9 +210,3 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
   };
 
 });
-
-
-
-
-
-

--- a/ui/app/js/controllers/permissions_controller.js
+++ b/ui/app/js/controllers/permissions_controller.js
@@ -6,35 +6,68 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
   $scope.loading = true;
   $scope.failed = false;
   $scope.username = $routeParams.username;
+  $scope.users = [];
+  $scope.tab = 1;
+
+
   if ($scope.username) {
     // history of a specific rule
     Permissions.getUserPermissions($scope.username)
-    .then(function(response) {
-      $scope.permissions = response;
-    });
+      .then(function (response) {
+        $scope.permissions = response;
+      });
   } else {
     Permissions.getUsers()
-    .success(function(response) {
-      $scope.users = _.map(response.users, function (each) {
-        return {username: each};
+      .success(function (response) {
+        var users = [];
+        response.users.forEach(function (eachUser) {
+          var user = Object.keys(eachUser)[0];
+          var eachElement = {};
+          eachElement['username'] = user;
+          eachElement['roles'] = eachUser[user].roles;
+          users.push(eachElement);
+        });
+        $scope.users = users;
+      })
+      .error(function () {
+        console.error(arguments);
+        $scope.failed = true;
+      })
+      .finally(function () {
+        $scope.loading = false;
+
       });
-      $scope.permissions_count = $scope.users.length;
-      $scope.page_size_pair = [{id: 20, name: '20'},
-        {id: 50, name: '50'}, 
-        {id: $scope.permissions_count, name: 'All'}];
-    })
-    .error(function() {
-      console.error(arguments);
-      $scope.failed = true;
-    })
-    .finally(function() {
-      $scope.loading = false;
-    });
+
+    $scope.permissions_count = $scope.users.length;
+    $scope.page_size_pair = [{ id: 20, name: '20' },
+    { id: 50, name: '50' },
+    { id: $scope.permissions_count, name: 'All' }];
+
   }
+
+  $scope.roles = function(){
+    var roles = [];
+    $scope.users.forEach(function (eachUser){
+      eachUser.roles.forEach(function(role){
+        if(roles.indexOf(role)=== -1){
+            roles.push(role);
+        }
+      });
+    });
+    return roles;
+  };
+
+
+  $scope.filterUserByRole = function (role) {
+    return function (user) {
+      return user.roles.indexOf(role) >= 0;
+    };
+  };
+
 
   $scope.signoffRequirements = [];
   PermissionsRequiredSignoffs.getRequiredSignoffs()
-    .then(function(payload) {
+    .then(function (payload) {
       $scope.signoffRequirements = payload.data.required_signoffs;
     });
 
@@ -49,11 +82,11 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
     search: $location.hash(),
   };
 
-  $scope.hasFilter = function() {
+  $scope.hasFilter = function () {
     return !!(false || $scope.filters.search.length);
   };
 
-  $scope.$watchCollection('filters.search', function(value) {
+  $scope.$watchCollection('filters.search', function (value) {
     $location.hash(value);
     Search.noticeSearchChange(
       value,
@@ -66,18 +99,20 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
   $scope.highlightSearch = Search.highlightSearch;
   // $scope.removeFilterSearchWord = Search.removeFilterSearchWord;
 
-  $scope.filterBySearch = function(item) {
+  $scope.filterBySearch = function (item) {
     // basically, look for a reason to NOT include this
     if (Search.word_regexes.length) {
       // every word in the word_regexes array needs to have some match
       var matches = 0;
-      _.each(Search.word_regexes, function(each) {
+      _.each(Search.word_regexes, function (each) {
         var regex = each[0];
         var on = each[1];
         // console.log(regex, on);
-        if ((on === '*' || on === 'username') && item.username && item.username.match(regex)) {
-          matches++;
-          return;
+        if ('username' in item) {
+          if ((on === '*' || on === 'username') && item.username && item.username.match(regex)) {
+            matches++;
+            return;
+          }
         }
       });
       return matches === Search.word_regexes.length;
@@ -87,7 +122,7 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
   };
   /* End filtering */
 
-  $scope.openUpdateModal = function(user) {
+  $scope.openUpdateModal = function (user) {
     $scope.is_edit = true;
     var modalInstance = $modal.open({
       templateUrl: 'permissions_modal.html',
@@ -104,15 +139,18 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
         user: function () {
           return user;
         },
-        permissionSignoffRequirements: function() {
+        permissionSignoffRequirements: function () {
           return $scope.signoffRequirements;
         },
+        roles: function() {
+          return $scope.roles();
+        }
       }
     });
   };
   /* End openUpdateModal */
 
-  $scope.openNewModal = function() {
+  $scope.openNewModal = function () {
     $scope.is_edit = false;
     var modalInstance = $modal.open({
       templateUrl: 'permissions_modal.html',
@@ -129,17 +167,20 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
         user: function () {
           return $scope.user;
         },
-        permissionSignoffRequirements: function() {
+        permissionSignoffRequirements: function () {
           return $scope.signoffRequirements;
         },
+        roles: function() {
+          return $scope.roles();
+        }
       }
     });
   };
-    /* End openNewModal */
+  /* End openNewModal */
 
 
 
-  $scope.openNewScheduledPermissionChangeModal = function(user) {
+  $scope.openNewScheduledPermissionChangeModal = function (user) {
 
     var modalInstance = $modal.open({
       templateUrl: 'permissions_scheduled_change_modal.html',
@@ -147,15 +188,15 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
       size: 'lg',
       backdrop: 'static',
       resolve: {
-        scheduled_changes: function() {
+        scheduled_changes: function () {
           return [];
         },
-        sc: function() {
+        sc: function () {
           sc = angular.copy(user);
           sc["change_type"] = "insert";
           return sc;
         },
-        permissionSignoffRequirements: function() {
+        permissionSignoffRequirements: function () {
           return $scope.signoffRequirements;
         },
       }
@@ -166,6 +207,10 @@ function($scope, $routeParams, $location, $timeout, Permissions, Search, $modal,
     Helpers.selectPageSize($scope, 'permissions_page_size');
   };
 
-
-
 });
+
+
+
+
+
+

--- a/ui/app/js/controllers/user_edit_controller.js
+++ b/ui/app/js/controllers/user_edit_controller.js
@@ -18,31 +18,28 @@ function ($scope, $modalInstance, CSRF, Permissions, users, roles, is_edit, user
     permissions: {}
   };
 
-  if($scope.is_edit){
+  if ($scope.is_edit) {
     $scope.original_user = user;
     $scope.user = angular.copy(user);
 
     $scope.user.permissions = [];
     Permissions.getUserPermissions($scope.user.username)
-    .then(function(permissions) {
-      _.forEach(permissions, function(p) {
-        if (p.options) {
-          p.options_as_json = JSON.stringify(p['options']);
-        }
+      .then(function (permissions) {
+        _.forEach(permissions, function (p) {
+          if (p.options) {
+            p.options_as_json = JSON.stringify(p['options']);
+          }
+        });
+        $scope.originalPermissions = angular.copy(permissions);
+        $scope.user.permissions = permissions;
       });
-      $scope.originalPermissions = angular.copy(permissions);
-      $scope.user.permissions = permissions;
-    });
 
-    $scope.getUserRoles = function (username){
-      $scope.users.forEach(function(eachUser){
-        if(eachUser.username === username){
-          $scope.user.roles = eachUser.roles;
-        }
-      });
-      $scope.loading = false;
-    };
-    $scope.getUserRoles($scope.user.username);
+    $scope.users.forEach(function (eachUser) {
+      if (eachUser.username === $scope.user.username) {
+        $scope.user.roles = eachUser.roles;
+      }
+    });
+    $scope.loading = false;
 
   }
   else {
@@ -98,7 +95,6 @@ function ($scope, $modalInstance, CSRF, Permissions, users, roles, is_edit, user
   $scope.$watchCollection('permission', function(value) {
     value.options = value.options_as_json;
   });
-
   $scope.grantRole = function() {
     $scope.saving = true;
     CSRF.getToken()
@@ -106,8 +102,7 @@ function ($scope, $modalInstance, CSRF, Permissions, users, roles, is_edit, user
       Permissions.grantRole($scope.user.username, $scope.role.role, $scope.role.data_version, csrf_token)
       .success(function(response) {
         $scope.role.data_version = response.new_data_version;
-        $scope.user.roles.push($scope.role.role);
-
+        $scope.user.roles.push($scope.role);
         if (!($scope.role.role in $scope.roles_list)) {
           $scope.roles_list.push($scope.role.role);
         }

--- a/ui/app/js/services/permissions_service.js
+++ b/ui/app/js/services/permissions_service.js
@@ -57,18 +57,6 @@ angular.module("app").factory('Permissions', function($http, $q, ScheduledChange
       return $http.post("/api/scheduled_changes/permissions", data);
     },
 
-    getUserRoles: function(username) {
-      // What comes back from the server is a dict like this:
-      //  {'roles': ['role1', 'role2'...]} if the user has roles
-      // otherwise the value of the dict will be an empty array:
-      //  {'roles': []}
-      // when the user has no roles
-      var url = '/api/users/' + encodeURIComponent(username) + '/roles';
-      return $http.get(url);
-    },
-    getAllRoles: function() {
-      return $http.get('/api/users/roles');
-    },
     grantRole: function(username, role, data_version, csrf_token) {
       var url = '/api/users/' + encodeURIComponent(username) + '/roles/';
       url += encodeURIComponent(role);

--- a/ui/app/templates/permissions.html
+++ b/ui/app/templates/permissions.html
@@ -1,41 +1,50 @@
-<div loader ng-show="loading"></div>
+<div class="tabbable tabs-below">
+  <ul class="nav nav-pills">
+    <li ng-class="{ active: (tab === 1) }">
+      <a href ng-click="tab = 1">Users</a>
+    </li>
+    <li ng-class="{ active: tab === 2 }">
+      <a href ng-click="tab = 2">Roles</a>
+    </li>
+  </ul>
+</div>
+<!-- Users tab begins here -->
+<div ng-if="tab === 1">
+  <div loader ng-show="loading"></div>
 
 
-<form role="form" class="search-form">
+  <form role="form" class="search-form">
 
-  <div class="form-group form-group-search">
-    <input type="search" class="form-control" placeholder="Search for anything"
-           ng-model="filters.search">
-    <span ng-show="filters.search.length" ng-click="filters.search=''"
-           class="glyphicon glyphicon-remove-circle clear-search"></span>
-  </div>
+    <div class="form-group form-group-search">
+      <input type="search" class="form-control" placeholder="Search for users" ng-model="filters.search">
+      <span ng-show="filters.search.length" ng-click="filters.search=''" class="glyphicon glyphicon-remove-circle clear-search"></span>
+    </div>
 
-  <div class="page-size" ng-show="filtered_items.length > 20">
-    <label>Page Size: </label>
-    <select ng-model="page_size" ng-name="page_size"
-      ng-options="page_size.name for page_size in page_size_pair track by page_size.id"
-      ng-change="selectPageSize()"></select>
-  </div>
+    <div class="page-size" ng-show="filtered_items.length > 20">
+      <label>Page Size: </label>
+      <select ng-model="page_size" ng-name="page_size"
+        ng-options="page_size.name for page_size in page_size_pair track by page_size.id"
+        ng-change="selectPageSize()"></select>
+    </div>
 
-</form>
+  </form>
 
 
-<h2>
-  <span ng-show="!username">Users</span>
-  <span ng-show="username">{{ username }}</span>
+  <h2>
+    <span ng-show="!username">Users</span>
+    <span ng-show="username">{{ username }}</span>
 
-  <span class="count">
+    <span class="count">
     ({{ filtered_items.length | number:0 }}
     <span ng-bind="hasFilter() ? 'found' : 'in total'"></span>)
-  </span>
+    </span>
 
-  <button class="btn btn-primary btn-xs"
-          ng-show="!username" ng-click="openNewModal()">
+    <button class="btn btn-primary btn-xs" ng-show="!username" ng-click="openNewModal()">
     Add a new permission
     <i class="glyphicon glyphicon-plus"></i>
   </button>
 
-</h2>
+  </h2>
 
 <div class="pagination-container" ng-show="filtered_items.length > pageSize">
   <pagination
@@ -46,29 +55,74 @@
   ></pagination>
 </div>
 
+  <div class="panel panel-default" style="clear:right" ng-repeat="user in filtered_items = (users | filter:filterBySearch) | orderBy:ordering | startFrom:(currentPage - 1)*pageSize | limitTo:pageSize">
+    <div class="panel-heading">
 
-<div class="panel panel-default" style="clear:right"
-     ng-repeat="user in filtered_items = (users | filter:filterBySearch) | orderBy:ordering | startFrom:(currentPage - 1)*pageSize | limitTo:pageSize">
-  <div class="panel-heading">
+      <h3 class="panel-title">
+        <div style="float: right">
+          <i ng-show="username && $first">Current</i>
+          <button ng-show="!username" class="btn btn-default btn-xs" ng-click="openNewScheduledPermissionChangeModal(user)">Schedule a Change</button>
+          <button ng-show="!username" class="btn btn-default btn-xs" ng-click="openUpdateModal(user)">Update</button>
+        </div>
+        <span title="Username" ng-bind-html="highlightSearch(user.username, 'username')"></span>
+      </h3>
+    </div>
 
-    <h3 class="panel-title">
-      <div style="float: right">
-        <i ng-show="username && $first">Current</i>
-        <button ng-show="!username" class="btn btn-default btn-xs" ng-click="openNewScheduledPermissionChangeModal(user)">Schedule a Change</button>
-        <button ng-show="!username" class="btn btn-default btn-xs" ng-click="openUpdateModal(user)">Update</button>
-      </div>
-      <span title="Username" ng-bind-html="highlightSearch(user.username, 'username')"></span>
-    </h3>
   </div>
 
+
+  <div class="pagination-container" ng-show="filtered_items.length > pageSize">
+    <pagination class="pagination-sm" total-items="filtered_items.length" ng-model="currentPage" items-per-page="pageSize"></pagination>
+  </div>
 </div>
 
+<!-- Roles tab begins here -->
+<div ng-if="tab === 2">
+<div class="row">
+  <div class="col-sm-6">
+    <h2>
+      <span ng-show="!username">Roles</span>
+      <span ng-show="username">{{ username }}</span>
 
-<div class="pagination-container" ng-show="filtered_items.length > pageSize">
-  <pagination
-    class="pagination-sm"
-    total-items="filtered_items.length"
-    ng-model="currentPage"
-    items-per-page="pageSize"
-  ></pagination>
+      <span class="count">
+    ({{ filtered_roles_items.length | number:0 }}
+    <span ng-bind="hasFilter() ? 'found' : 'in total'"></span>)
+      </span>
+    </h2>
+  </div>
+
+  <div class="col-sm-5 text-right role-dropdown">
+    <div class="row" ng-show="!rule_id">
+      <label>All Roles:</label>
+      <select id="role-select-box" ng-model="current_role" name="current_role" ng-options="current_role as current_role for current_role in roles()">
+        <option value="">
+          All Roles
+        </option>
+      </select>
+    </div>
+  </div>
+</div>
+
+  <div class="pagination-container" ng-show="filtered_roles_items.length > pageSize">
+    <pagination class="pagination-sm" total-items="filtered_roles_items.length" ng-model="currentPage" items-per-page="pageSize"></pagination>
+  </div>
+
+  <div class="panel-group" ng-repeat="role in filtered_roles_items = (roles() | filter: current_role) | startFrom:(currentPage - 1)* pageSize | limitTo:pageSize">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          {{ role }}
+        </h4>
+      </div>
+      <div class="panel-body">
+        <div ng-repeat="roleUser in users | filter: filterUserByRole(role)">
+          <h5 class="panel panel-default panel-heading">{{ roleUser.username }}</h5>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="pagination-container" ng-show="filtered_roles_items.length > pageSize">
+    <pagination class="pagination-sm" total-items="filtered_roles_items.length" ng-model="currentPage" items-per-page="pageSize"></pagination>
+  </div>
 </div>

--- a/ui/app/templates/permissions.html
+++ b/ui/app/templates/permissions.html
@@ -107,7 +107,7 @@
     <pagination class="pagination-sm" total-items="filtered_roles_items.length" ng-model="currentPage" items-per-page="pageSize"></pagination>
   </div>
 
-  <div class="panel-group" ng-repeat="role in filtered_roles_items = (roles() | filter: current_role) | startFrom:(currentPage - 1)* pageSize | limitTo:pageSize">
+  <div class="panel-group" ng-repeat="role in filtered_roles_items = (roles() | filter: current_role) | startFrom:(currentPage - 1)* pageSize | limitTo:pageSize track by $index">
     <div class="panel panel-default">
       <div class="panel-heading">
         <h4 class="panel-title">

--- a/ui/app/templates/permissions_modal.html
+++ b/ui/app/templates/permissions_modal.html
@@ -54,7 +54,7 @@
           </div>
         <h4>Current Permissions</h4>
         <div class="panel panel-default"
-             ng-repeat="permission in user.permissions">
+             ng-repeat="permission in user.permissions track by $index">
           <div class="panel-heading">
               <div style="float: right">
                 <button class="btn btn-primary btn-xs" ng-show="!saving && !userPermissionsSignoffRequirements[$index].signoffRequirements.length" ng-click="updatePermission(permission)">Save changes</button>
@@ -103,7 +103,7 @@
               <button class="btn btn-primary btn-xs" ng-show="!saving" ng-click="revokeRole(role)">Revoke</button>
             </div>
             <h3 class="panel-title">
-              {{ role.role }}
+              {{ role }}
             </h3>
           </div>
         </div>

--- a/ui/app/templates/permissions_modal.html
+++ b/ui/app/templates/permissions_modal.html
@@ -103,7 +103,7 @@
               <button class="btn btn-primary btn-xs" ng-show="!saving" ng-click="revokeRole(role)">Revoke</button>
             </div>
             <h3 class="panel-title">
-              {{ role }}
+              {{ role.role }}
             </h3>
           </div>
         </div>

--- a/ui/config/files.js
+++ b/ui/config/files.js
@@ -19,6 +19,8 @@ module.exports = function(lineman) {
         "vendor/js/moment.min.js",
         "vendor/js/sweet-alert.min.js",
         "vendor/js/angular-css-injector.min.js",
+        "vendor/bootstrap/js/bootstrap.min.js",
+
 
         "vendor/js/localforage.min.js",
         "vendor/js/angular-localForage.min.js",

--- a/ui/spec/controllers/permissions_controller_spec.js
+++ b/ui/spec/controllers/permissions_controller_spec.js
@@ -6,8 +6,16 @@ describe("controller: PermissionsController", function() {
 
   var empty_user = '';
 
-  var sample_users = {
-    "users": ["peterbe", "bhearsum@example.com"]
+  var sample_users = {users: [
+    {
+      peterbe: {
+        roles: ['qa', 'releng']
+      }
+    }, {
+      bhearsum: {
+        roles: ['qa', 'releng']
+      }
+    }]
   };
 
   var sample_permissions = {
@@ -63,9 +71,13 @@ describe("controller: PermissionsController", function() {
       this.$httpBackend.flush();
       expect(this.scope.users.length).toEqual(2);
       expect(this.scope.users).toEqual([
-        {username: "peterbe"},
-        {username: "bhearsum@example.com"}
-      ]);
+        {
+          username: "peterbe",
+          roles: ['qa', 'releng']
+        }, {
+          username: "bhearsum",
+          roles: ['qa', 'releng']
+        }]);
     });
 
   });
@@ -122,8 +134,6 @@ describe("controller: PermissionsController", function() {
       this.$httpBackend.expectGET('/api/users')
       .respond(200, JSON.stringify(sample_users));
       this.$httpBackend.expectGET('/api/required_signoffs/permissions')
-      .respond(200, '{"required_signoffs": []}');
-      this.$httpBackend.expectGET('/api/users/roles')
       .respond(200, JSON.stringify(sample_all_roles));
       this.$httpBackend.expectGET('/api/releases/columns/product').respond(200,{});
       this.scope.openNewModal();
@@ -136,10 +146,6 @@ describe("controller: PermissionsController", function() {
       .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.expectGET('/api/users/peterbe/permissions')
       .respond(200, JSON.stringify(sample_permissions));
-      this.$httpBackend.expectGET('/api/users/peterbe/roles')
-      .respond(200, JSON.stringify(sample_roles));
-      this.$httpBackend.expectGET('/api/users/roles')
-      .respond(200, JSON.stringify(sample_all_roles));
       this.$httpBackend.expectGET('/api/releases/columns/product').respond(200,{});
       this.scope.openUpdateModal({username: "peterbe"});
     });

--- a/ui/spec/controllers/permissions_controller_spec.js
+++ b/ui/spec/controllers/permissions_controller_spec.js
@@ -6,16 +6,19 @@ describe("controller: PermissionsController", function() {
 
   var empty_user = '';
 
-  var sample_users = {users: [
-    {
-      peterbe: {
-        roles: ['qa', 'releng']
-      }
-    }, {
-      bhearsum: {
-        roles: ['qa', 'releng']
-      }
-    }]
+  var sample_users = {
+    peterbe: {
+      roles: [
+        { 'role': 'qa', 'data_version': 1 },
+        { 'role': 'releng', 'data_version': 1 }
+      ]
+    },
+    bhearsum: {
+      roles: [
+        { 'role': 'qa', 'data_version': 1 },
+        { 'role': 'releng', 'data_version': 1 }
+      ]
+    }
   };
 
   var sample_permissions = {
@@ -29,7 +32,7 @@ describe("controller: PermissionsController", function() {
     }
   };
 
-  var sample_roles = {
+    var sample_roles = {
     'roles': [
       {'role':'qa', 'data_version': 1},
       {'role':'releng', 'data_version':1}
@@ -56,7 +59,7 @@ describe("controller: PermissionsController", function() {
   describe("fetching all users", function() {
     it("should return all rules empty", function() {
       this.$httpBackend.expectGET('/api/users')
-      .respond(200, '{"users": []}');
+      .respond(200, '{}');
       this.$httpBackend.expectGET('/api/required_signoffs/permissions')
       .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
@@ -73,10 +76,16 @@ describe("controller: PermissionsController", function() {
       expect(this.scope.users).toEqual([
         {
           username: "peterbe",
-          roles: ['qa', 'releng']
+          roles: [
+            { 'role': 'qa', 'data_version': 1 },
+            { 'role': 'releng', 'data_version': 1 }
+          ]
         }, {
           username: "bhearsum",
-          roles: ['qa', 'releng']
+          roles: [
+            { 'role': 'qa', 'data_version': 1 },
+            { 'role': 'releng', 'data_version': 1 }
+          ]
         }]);
     });
 
@@ -85,7 +94,7 @@ describe("controller: PermissionsController", function() {
   describe("filter by search", function() {
     it("should return true always if no filters active", function() {
       this.$httpBackend.expectGET('/api/users')
-      .respond(200, '{"users": []}');
+      .respond(200, '{}');
       this.$httpBackend.expectGET('/api/required_signoffs/permissions')
       .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();
@@ -98,7 +107,7 @@ describe("controller: PermissionsController", function() {
 
     it("should filter when only one search word name", function() {
       this.$httpBackend.expectGET('/api/users')
-      .respond(200, '{"users": []}');
+      .respond(200, '{}');
       this.$httpBackend.expectGET('/api/required_signoffs/permissions')
       .respond(200, '{"required_signoffs": []}');
       this.$httpBackend.flush();

--- a/ui/spec/controllers/user_edit_controller_spec.js
+++ b/ui/spec/controllers/user_edit_controller_spec.js
@@ -11,10 +11,16 @@ describe("controller: UserPermissionsCtrl", function() {
   var users = [
     {
       username: "peterbe",
-      roles: ['qa', 'releng']
+      roles: [
+        { 'role': 'qa', 'data_version': 1 },
+        { 'role': 'releng', 'data_version': 1 }
+      ]
     }, {
       username: "bhearsum",
-      roles: ['qa', 'releng']
+      roles: [
+        { 'role': 'qa', 'data_version': 1 },
+        { 'role': 'releng', 'data_version': 1 }
+      ]
     }];
 
   var sample_permissions = {
@@ -25,9 +31,17 @@ describe("controller: UserPermissionsCtrl", function() {
   };
 
   var sample_roles = {
-    'roles': ['qa', 'releng']
-    };
-  var sample_all_roles = {'roles': ['qa', 'releng']};
+    'roles': [
+      { 'role': 'qa', 'data_version': 1 },
+      { 'role': 'releng', 'data_version': 1 }
+    ]
+  };
+  var sample_all_roles = {
+    'roles': [
+      { 'role': 'qa', 'data_version': 1 },
+      { 'role': 'releng', 'data_version': 1 }
+    ]
+  };
   var signoffRequirements = [];
 
   beforeEach(inject(function($controller, $rootScope, $location, $modal, Permissions, $httpBackend) {
@@ -79,7 +93,10 @@ describe("controller: UserPermissionsCtrl", function() {
           //   data_version: 1
           // }
         ],
-        roles : [ 'qa', 'releng']
+        roles: [
+          { 'role': 'qa', 'data_version': 1 },
+          { 'role': 'releng', 'data_version': 1 }
+        ]
       });
       // expect(this.scope.user.username).toEqual('peterbe');
       expect(this.scope.is_edit).toEqual(true);
@@ -142,7 +159,7 @@ describe("controller: UserPermissionsCtrl", function() {
       expect(this.scope.user.roles).toEqual(sample_roles.roles);
       this.$httpBackend.flush();
       expect(this.scope.saving).toEqual(false);
-      sample_roles.roles.push(new_role.role);
+      sample_roles.roles.push(new_role);
       expect(this.scope.user.roles).toEqual(sample_roles.roles);
     });
 

--- a/ui/spec/controllers/user_edit_controller_spec.js
+++ b/ui/spec/controllers/user_edit_controller_spec.js
@@ -8,6 +8,14 @@ describe("controller: UserPermissionsCtrl", function() {
   var user = {
     username: "peterbe"
   };
+  var users = [
+    {
+      username: "peterbe",
+      roles: ['qa', 'releng']
+    }, {
+      username: "bhearsum",
+      roles: ['qa', 'releng']
+    }];
 
   var sample_permissions = {
     "/releases/:name": {
@@ -17,10 +25,8 @@ describe("controller: UserPermissionsCtrl", function() {
   };
 
   var sample_roles = {
-    'roles': [
-      {'role':'qa', 'data_version': 1},
-      {'role':'releng', 'data_version':1}
-    ]};
+    'roles': ['qa', 'releng']
+    };
   var sample_all_roles = {'roles': ['qa', 'releng']};
   var signoffRequirements = [];
 
@@ -39,7 +45,8 @@ describe("controller: UserPermissionsCtrl", function() {
       Permissions: Permissions,
       user: user,
       is_edit: true,
-      users: [user],
+      users: users,
+      roles:sample_all_roles.roles,
       permissionSignoffRequirements: signoffRequirements,
     });
   }));
@@ -54,10 +61,6 @@ describe("controller: UserPermissionsCtrl", function() {
     it("should should all defaults", function() {
       this.$httpBackend.expectGET('/api/users/peterbe/permissions')
       .respond(200, JSON.stringify(sample_permissions));
-      this.$httpBackend.expectGET('/api/users/peterbe/roles')
-      .respond(200, JSON.stringify(sample_roles));
-      this.$httpBackend.expectGET('/api/users/roles')
-      .respond(200, JSON.stringify(sample_all_roles));
       this.$httpBackend.flush();
       expect(this.scope.errors).toEqual({permissions:{}});
       expect(this.scope.saving).toEqual(false);
@@ -76,10 +79,7 @@ describe("controller: UserPermissionsCtrl", function() {
           //   data_version: 1
           // }
         ],
-        roles : [
-          {'role':'qa', 'data_version': 1},
-          {'role':'releng', 'data_version':1}
-        ]
+        roles : [ 'qa', 'releng']
       });
       // expect(this.scope.user.username).toEqual('peterbe');
       expect(this.scope.is_edit).toEqual(true);
@@ -88,10 +88,6 @@ describe("controller: UserPermissionsCtrl", function() {
     it("should should be able add a permission", function() {
       this.$httpBackend.expectGET('/api/users/peterbe/permissions')
       .respond(200, JSON.stringify(sample_permissions));
-      this.$httpBackend.expectGET('/api/users/peterbe/roles')
-      .respond(200, JSON.stringify(sample_roles));
-      this.$httpBackend.expectGET('/api/users/roles')
-      .respond(200, JSON.stringify(sample_all_roles));
       this.$httpBackend.flush();
       this.$httpBackend.expectGET('/api/csrf_token')
       .respond(200, 'token');
@@ -111,10 +107,6 @@ describe("controller: UserPermissionsCtrl", function() {
     it("should should be able update a permission", function() {
       this.$httpBackend.expectGET('/api/users/peterbe/permissions')
       .respond(200, JSON.stringify(sample_permissions));
-      this.$httpBackend.expectGET('/api/users/peterbe/roles')
-      .respond(200, JSON.stringify(sample_roles));
-      this.$httpBackend.expectGET('/api/users/roles')
-      .respond(200, JSON.stringify(sample_all_roles));
       this.$httpBackend.flush();
       this.$httpBackend.expectGET('/api/csrf_token')
       .respond(200, 'token');
@@ -137,10 +129,6 @@ describe("controller: UserPermissionsCtrl", function() {
     it("should should be able add a role", function() {
       this.$httpBackend.expectGET('/api/users/peterbe/permissions')
       .respond(200, JSON.stringify(sample_permissions));
-      this.$httpBackend.expectGET('/api/users/peterbe/roles')
-      .respond(200, JSON.stringify(sample_roles));
-      this.$httpBackend.expectGET('/api/users/roles')
-      .respond(200, JSON.stringify(sample_all_roles));
       this.$httpBackend.flush();
       this.$httpBackend.expectGET('/api/csrf_token')
       .respond(200, 'token');
@@ -154,7 +142,7 @@ describe("controller: UserPermissionsCtrl", function() {
       expect(this.scope.user.roles).toEqual(sample_roles.roles);
       this.$httpBackend.flush();
       expect(this.scope.saving).toEqual(false);
-      sample_roles.roles.push(new_role);
+      sample_roles.roles.push(new_role.role);
       expect(this.scope.user.roles).toEqual(sample_roles.roles);
     });
 


### PR DESCRIPTION
This PR displays a list of `roles` and a list of `users` under each `role` on the Permissions UI. There is also an option to view a selected `role` from the filter provided.

An endpoint was created to fetch the users for a particular role.