### PR TITLE
Don't retrieve signoffs if names_only

### DIFF
--- a/auslib/web/admin/views/releases.py
+++ b/auslib/web/admin/views/releases.py
@@ -363,9 +363,10 @@ class ReleasesAPIView(AdminView):
 
     def get(self, **kwargs):
         releases = release_list(connexion.request)
-        for release in releases:
-            requirements = dbo.releases.getPotentialRequiredSignoffs([release])
-            release['required_signoffs'] = serialize_signoff_requirements(requirements)
+        if not connexion.request.args.get('names_only'):
+            for release in releases:
+                requirements = dbo.releases.getPotentialRequiredSignoffs([release])
+                release['required_signoffs'] = serialize_signoff_requirements(requirements)
         return serialize_releases(connexion.request, releases)
 
     @requirelogin


### PR DESCRIPTION
This is meant to address
https://bugzilla.mozilla.org/show_bug.cgi?id=1408200.

I didn't write a test because I didn't think it would be possible to
functionally distinguish between the case where we did make a request
and just didn't show its information, vs. where we didn't make a
request.