### PR TITLE
bug 1396959 Enable removal of scheduled deletes to required signoff

### DIFF
--- a/ui/app/js/controllers/required_signoffs_controller.js
+++ b/ui/app/js/controllers/required_signoffs_controller.js
@@ -43,8 +43,7 @@ function($scope, $modal, $q, CSRF, ProductRequiredSignoffs, PermissionsRequiredS
     }
   }, true);
 
-  $scope.undoRemoveRole = function(role, rs) {
-    var roleName = role.$key;
+  $scope.undoRemoveRole = function(roleName, rs) {
     var product = Object.keys(rs)[0];
     var channel = Object.keys(rs[product].channels)[0];
 

--- a/ui/app/js/controllers/required_signoffs_controller.js
+++ b/ui/app/js/controllers/required_signoffs_controller.js
@@ -47,8 +47,6 @@ function($scope, $modal, $q, CSRF, ProductRequiredSignoffs, PermissionsRequiredS
     var product = Object.keys(rs)[0];
     var channel = Object.keys(rs[product].channels)[0];
 
-    $scope.required_signoffs[product].channels[channel][roleName].sc.signoffs_required = 1;
-
     CSRF.getToken()
     .then(function(csrf_token) {
       var sc_id = $scope.required_signoffs[product].channels[channel][roleName].sc.sc_id;

--- a/ui/app/js/controllers/required_signoffs_controller.js
+++ b/ui/app/js/controllers/required_signoffs_controller.js
@@ -43,28 +43,23 @@ function($scope, $modal, $q, CSRF, ProductRequiredSignoffs, PermissionsRequiredS
     }
   }, true);
 
-  $scope.undoRemoveRole = function(role, rs, csrf_token) {
+  $scope.undoRemoveRole = function(role, rs) {
     var roleName = role.$key;
     var product = Object.keys(rs)[0];
-    var chans = rs[product].channels;
-    var channel = Object.keys(chans)[0];
+    var channel = Object.keys(rs[product].channels)[0];
 
     $scope.required_signoffs[product].channels[channel][roleName].sc.signoffs_required = 1;
-    $scope.required_signoffs[product].channels[channel][roleName].sc.change_type = "update";
-    var update_sc_id = $scope.required_signoffs[product].channels[channel][roleName].sc.sc_id;
-    var data = {
-      "product": $scope.product, 
-      "role": roleName,
-      "data_version": $scope.required_signoffs[product].channels[channel][roleName].data_version};
-    data["when"] = new Date().getTime() + 5000;
-    data["sc_data_version"] = $scope.required_signoffs[product].channels[channel][roleName].sc.sc_data_version;
-    data["signoffs_required"] = $scope.required_signoffs[product].channels[channel][roleName].sc.signoffs_required;
 
     CSRF.getToken()
     .then(function(csrf_token) {
-      data["csrf_token"] = csrf_token;
-      ProductRequiredSignoffs.deleteScheduledChange(update_sc_id, data)
+      var sc_id = $scope.required_signoffs[product].channels[channel][roleName].sc.sc_id;
+      var data = {
+        "csrf_token": csrf_token,
+        "sc_data_version": $scope.required_signoffs[product].channels[channel][roleName].sc.sc_data_version
+      };
+      ProductRequiredSignoffs.deleteScheduledChange(sc_id, data)
       .success(function(response) {
+        $scope.required_signoffs[product].channels[channel][roleName].sc = null;
       });
     });
 

--- a/ui/app/templates/required_signoffs.html
+++ b/ui/app/templates/required_signoffs.html
@@ -98,7 +98,7 @@
           <span class="label label-info" ng-show="role['sc'] !== null && role['sc']['change_type'] !== 'delete'">Pending</span>
           <span class="label label-danger" ng-show="role['sc'] !== null && role['sc']['change_type'] === 'delete'">Pending Delete</span>
           <button class="btn btn-xs btn-primary" ng-show="role['sc'] !== null && role['sc']['change_type'] === 'delete'"
-                  ng-click="undoRemoveRole(role, required_signoffs)">
+                  ng-click="undoRemoveRole(role.$key, required_signoffs)">
             Cancel delete
           </button>
 

--- a/ui/app/templates/required_signoffs.html
+++ b/ui/app/templates/required_signoffs.html
@@ -99,7 +99,7 @@
           <span class="label label-danger" ng-show="role['sc'] !== null && role['sc']['change_type'] === 'delete'">Pending Delete</span>
           <button class="btn btn-xs btn-primary" ng-show="role['sc'] !== null && role['sc']['change_type'] === 'delete'"
                   ng-click="undoRemoveRole(role, required_signoffs)">
-            Undo delete
+            Cancel delete
           </button>
 
           <div style="float: right" ng-show="role['sc'] !== null">

--- a/ui/app/templates/required_signoffs.html
+++ b/ui/app/templates/required_signoffs.html
@@ -97,6 +97,11 @@
           <span ng-show="role['sc'] !== null">{{ role["sc"]["signoffs_required"] }} member(s) of {{ role.$key }} (currently: {{ role["signoffs_required"] }})</span>
           <span class="label label-info" ng-show="role['sc'] !== null && role['sc']['change_type'] !== 'delete'">Pending</span>
           <span class="label label-danger" ng-show="role['sc'] !== null && role['sc']['change_type'] === 'delete'">Pending Delete</span>
+          <button class="btn btn-xs btn-primary" ng-show="role['sc'] !== null && role['sc']['change_type'] === 'delete'"
+                  ng-click="undoRemoveRole(role, required_signoffs)">
+            Undo delete
+          </button>
+
           <div style="float: right" ng-show="role['sc'] !== null">
             <button class="btn btn-xs btn-primary" ng-click="signoff('channel', role['sc'], role.$key, channel)"
                     ng-show="! role['sc']['signoffs'].hasOwnProperty(current_user)">


### PR DESCRIPTION
Currently, there is no way to remove a scheduled delete from a role in required signoffs. This PR leverages on pre-existing API endpoints to enable this.