### PR TITLE
Bug 1396106: Edits to "scheduled changes" are not auto signed-off

### DIFF
--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -42,6 +42,8 @@ class ViewTest(unittest.TestCase):
         dbo.permissions.t.insert().execute(permission='permission', username='bob', data_version=1)
         dbo.permissions.t.insert().execute(permission='release', username='bob',
                                            options=dict(products=['fake', "a", 'b'], actions=["create", "modify"]), data_version=1)
+        dbo.permissions.t.insert().execute(permission='release', username='julie', options=dict(products=['a'], actions=["modify"]), data_version=1)
+        dbo.permissions.t.insert().execute(permission='rule', username='julie', options=dict(products=['fake'], actions=["create"]), data_version=1)
         dbo.permissions.t.insert().execute(permission='release_read_only', username='bob', options=dict(actions=["set"], products=["a", "b"]), data_version=1)
         dbo.permissions.t.insert().execute(permission='rule', username='bob', options=dict(actions=["modify"], products=['a', "b"]), data_version=1)
         dbo.permissions.t.insert().execute(permission='release', username='ashanti', options=dict(actions=["modify"], products=['a']), data_version=1)

--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -616,6 +616,32 @@ class TestPermissionsScheduledChanges(ViewTest):
         self.assertEquals(len(rows), 0)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testUpdateScheduleChangeExistingPermissionDiffUserResetSignOffs(self):
+        data = {
+            "options": '{"products": ["superfake"]}', "data_version": 1, "sc_data_version": 1, "when": 200000000,
+        }
+        rows = dbo.permissions.scheduled_changes.signoffs.t.select().where(
+            dbo.permissions.scheduled_changes.signoffs.sc_id == 2).execute().fetchall()
+        self.assertEquals(len(rows), 2)
+        ret = self._post("/scheduled_changes/permissions/2", data=data, username="bob")
+        self.assertEquals(ret.status_code, 200, ret.data)
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {'bob': 'relman'}})
+
+        r = dbo.permissions.scheduled_changes.t.select().where(
+            dbo.permissions.scheduled_changes.sc_id == 2).execute().fetchall()
+        self.assertEquals(len(r), 1)
+        db_data = dict(r[0])
+        expected = {
+            "sc_id": 2, "complete": False, "data_version": 2, "scheduled_by": "bob", "change_type": "update",
+            "base_permission": "release_locale",
+            "base_username": "ashanti", "base_options": {"products": ["superfake"]}, "base_data_version": 1,
+        }
+        self.assertEquals(db_data, expected)
+        rows = dbo.permissions.scheduled_changes.signoffs.t.select().where(
+            dbo.releases.scheduled_changes.signoffs.sc_id == 2).execute().fetchall()
+        self.assertEquals(len(rows), 0)
+
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testUpdateCompletedScheduledChangeExistingPermission(self):
         data = {
             "options": '{"products": ["Thunderbird"]}', "data_version": 1, "sc_data_version": 1, "when": 200000000,

--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -574,7 +574,7 @@ class TestPermissionsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/permissions/2", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {'bill': 'releng'}})
 
         r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 2).execute().fetchall()
         self.assertEquals(len(r), 1)
@@ -599,7 +599,7 @@ class TestPermissionsScheduledChanges(ViewTest):
         self.assertEquals(len(rows), 2)
         ret = self._post("/scheduled_changes/permissions/2", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {'bill': 'releng'}})
 
         r = dbo.permissions.scheduled_changes.t.select().where(
             dbo.permissions.scheduled_changes.sc_id == 2).execute().fetchall()
@@ -630,7 +630,7 @@ class TestPermissionsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/permissions/1", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {'bill': 'releng'}})
 
         r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 1).execute().fetchall()
         self.assertEquals(len(r), 1)

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1430,7 +1430,7 @@ class TestReleasesScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/releases/2", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {'bill': 'releng'}})
 
         r = dbo.releases.scheduled_changes.t.select().where(dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
         self.assertEquals(len(r), 1)
@@ -1456,7 +1456,7 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertEquals(len(rows), 2)
         ret = self._post("/scheduled_changes/releases/4", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {'bill': 'releng'}})
 
         r = dbo.releases.scheduled_changes.t.select().where(
             dbo.releases.scheduled_changes.sc_id == 4).execute().fetchall()
