### PR TITLE
Improve History.getChange efficiency.

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -741,7 +741,10 @@ class History(AUSTable):
                 raise ValueError("data_version queried for non-versioned table")
 
             where = [self.data_version == data_version]
+            self.log.debug("Querying for change_id by:")
+            self.log.debug("data_version: %s", data_version)
             for col in column_names.keys():
+                self.log.debug("%s: %s", column_names[col], column_values[col])
                 where.append(column_names[col] == column_values[col])
 
             # To improve query efficiency we first get the change_id,
@@ -755,13 +758,14 @@ class History(AUSTable):
             change_ids = self.select(columns=[self.change_id], where=where,
                                      transaction=transaction)
             if len(change_ids) != 1:
-                self.log.debug("Found %s changes, should have been 1", len(change_ids))
+                self.log.debug("Found %s changes when not querying by change_id, should have been 1", len(change_ids))
                 return None
             change_id = change_ids[0]["change_id"]
 
+        self.log.debug("Querying for full change by change_id %s", change_id)
         changes = self.select(where=[self.change_id == change_id], transaction=transaction)
         if len(changes) != 1:
-            self.log.debug("Found %s changes, should have been 1", len(changes))
+            self.log.debug("Found %s changes when querying by change_id, should have been 1", len(changes))
             return None
         return changes[0]
 

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -460,6 +460,7 @@ class TestHistoryTable(unittest.TestCase, TestTableMixin, MemoryDatabaseMixin):
         self.assertTrue('foo' in columns)
         self.assertTrue('changed_by' in columns)
         self.assertTrue('timestamp' in columns)
+        self.assertTrue('data_version' in columns)
 
     @mock.patch("time.time", mock.MagicMock(return_value=1.0))
     def testHistoryUponInsert(self):
@@ -600,6 +601,7 @@ class TestMultiplePrimaryHistoryTable(unittest.TestCase, TestMultiplePrimaryTabl
         self.assertTrue('foo' in columns)
         self.assertTrue('changed_by' in columns)
         self.assertTrue('timestamp' in columns)
+        self.assertTrue('data_version' in columns)
 
     @mock.patch("time.time", mock.MagicMock(return_value=1.0))
     def testMultiplePrimaryHistoryUponInsert(self):


### PR DESCRIPTION
The current version of the query we use to grab the ancestor version of a Release when merging ends up running queries like:
```
SELECT releases_history.change_id, releases_history.changed_by, releases_history.timestamp, releases_history.name, releases_history.product, releases_history.`read_only`, releases_history.data, releases_history.data_version FROM releases_history WHERE releases_history.data_version = %s AND releases_history.name = %s
```

This ends up using an index on releases_history.name. In the nightly case, this means there's still ~15,000 rows to scan through to find the one we want. In my local testing, reducing the number of columns that we select on this big query speeds it up by ~450 times. On a releases_history table with ~13,000 rows, selecting all columns took 18.09 seconds, and selecting only change_id took 0.04. Once we have the change_id, selecting the entire row we want goes very fast!

I'm not actually 100% sure I understand why this helps - I'm hoping to confirm my theory with someone who knows mysql better before landing this.