### PR TITLE
Only make version tags when releasing

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -162,7 +162,7 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && scripts/push-dockerimage.sh"
+        - "git clone $GITHUB_BASE_REPO_URL balrog && cd balrog && git checkout $GITHUB_BASE_BRANCH && scripts/push-dockerimage.sh latest ${GITHUB_BASE_BRANCH}-${GITHUB_BASE_SHA}"
     extra:
       github:
         env: true
@@ -190,7 +190,7 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog/agent && git checkout $GITHUB_HEAD_BRANCH && scripts/push-dockerimage.sh"
+        - "git clone $GITHUB_BASE_REPO_URL balrog && cd balrog/agent && git checkout $GITHUB_BASE_BRANCH && scripts/push-dockerimage.sh latest ${GITHUB_BASE_BRANCH}-${GITHUB_BASE_SHA}"
     extra:
       github:
         env: true

--- a/agent/scripts/push-dockerimage.sh
+++ b/agent/scripts/push-dockerimage.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-extra_tag=$1
+tags=$@
 
 password_url="taskcluster/secrets/v1/secret/repo:github.com/mozilla/balrog:dockerhub"
 artifact_url="taskcluster/queue/v1/task/${TASK_ID}/runs/${RUN_ID}/artifacts/public/docker-image-shasum256.txt"
@@ -15,47 +15,38 @@ if [ -z $dockerhub_password ]; then
     echo "Dockerhub password not set, can't continue!"
     exit 1
 fi