@@ -1472,7 +1472,7 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertEquals(db_data, expected)
         rows = dbo.releases.scheduled_changes.signoffs.t.select(). \
             where(dbo.releases.scheduled_changes.signoffs.sc_id == 4).execute().fetchall()
-        self.assertEquals(len(rows), 0)
+        self.assertEquals(len(rows), 1)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testUpdateScheduledChangeExistingDeleteRelease(self):

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1475,6 +1475,35 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertEquals(len(rows), 1)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testUpdateScheduleChangeExistingReleaseDiffUserResetSignOffs(self):
+        data = {
+            "data": '{"name": "a", "hashFunction": "sha512", "extv": "3.0", "schema_version": 1}', "name": "a",
+            "data_version": 1, "sc_data_version": 1, "when": 78900000000, "change_type": "update"
+        }
+        rows = dbo.releases.scheduled_changes.signoffs.t.select(). \
+            where(dbo.releases.scheduled_changes.signoffs.sc_id == 2).execute().fetchall()
+        self.assertEquals(len(rows), 1)
+        ret = self._post("/scheduled_changes/releases/2", data=data, username="julie")
+        self.assertEquals(ret.status_code, 200, ret.data)
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {'julie': 'releng'}})
+
+        r = dbo.releases.scheduled_changes.t.select().where(
+            dbo.releases.scheduled_changes.sc_id == 2).execute().fetchall()
+        self.assertEquals(len(r), 1)
+        db_data = dict(r[0])
+        expected = {
+            "sc_id": 2, "complete": False, "change_type": "update", "data_version": 2, "scheduled_by": "julie",
+            "base_name": "a", "base_product": "a",
+            "base_read_only": False,
+            "base_data": {"name": "a", "hashFunction": "sha512", "extv": "3.0", "schema_version": 1},
+            "base_data_version": 1,
+        }
+        self.assertEquals(db_data, expected)
+        rows = dbo.releases.scheduled_changes.signoffs.t.select(). \
+            where(dbo.releases.scheduled_changes.signoffs.sc_id == 2).execute().fetchall()
+        self.assertEquals(len(rows), 1)
+
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testUpdateScheduledChangeExistingDeleteRelease(self):
         data = {
             "name": "c",

--- a/auslib/test/admin/views/test_required_signoffs.py
+++ b/auslib/test/admin/views/test_required_signoffs.py
@@ -318,7 +318,7 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/required_signoffs/product/2", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {'bill': 'releng'}})
 
         r = dbo.productRequiredSignoffs.scheduled_changes.t.select().where(dbo.productRequiredSignoffs.scheduled_changes.sc_id == 2).execute().fetchall()
         self.assertEquals(len(r), 1)
@@ -341,7 +341,7 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/required_signoffs/product/1", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {'bill': 'releng'}})
 
         r = dbo.productRequiredSignoffs.scheduled_changes.t.select().where(dbo.productRequiredSignoffs.scheduled_changes.sc_id == 1).execute().fetchall()
         self.assertEquals(len(r), 1)
@@ -780,7 +780,7 @@ class TestPermissionsRequiredSignoffsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/required_signoffs/permissions/2", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {'bill': 'releng'}})
 
         r = dbo.permissionsRequiredSignoffs.scheduled_changes.t.select().where(dbo.permissionsRequiredSignoffs.scheduled_changes.sc_id == 2)\
                                                                         .execute().fetchall()

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1061,6 +1061,8 @@ class TestRuleScheduledChanges(ViewTest):
         dbo.rules.scheduled_changes.conditions.t.insert().execute(sc_id=6, when=5500000, data_version=1)
         dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=12, changed_by="bill", timestamp=75, sc_id=6)
         dbo.rules.scheduled_changes.conditions.history.t.insert().execute(change_id=13, changed_by="bill", timestamp=76, sc_id=6, when=5500000, data_version=1)
