### PR TITLE
bug 1246993: admin api doesn't always rollback transactions on failures

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -573,6 +573,12 @@ class AUSTable(object):
             self.onUpdate(self, "UPDATE", changed_by, query, trans)
 
         ret = trans.execute(query)
+        # It's important that OutdatedDataError is raised as early as possible
+        # because callers may be able to handle it gracefully (and continue
+        # with their update). If we raise this _after_ adding history or merging
+        # with Scheduled Changes, we may end up altering the history or
+        # scheduled changes more than once if the caller ends up re-calling
+        # AUSTable.update() after handling the OutdatedDataError.
         if ret.rowcount != 1:
             raise OutdatedDataError("Failed to update row, old_data_version doesn't match current data_version")
         if self.history:

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -573,12 +573,12 @@ class AUSTable(object):
             self.onUpdate(self, "UPDATE", changed_by, query, trans)
 
         ret = trans.execute(query)
+        if ret.rowcount != 1:
+            raise OutdatedDataError("Failed to update row, old_data_version doesn't match current data_version")
         if self.history:
             trans.execute(self.history.forUpdate(new_row, changed_by))
         if self.scheduled_changes:
             self.scheduled_changes.mergeUpdate(orig_row, what, changed_by, trans)
-        if ret.rowcount != 1:
-            raise OutdatedDataError("Failed to update row, old_data_version doesn't match current data_version")
         return ret
 
     def update(self, where, what, changed_by=None, old_data_version=None, transaction=None, dryrun=False):

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -87,7 +87,7 @@ class ViewTest(unittest.TestCase):
         dbo.releases.history.t.insert().execute(change_id=5, timestamp=15, changed_by="bill", name='b')
         dbo.releases.history.t.insert().execute(
             change_id=6, timestamp=16, changed_by="bill",
-            name='b', product='a', data=createBlob(dict(name='b', hashFunction="sha512", schema_version=1)), data_version=1)
+            name='b', product='b', data=createBlob(dict(name='b', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(
             name='c', product='c', data=createBlob(dict(name='c', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(name='d', product='d', data_version=1, data=createBlob("""

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -84,9 +84,35 @@ class ViewTest(unittest.TestCase):
             name='ab', product='a', data=createBlob(dict(name='ab', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(
             name='b', product='b', data=createBlob(dict(name='b', hashFunction="sha512", schema_version=1)), data_version=1)
+        dbo.releases.history.t.insert().execute(change_id=5, timestamp=15, changed_by="bill", name='b')
+        dbo.releases.history.t.insert().execute(
+            change_id=6, timestamp=16, changed_by="bill",
+            name='b', product='a', data=createBlob(dict(name='b', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(
             name='c', product='c', data=createBlob(dict(name='c', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(name='d', product='d', data_version=1, data=createBlob("""
+{
+    "name": "d",
+    "schema_version": 1,
+    "hashFunction": "sha512",
+    "platforms": {
+        "p": {
+            "locales": {
+                "d": {
+                    "complete": {
+                        "filesize": 1234,
+                        "from": "*",
+                        "hashValue": "abc"
+                    }
+                }
+            }
+        }
+    }
+}
+"""))
+        dbo.releases.history.t.insert().execute(change_id=3, timestamp=9, changed_by="bill", name='d')
+        dbo.releases.history.t.insert().execute(change_id=4, timestamp=10, changed_by="bill",
+                                                name='d', product='d', data_version=1, data=createBlob("""
 {
     "name": "d",
     "schema_version": 1,

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -78,6 +78,10 @@ class ViewTest(unittest.TestCase):
             name='a', product='a', data=createBlob(dict(name='a', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(
             name='ab', product='a', data=createBlob(dict(name='ab', hashFunction="sha512", schema_version=1)), data_version=1)
+        dbo.releases.history.t.insert().execute(change_id=1, timestamp=5, changed_by="bill", name='ab')
+        dbo.releases.history.t.insert().execute(
+            change_id=2, timestamp=6, changed_by="bill",
+            name='ab', product='a', data=createBlob(dict(name='ab', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(
             name='b', product='b', data=createBlob(dict(name='b', hashFunction="sha512", schema_version=1)), data_version=1)
         dbo.releases.t.insert().execute(

--- a/auslib/test/admin/views/test_history.py
+++ b/auslib/test/admin/views/test_history.py
@@ -24,15 +24,10 @@ class TestHistoryView(ViewTest):
         )
         self.assertStatusCode(ret, 200)
 
-        table = dbo.releases.history
-        query = table.t.count()
-        count, = query.execute().first()
-        self.assertEqual(count, 1)
+        rows = dbo.releases.history.t.select().where(dbo.releases.history.name == "d").execute().fetchall()
+        self.assertEqual(len(rows), 1)
 
-        row, = table.select()
-        change_id = row['change_id']
-
-        url = '/history/view/release/%d/data_version' % change_id
+        url = '/history/view/release/%d/data_version' % rows[0]["change_id"]
         ret = self.client.get(url)
         self.assertStatusCode(ret, 200)
 
@@ -45,15 +40,10 @@ class TestHistoryView(ViewTest):
         )
         self.assertStatusCode(ret, 200)
 
-        table = dbo.releases.history
-        query = table.t.count()
-        count, = query.execute().first()
-        self.assertEqual(count, 1)
+        rows = dbo.releases.history.t.select().where(dbo.releases.history.name == "d").execute().fetchall()
+        self.assertEqual(len(rows), 1)
 
-        row, = table.select()
-        change_id = row['change_id']
-
-        url = '/history/view/release/%d/data' % change_id
+        url = '/history/view/release/%d/data' % rows[0]["change_id"]
         ret = self.client.get(url)
         self.assertStatusCode(ret, 200)
         self.assertEqual(json.loads(ret.data), json.loads("""
@@ -86,11 +76,9 @@ class TestHistoryView(ViewTest):
         )
         self.assertStatusCode(ret, 200)
 
-        table = dbo.releases.history
-        row, = table.select(order_by=[table.change_id.desc()], limit=1)
-        change_id = row['change_id']
+        row = dbo.releases.history.t.select().where(dbo.releases.history.name == "d").execute().fetchall()[-1]
 
-        url = '/history/diff/release/%d/data' % change_id
+        url = '/history/diff/release/%d/data' % row["change_id"]
         ret = self.client.get(url)
         self.assertStatusCode(ret, 200)
         self.assertTrue('"fakePartials": true' in ret.data)

--- a/auslib/test/admin/views/test_history.py
+++ b/auslib/test/admin/views/test_history.py
@@ -25,7 +25,7 @@ class TestHistoryView(ViewTest):
         self.assertStatusCode(ret, 200)
 
         rows = dbo.releases.history.t.select().where(dbo.releases.history.name == "d").execute().fetchall()
-        self.assertEqual(len(rows), 1)
+        self.assertEqual(len(rows), 3)
 
         url = '/history/view/release/%d/data_version' % rows[0]["change_id"]
         ret = self.client.get(url)
@@ -41,9 +41,9 @@ class TestHistoryView(ViewTest):
         self.assertStatusCode(ret, 200)
 
         rows = dbo.releases.history.t.select().where(dbo.releases.history.name == "d").execute().fetchall()
-        self.assertEqual(len(rows), 1)
+        self.assertEqual(len(rows), 3)
 
-        url = '/history/view/release/%d/data' % rows[0]["change_id"]
+        url = '/history/view/release/%d/data' % rows[2]["change_id"]
         ret = self.client.get(url)
         self.assertStatusCode(ret, 200)
         self.assertEqual(json.loads(ret.data), json.loads("""
@@ -76,9 +76,10 @@ class TestHistoryView(ViewTest):
         )
         self.assertStatusCode(ret, 200)
 
-        row = dbo.releases.history.t.select().where(dbo.releases.history.name == "d").execute().fetchall()[-1]
+        rows = dbo.releases.history.t.select().where(dbo.releases.history.name == "d").execute().fetchall()
+        self.assertEqual(len(rows), 4)
 
-        url = '/history/diff/release/%d/data' % row["change_id"]
+        url = '/history/diff/release/%d/data' % rows[3]["change_id"]
         ret = self.client.get(url)
         self.assertStatusCode(ret, 200)
         self.assertTrue('"fakePartials": true' in ret.data)

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -319,7 +319,7 @@ class TestReleasesAPI_JSON(ViewTest):
                 }
             }
         }"""
-        ret = self._post('/releases/ee', data=dict(data=blob, hashFunction="sha512", name='ee', product='ee', data_version=1))
+        ret = self._post('/releases/ee', data=dict(data=blob, hashFunction="sha512", name='ee', product='ee'))
         self.assertStatusCode(ret, 201)
 
         # Updating same release
@@ -340,12 +340,16 @@ class TestReleasesAPI_JSON(ViewTest):
         history_rows = dbo.releases.history.t.select().where(dbo.releases.history.name == "ee").execute().fetchall()
         self.assertEqual(len(history_rows), 4)
         self.assertEqual(history_rows[0]["data"], None)
+        self.assertEqual(history_rows[0]["data_version"], None)
         self.assertEqual(history_rows[0]["read_only"], False)
         self.assertEqual(history_rows[1]["data"], {"name": "ee", "schema_version": 1, "hashFunction": "sha512"})
+        self.assertEqual(history_rows[1]["data_version"], 1)
         self.assertEqual(history_rows[1]["read_only"], False)
         self.assertEqual(history_rows[2]["data"], blob)
+        self.assertEqual(history_rows[2]["data_version"], 2)
         self.assertEqual(history_rows[2]["read_only"], False)
         self.assertEqual(history_rows[3]["data"], blob)
+        self.assertEqual(history_rows[3]["data_version"], 3)
         self.assertEqual(history_rows[3]["read_only"], False)
 
     def testReleasePostMismatchedName(self):

--- a/auslib/web/admin/views/base.py
+++ b/auslib/web/admin/views/base.py
@@ -70,6 +70,9 @@ class AdminView(MethodView):
     def post(self, *args, **kwargs):
         self.log.debug("processing POST request to %s" % request.path)
         trans = dbo.begin()
+        # Transactions are automatically rolled back by the context manager if
+        # _post raises an Exception, but we need to make sure they are also
+        # rolled back if the View returns any sort of error.
         try:
             ret = self._post(*args, transaction=trans, **kwargs)
             if ret.status_code >= 400:

--- a/auslib/web/admin/views/base.py
+++ b/auslib/web/admin/views/base.py
@@ -86,6 +86,8 @@ class AdminView(MethodView):
         except:
             trans.rollback()
             raise
+        finally:
+            trans.close()
 
     @handleGeneralExceptions("DELETE")
     def delete(self, *args, **kwargs):

--- a/auslib/web/admin/views/base.py
+++ b/auslib/web/admin/views/base.py
@@ -60,65 +60,51 @@ def handleGeneralExceptions(messages):
     return wrap
 
 
+def transactionHandler(request_handler):
+    def decorated(*args, **kwargs):
+        trans = dbo.begin()
+        # Transactions are automatically rolled back by the context manager if
+        # _post raises an Exception, but we need to make sure they are also
+        # rolled back if the View returns any sort of error.
+        try:
+            ret = request_handler(*args, transaction=trans, **kwargs)
+            if ret.status_code >= 400:
+                trans.rollback()
+            else:
+                trans.commit()
+            return ret
+        except:
+            trans.rollback()
+            raise
+        finally:
+            trans.close()
+
+    return decorated
+
+
 class AdminView(MethodView):
 
     def __init__(self, *args, **kwargs):
         self.log = logging.getLogger(self.__class__.__name__)
         MethodView.__init__(self, *args, **kwargs)
 
+    @transactionHandler
     @handleGeneralExceptions("POST")
     def post(self, *args, **kwargs):
         self.log.debug("processing POST request to %s" % request.path)
-        trans = dbo.begin()
-        # Transactions are automatically rolled back by the context manager if
-        # _post raises an Exception, but we need to make sure they are also
-        # rolled back if the View returns any sort of error.
-        try:
-            ret = self._post(*args, transaction=trans, **kwargs)
-            if ret.status_code >= 400:
-                trans.rollback()
-            else:
-                trans.commit()
-            return ret
-        except:
-            trans.rollback()
-            raise
-        finally:
-            trans.close()
+        return self._post(*args, **kwargs)
 
+    @transactionHandler
     @handleGeneralExceptions("PUT")
     def put(self, *args, **kwargs):
         self.log.debug("processing PUT request to %s" % request.path)
-        trans = dbo.begin()
-        try:
-            ret = self._put(*args, transaction=trans, **kwargs)
-            if ret.status_code >= 400:
-                trans.rollback()
-            else:
-                trans.commit()
-            return ret
-        except:
-            trans.rollback()
-            raise
-        finally:
-            trans.close()
+        return self._put(*args, **kwargs)
 
+    @transactionHandler
     @handleGeneralExceptions("DELETE")
     def delete(self, *args, **kwargs):
         self.log.debug("processing DELETE request to %s" % request.path)
-        trans = dbo.begin()
-        try:
-            ret = self._delete(*args, transaction=trans, **kwargs)
-            if ret.status_code >= 400:
-                trans.rollback()
-            else:
-                trans.commit()
-            return ret
-        except:
-            trans.rollback()
-            raise
-        finally:
-            trans.close()
+        return self._delete(*args, **kwargs)
 
 
 def serialize_signoff_requirements(requirements):


### PR DESCRIPTION
There's two distinct cases where we may end up with unwanted rows in the database:
1) If a View _returns_ a 400 or 500 instead of raising an Exception, the transaction will still be committed. If any of the View code made a change to the database (for example, how changeRelease will create a release before actually adding the desired data to it), this will be committed even though it shouldn't be. The fix for this is to check return code and explicitly rollback the transaction instead of relying on the context manager to do it.
2) If we start making changes to the database, then something happens that invalidates them, but we recover from it and continue on - the original changes we made will still be present. This is what's happening when we handled OutdatedDataError in Releases.update right now -- we've already called AUSTable.update, which has added a row the history table, and then when we call it _again_ after handling the merge error, we end up with a duplicate history row. The fix for this is to not update the history table before potentially raising OutdatedDataError. This is not a perfect fix (ideally, we'd rollback the transaction and create a new one), but it fixes the currently known issues, and is not terribly invasive.

With these two fixes applied we've had 3 staging releases with absolutely no failures to merge updates:
```
$ for i in build10 build11 build12; do echo -n "Attempted Merges for $i: " && grep 'Trying to merge' output-oct3.txt | grep $i | wc -l && echo -n "Successful Merges for $i: " && grep 'Successfully merged' output-oct3.txt | grep $i | wc -l; done
Attempted Merges for build10: 24
Successful Merges for build10: 24
Attempted Merges for build11: 134
Successful Merges for build11: 134
Attempted Merges for build12: 112
Successful Merges for build12: 112
```