+if [ ${#errors[@]} -eq 0 ]; then
+    echo "Must pass at least one tag"
+    exit 2
+fi
 
 commit=$(git rev-parse HEAD)
 version=$(cat version.txt)
-# This is hardcoded because we can't accurately set it programatically for
-# release events, where we've updated to a tag. At the time of writing,
-# we only built docker images for commits to master or release events...
-branch=master
-#branch=$(git rev-parse --abbrev-ref HEAD)
-date=$(date --utc +%Y-%m-%d-%H-%M)
 
-echo "{
-    \"commit\": \"${commit}\",
-    \"version\": \"${version}\",
-    \"source\": \"https://github.com/mozilla/balrog\",
-    \"build\": \"https://tools.taskcluster.net/task-inspector/#${TASK_ID}\"
-}" > version.json
-
-branch_tag="${branch}"
-if [ "$branch" == "master" ]; then
-    branch_tag="latest"
-fi
-commit_tag="${branch}-${commit}"
+cat > version.json <<EOF
+{
+    "commit": "${commit}",
+    "version": "${version}",
+    "source": "https://github.com/mozilla/balrog",
+    "build": "https://tools.taskcluster.net/task-inspector/#${TASK_ID}"
+}
+EOF
 
 echo "Building Docker image"
-docker build -t mozilla/balrogagent:${branch_tag} .
-echo "Tagging Docker image with git commit tag"
-docker tag mozilla/balrogagent:${branch_tag} "mozilla/balrogagent:${commit_tag}"
+docker build -t buildtemp .
 echo "Logging into Dockerhub"
 docker login -e $dockerhub_email -u $dockerhub_username -p $dockerhub_password
-echo "Pushing Docker image"
-docker push mozilla/balrogagent:${branch_tag}
-docker push mozilla/balrogagent:${commit_tag}
 
-if [ ! -z $extra_tag ]; then
-  echo "Tagging Docker image with ${extra_tag}"
-  docker tag mozilla/balrogagent:${branch_tag} "mozilla/balrogagent:${extra_tag}"
-  docker push mozilla/balrogagent:${extra_tag}
-fi
+for tag in ${tags[@]}; do
+    echo "Tagging Docker image with ${tag}"
+    docker tag buildtemp "mozilla/balrogagent:${tag}"
+    echo "Pushing Docker image tagged with ${tag}"
+    docker push mozilla/balrogagent:${tag}
+done
 
-sha256=$(docker images --no-trunc mozilla/balrogagent | grep "${commit_tag}" | awk '/^mozilla/ {print $3}')
+sha256=$(docker images --no-trunc mozilla/balrogagent | grep "${tags[0]}" | awk '/^mozilla/ {print $3}')
 echo "SHA256 is ${sha256}, creating artifact for it"
 put_url=$(curl --retry 5 --retry-delay 5 --data "{\"storageType\": \"s3\", \"contentType\": \"text/plain\", \"expires\": \"${artifact_expiry}\"}" ${artifact_url} | python -c 'import json; import sys; print json.load(sys.stdin)["putUrl"]')
 curl --retry 5 --retry-delay 5 -X PUT -H "Content-Type: text/plain" --data "${sha256}" "${put_url}"
 echo 'Artifact created, all done!'
+

--- a/agent/scripts/push-dockerimage.sh
+++ b/agent/scripts/push-dockerimage.sh
@@ -15,7 +15,7 @@ if [ -z $dockerhub_password ]; then
     echo "Dockerhub password not set, can't continue!"
     exit 1
 fi
-if [ ${#errors[@]} -eq 0 ]; then
+if [ ${#tags[@]} -eq 0 ]; then
     echo "Must pass at least one tag"
     exit 2
 fi

--- a/scripts/push-dockerimage.sh
+++ b/scripts/push-dockerimage.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-extra_tag=$1
+tags=$@
 
 password_url="taskcluster/secrets/v1/secret/repo:github.com/mozilla/balrog:dockerhub"
 artifact_url="taskcluster/queue/v1/task/${TASK_ID}/runs/${RUN_ID}/artifacts/public/docker-image-shasum256.txt"
@@ -15,15 +15,13 @@ if [ -z $dockerhub_password ]; then
     echo "Dockerhub password not set, can't continue!"
     exit 1
 fi
+if [ ${#errors[@]} -eq 0 ]; then
+    echo "Must pass at least one tag"
+    exit 2
+fi
 
 commit=$(git rev-parse HEAD)
 version=$(cat version.txt)
-# This is hardcoded because we can't accurately set it programatically for
-# release events, where we've updated to a tag. At the time of writing,
-# we only built docker images for commits to master or release events...
-branch=master
-#branch=$(git rev-parse --abbrev-ref HEAD)
-date=$(date --utc +%Y-%m-%d-%H-%M)
 
 cat > version.json <<EOF
 {
@@ -34,29 +32,19 @@ cat > version.json <<EOF
 }
 EOF
 
-branch_tag="${branch}"
-if [ "$branch" == "master" ]; then
-    branch_tag="latest"
-fi
-commit_tag="${branch}-${commit}"
-
 echo "Building Docker image"
-docker build -t mozilla/balrog:${branch_tag} .
-echo "Tagging Docker image with git commit tag"
-docker tag mozilla/balrog:${branch_tag} "mozilla/balrog:${commit_tag}"
+docker build -t buildtemp .
 echo "Logging into Dockerhub"
 docker login -e $dockerhub_email -u $dockerhub_username -p $dockerhub_password
-echo "Pushing Docker image"
-docker push mozilla/balrog:${branch_tag}
-docker push mozilla/balrog:${commit_tag}
 
-if [ ! -z $extra_tag ]; then
-  echo "Tagging Docker image with ${extra_tag}"
-  docker tag mozilla/balrog:${branch_tag} "mozilla/balrog:${extra_tag}"
-  docker push mozilla/balrog:${extra_tag}
-fi
+for tag in ${tags[@]}; do
+    echo "Tagging Docker image with ${tag}"
+    docker tag buildtemp "mozilla/balrog:${tag}"
+    echo "Pushing Docker image tagged with ${tag}"
+    docker push mozilla/balrog:${tag}
+done
 
-sha256=$(docker images --no-trunc mozilla/balrog | grep "${commit_tag}" | awk '/^mozilla/ {print $3}')
+sha256=$(docker images --no-trunc mozilla/balrog | grep "${tags[0]}" | awk '/^mozilla/ {print $3}')
 echo "SHA256 is ${sha256}, creating artifact for it"
 put_url=$(curl --retry 5 --retry-delay 5 --data "{\"storageType\": \"s3\", \"contentType\": \"text/plain\", \"expires\": \"${artifact_expiry}\"}" ${artifact_url} | python -c 'import json; import sys; print json.load(sys.stdin)["putUrl"]')
 curl --retry 5 --retry-delay 5 -X PUT -H "Content-Type: text/plain" --data "${sha256}" "${put_url}"

--- a/scripts/push-dockerimage.sh
+++ b/scripts/push-dockerimage.sh
@@ -15,7 +15,7 @@ if [ -z $dockerhub_password ]; then
     echo "Dockerhub password not set, can't continue!"
     exit 1
 fi
-if [ ${#errors[@]} -eq 0 ]; then
+if [ ${#tags[@]} -eq 0 ]; then
     echo "Must pass at least one tag"
     exit 2
 fi


### PR DESCRIPTION
After @relud got Balrog dev working yesterday I realized that it ended up picking up a new version when I created a Release tag, because the Docker build/tag script created a master-abcdef tag in addition to the "vX.Y" one. This PR fixes that by forcing callers to pass in all tag names to the Docker script and iterating over them. I think this ended up simplifying the scripts a bit too, because they no longer need to do any git repo queries to guess at branch or commits.

I verified this on https://github.com/testbhearsum/balrog/commits/master, which pushes to https://hub.docker.com/r/bhearsumtesttest/balrog/tags/ and https://hub.docker.com/r/bhearsumtesttest/balrogagent/tags/.