+        dbo.rules.scheduled_changes.signoffs.t.insert().execute(sc_id=6, username="bill", role="releng")
+        dbo.rules.scheduled_changes.signoffs.t.insert().execute(sc_id=6, username="mary", role="relman")
 
         dbo.rules.scheduled_changes.t.insert().execute(
             sc_id=7, scheduled_by="bill", data_version=1, base_priority=40, base_backgroundRate=50, base_mapping="a", base_update_type="minor",
@@ -1121,7 +1123,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "insert", "signoffs": {}, "required_signoffs": {"relman": 1},
+                    "change_type": "insert", "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"relman": 1},
                 },
                 {
                     "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
@@ -1190,7 +1192,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-                    "change_type": "insert", "signoffs": {}, "required_signoffs": {"relman": 1},
+                    "change_type": "insert", "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"relman": 1},
                 },
                 {
                     "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
@@ -1468,6 +1470,36 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(db_data, expected)
         rows = dbo.rules.scheduled_changes.signoffs.t.select().where(
             dbo.rules.scheduled_changes.signoffs.sc_id == 3).execute().fetchall()
+        self.assertEquals(len(rows), 1)
+
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testUpdateScheduledChangeDiffUserResetSignOffs(self):
+        data = {
+            "when": 2900000, "priority": 150, "backgroundRate": 50, "update_type": "minor", "sc_data_version": 1,
+            "channel": "j"
+        }
+        rows = dbo.rules.scheduled_changes.signoffs.t.select().where(
+            dbo.rules.scheduled_changes.signoffs.sc_id == 6).execute().fetchall()
+        self.assertEquals(len(rows), 2)
+        ret = self._post("/scheduled_changes/rules/6", data=data, username="julie")
+        self.assertEquals(ret.status_code, 200, ret.data)
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 2, "signoffs": {'julie': 'releng'}})
+        r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 6).execute().fetchall()
+        self.assertEquals(len(r), 1)
+        db_data = dict(r[0])
+        expected = {
+            "sc_id": 6, "scheduled_by": "julie", "data_version": 2, "complete": False,
+            "base_priority": 150, "base_backgroundRate": 50, "base_mapping": "ab", "base_update_type": "minor",
+            "base_channel": "j", "base_buildID": None, "base_locale": None, "base_osVersion": None,
+            "base_product": "fake", "base_data_version": None, "base_alias": None,
+            "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None,
+            "base_headerArchitecture": None, "base_comment": None, "base_memory": None, "base_mig64": None, "base_jaws": None,
+            "base_instructionSet": None, "base_version": None, "base_rule_id": None, "base_buildTarget": None,
+            "change_type": "insert",
+        }
+        self.assertEquals(db_data, expected)
+        rows = dbo.rules.scheduled_changes.signoffs.t.select().where(
+            dbo.rules.scheduled_changes.signoffs.sc_id == 6).execute().fetchall()
         self.assertEquals(len(rows), 1)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1450,7 +1450,7 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(len(rows), 2)
         ret = self._post("/scheduled_changes/rules/3", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"new_data_version": 3, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"new_data_version": 3, "signoffs": {'bill': 'releng'}})
 
         r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 3).execute().fetchall()
         self.assertEquals(len(r), 1)
@@ -1468,7 +1468,7 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(db_data, expected)
         rows = dbo.rules.scheduled_changes.signoffs.t.select().where(
             dbo.rules.scheduled_changes.signoffs.sc_id == 3).execute().fetchall()
-        self.assertEquals(len(rows), 0)
+        self.assertEquals(len(rows), 1)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testUpdateScheduledChangeCantRemoveProductWithoutPermission(self):


### PR DESCRIPTION
**What does this PR do?**
1) Previously when a user creates a schedule change the system automatically adds the required signoff for the user but the same user editing the schedule change also automatically revokes the signoff. This PR makes sure the signoff is not revoked if only it's the same user who created the schedule change that is editing the schedule change.
2) If a different user happens to be the one editing the schedule change then the system revokes all previous signoffs and adds a signoff for the editing user

**How should this be manually tested?**
_CASE 1_
Navigate to the rules page and try to create a schedule change and before the change is completed edit the schedule change. It should not revoke the signoff that was added while creating the schedule change
_CASE 2_
Navigate to the rules page and try to create a schedule change and before the change is completed
set a different remote user and try editing the schedule change. It should remove the previous users signoff but automatically add the current users signoff