### PR TITLE
bug 1402411: add support for JAWS in SYSTEM_CAPABILITIES

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1603,9 +1603,10 @@ class Rules(AUSTable):
 
     def _booleanMatchesRule(self, ruleValue, queryValue):
         """As with all other columns, if the value isn't present in the Rule, the Rule matches.
-        Unlike other columns, some boolean fields may optional in the update query, so we must handle
-        False, True, and None values explicitly. Note that None in the updateQuery is treated as "unknown",
-        i.e.: False and None are not the same thing.
+        Unlike other columns, the non-existence of a boolean field in the updateQuery evaluates
+        to False, so we need to handle True, False, and None explicitly. Note that None in the
+        updateQuery is treated as "unknown", and will cause any Rule without an explicit value
+        for the field to match.
         The full truth table is:
         rule | query | matches?
           F      0        Y
@@ -1767,8 +1768,10 @@ class Rules(AUSTable):
                 self.log.debug("%s doesn't match %s", rule['locale'], updateQuery['locale'])
                 continue
             if not self._booleanMatchesRule(rule["mig64"], updateQuery.get("mig64")):
+                self.log.debug("%s doesn't match %s", rule['mig64'], updateQuery['mig64'])
                 continue
             if not self._booleanMatchesRule(rule["jaws"], updateQuery.get("jaws")):
+                self.log.debug("%s doesn't match %s", rule['jaws'], updateQuery['jaws'])
                 continue
 
             matchingRules.append(rule)

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1492,6 +1492,7 @@ class Rules(AUSTable):
                            Column('osVersion', String(1000)),
                            Column('memory', String(100)),
                            Column('instructionSet', String(1000)),
+                           Column('jaws', CompatibleBooleanColumn),
                            Column('mig64', CompatibleBooleanColumn),
                            Column('distribution', String(100)),
                            Column('distVersion', String(100)),
@@ -1600,10 +1601,10 @@ class Rules(AUSTable):
                 return True
         return False
 
-    def _mig64MatchesRule(self, ruleMig64, queryMig64):
-        """As with all other columns, if mig64 isn't present in the Rule, the Rule matches.
-        Unlike other columns, mig64 is optional in the update query, so we must handle False,
-        True, and None values. Note that None in the updateQuery is treated as "unknown",
+    def _booleanMatchesRule(self, ruleValue, queryValue):
+        """As with all other columns, if the value isn't present in the Rule, the Rule matches.
+        Unlike other columns, some boolean fields may optional in the update query, so we must handle
+        False, True, and None values explicitly. Note that None in the updateQuery is treated as "unknown",
         i.e.: False and None are not the same thing.
         The full truth table is:
         rule | query | matches?
@@ -1619,12 +1620,12 @@ class Rules(AUSTable):
 
         Additional context in https://bugzilla.mozilla.org/show_bug.cgi?id=1386756"""
 
-        if ruleMig64 is not None:
-            if queryMig64 is None or ruleMig64 != queryMig64:
+        if ruleValue is not None:
+            if queryValue is None or ruleValue != queryValue:
                 return False
         return True
 
-    def _simpleBooleanMatchesSubRule(self, subRuleString, queryString, substring):
+    def _simpleExpressionMatchesSubRule(self, subRuleString, queryString, substring):
         """Performs the actual logical 'AND' operation on a rule as well as partial/full string matching
            for each section of a rule.
            If all parts of the subRuleString match the queryString, then we have successfully resolved the
@@ -1640,7 +1641,7 @@ class Rules(AUSTable):
                 return False
         return True
 
-    def _simpleBooleanMatchesRule(self, ruleString, queryString, substring=True):
+    def _simpleExpressionMatchesRule(self, ruleString, queryString, substring=True):
         """Decides whether a column from a rule matches an incoming one using simplified boolean logic.
            Only two operators are supported: '&&' (and), ',' (or). A rule like 'AMD,SSE' will match incoming
            rules that contain either 'AMD' or 'SSE'. A rule like 'AMD&&SSE' will only match incoming rules
@@ -1655,7 +1656,7 @@ class Rules(AUSTable):
         decomposedRules = [[rule.strip() for rule in subRule.split('&&')] for subRule in ruleString.split(',')]
 
         for subRule in decomposedRules:
-            if self._simpleBooleanMatchesSubRule(subRule, queryString, substring):
+            if self._simpleExpressionMatchesSubRule(subRule, queryString, substring):
                 # We can immediately return True on the first match because this loop is iterating over an OR expression
                 # so we need just one match to pass.
                 return True
@@ -1755,7 +1756,7 @@ class Rules(AUSTable):
             # To help keep the rules table compact, multiple OS versions may be
             # specified in a single rule. They are comma delimited, so we need to
             # break them out and create clauses for each one.
-            if not self._simpleBooleanMatchesRule(rule['osVersion'], updateQuery['osVersion']):
+            if not self._simpleExpressionMatchesRule(rule['osVersion'], updateQuery['osVersion']):
                 self.log.debug("%s doesn't match %s", rule['osVersion'], updateQuery['osVersion'])
                 continue
             if not self._csvMatchesRule(rule['instructionSet'], updateQuery.get('instructionSet', ""), substring=False):
@@ -1765,7 +1766,9 @@ class Rules(AUSTable):
             if not self._localeMatchesRule(rule['locale'], updateQuery['locale']):
                 self.log.debug("%s doesn't match %s", rule['locale'], updateQuery['locale'])
                 continue
-            if not self._mig64MatchesRule(rule["mig64"], updateQuery.get("mig64")):
+            if not self._booleanMatchesRule(rule["mig64"], updateQuery.get("mig64")):
+                continue
+            if not self._booleanMatchesRule(rule["jaws"], updateQuery.get("jaws")):
                 continue
 
             matchingRules.append(rule)

--- a/auslib/migrate/versions/030_add_jaws.py
+++ b/auslib/migrate/versions/030_add_jaws.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, MetaData, Table
+
+from auslib.db import CompatibleBooleanColumn
+
+
+def upgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+
+    jaws = Column("jaws", CompatibleBooleanColumn)
+    jaws.create(Table("rules", metadata, autoload=True))
+
+    history_jaws = Column("jaws", CompatibleBooleanColumn)
+    history_jaws.create(Table("rules_history", metadata, autoload=True))
+
+    base_jaws = Column("base_jaws", CompatibleBooleanColumn)
+    base_jaws.create(Table("rules_scheduled_changes", metadata, autoload=True))
+
+    history_base_jaws = Column("base_jaws", CompatibleBooleanColumn)
+    history_base_jaws.create(Table("rules_scheduled_changes_history", metadata, autoload=True))
+
+
+def downgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+    Table('rules', metadata, autoload=True).c.jaws.drop()
+    Table('rules_history', metadata, autoload=True).c.jaws.drop()
+    Table('rules_scheduled_changes', metadata, autoload=True).c.base_jaws.drop()
+    Table('rules_scheduled_changes_history', metadata, autoload=True).c.base_jaws.drop()

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -128,6 +128,10 @@ class ViewTest(unittest.TestCase):
             rule_id=8, product='fake2', priority=25, backgroundRate=100, mapping='a', update_type='minor', channel="c", mig64=True,
             data_version=1
         )
+        dbo.rules.t.insert().execute(
+            rule_id=9, product='fake3', priority=25, backgroundRate=100, mapping='a', update_type='minor', channel="c", jaws=True,
+            data_version=1
+        )
         self.client = app.test_client()
 
     def tearDown(self):

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1004,7 +1004,7 @@ cbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbdacbda
         self.assertEquals(ret_data, json.loads("""
 {
     "releases": [
-        {"data_version": 1, "name": "a", "product": "a", "read_only": false, "rule_ids": [3, 4, 6, 7, 8], "required_signoffs": {"releng": 1}},
+        {"data_version": 1, "name": "a", "product": "a", "read_only": false, "rule_ids": [3, 4, 6, 7, 8, 9], "required_signoffs": {"releng": 1}},
         {"data_version": 1, "name": "ab", "product": "a", "read_only": false, "rule_ids": [], "required_signoffs": {}}
     ]
 }
@@ -1694,7 +1694,7 @@ class TestRuleIdsReturned(ViewTest):
 
     def testMappingIncluded(self):
         rel_name = 'ab'
-        rule_id = 9
+        rule_id = 10
 
         releases = self._get("/releases")
         releases_data = json.loads(releases.data)

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -441,7 +441,7 @@ class TestSingleRuleView_JSON(ViewTest):
         self.assertEquals(load['new_data_version'], 2)
 
         # Assure the changes made it into the database
-        r = dbo.rules.t.select().where(dbo.rules.rule_id == 8).execute().fetchall()
+        r = dbo.rules.t.select().where(dbo.rules.rule_id == 9).execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['jaws'], None)
         self.assertEquals(r[0]['data_version'], 2)
@@ -958,8 +958,8 @@ class TestRuleHistoryView(ViewTest):
 class TestSingleColumn_JSON(ViewTest):
 
     def testGetRules(self):
-        expected_product = ["fake", "fake2", "a"]
-        expected = dict(count=3, product=expected_product)
+        expected_product = ["fake", "fake2", "fake3", "a"]
+        expected = dict(count=4, product=expected_product)
         ret = self._get("/rules/columns/product")
         returned_data = json.loads(ret.data)
         self.assertEquals(returned_data['count'], expected['count'])

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -12,7 +12,7 @@ class TestRulesAPI_JSON(ViewTest):
     def testGetRules(self):
         ret = self._get("/rules")
         got = json.loads(ret.data)
-        self.assertEquals(got["count"], 8)
+        self.assertEquals(got["count"], 9)
 
     def testGetRulesWithProductFilter(self):
         ret = self._get("/rules", qs={"product": "fake"})
@@ -23,21 +23,21 @@ class TestRulesAPI_JSON(ViewTest):
                 "update_type": "minor", "channel": "a", "data_version": 1, "comment": None, "fallbackMapping": None,
                 "version": None, "buildID": None, "locale": None, "distribution": None, "osVersion": None,
                 "instructionSet": None, "distVersion": None, "headerArchitecture": None, "alias": None,
-                "memory": None, "mig64": None,
+                "memory": None, "mig64": None, "jaws": None,
             },
             {
                 "rule_id": 6, "product": "fake", "priority": 40, "backgroundRate": 50, "mapping": "a", "update_type": "minor",
                 "channel": "e", "data_version": 1, "buildTarget": None, "comment": None, "fallbackMapping": None,
                 "version": None, "buildID": None, "locale": None, "distribution": None, "osVersion": None,
                 "instructionSet": None, "distVersion": None, "headerArchitecture": None, "alias": None,
-                "memory": None, "mig64": None,
+                "memory": None, "mig64": None, "jaws": None,
             },
             {
                 "rule_id": 7, "product": "fake", "priority": 30, "backgroundRate": 85, "mapping": "a", "update_type": "minor",
                 "channel": "c", "data_version": 1, "buildTarget": None, "comment": None, "fallbackMapping": None,
                 "version": None, "buildID": None, "locale": None, "distribution": None, "osVersion": None,
                 "instructionSet": None, "distVersion": None, "headerArchitecture": None, "alias": None,
-                "memory": None, "mig64": None,
+                "memory": None, "mig64": None, "jaws": None,
             }
         ]
         self.assertEquals(got["count"], 3)
@@ -99,6 +99,18 @@ class TestRulesAPI_JSON(ViewTest):
         self.assertEquals(r[0]['backgroundRate'], 33)
         self.assertEquals(r[0]['priority'], 0)
         self.assertEquals(r[0]['mig64'], True)
+        self.assertEquals(r[0]['data_version'], 1)
+
+    def testCreateRuleWithJaws(self):
+        ret = self._post('/rules', data=dict(backgroundRate=33, mapping='c', priority=0, jaws=True,
+                                             product='Firefox', update_type='minor', channel='nightly'))
+        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+        r = dbo.rules.t.select().where(dbo.rules.rule_id == ret.data).execute().fetchall()
+        self.assertEquals(len(r), 1)
+        self.assertEquals(r[0]['mapping'], 'c')
+        self.assertEquals(r[0]['backgroundRate'], 33)
+        self.assertEquals(r[0]['priority'], 0)
+        self.assertEquals(r[0]['jaws'], True)
         self.assertEquals(r[0]['data_version'], 1)
 
     def testVersionMaxFieldLength(self):
@@ -293,6 +305,7 @@ class TestSingleRuleView_JSON(ViewTest):
             alias=None,
             memory=None,
             mig64=None,
+            jaws=None,
         )
         self.assertEquals(json.loads(ret.data), expected)
         self.assertIn('X-CSRF-Token', ret.headers)
@@ -322,6 +335,7 @@ class TestSingleRuleView_JSON(ViewTest):
             alias="frodo",
             memory=None,
             mig64=None,
+            jaws=None,
         )
         self.assertEquals(json.loads(ret.data), expected)
 
@@ -386,6 +400,23 @@ class TestSingleRuleView_JSON(ViewTest):
         self.assertEquals(r[0]['version'], '3.5')
         self.assertEquals(r[0]['buildTarget'], 'd')
 
+    def testPostChangeToJaws(self):
+        # Make some changes to a rule
+        ret = self._post('/rules/1', data=dict(jaws=True, data_version=1))
+        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+        load = json.loads(ret.data)
+        self.assertEquals(load['new_data_version'], 2)
+
+        # Assure the changes made it into the database
+        r = dbo.rules.t.select().where(dbo.rules.rule_id == 1).execute().fetchall()
+        self.assertEquals(len(r), 1)
+        self.assertEquals(r[0]['jaws'], True)
+        self.assertEquals(r[0]['data_version'], 2)
+        # And that we didn't modify other fields
+        self.assertEquals(r[0]['update_type'], 'minor')
+        self.assertEquals(r[0]['version'], '3.5')
+        self.assertEquals(r[0]['buildTarget'], 'd')
+
     def testPostUnsetMig64(self):
         # Make some changes to a rule
         ret = self._post('/rules/8', data=dict(mig64=None, data_version=1))
@@ -397,6 +428,22 @@ class TestSingleRuleView_JSON(ViewTest):
         r = dbo.rules.t.select().where(dbo.rules.rule_id == 8).execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['mig64'], None)
+        self.assertEquals(r[0]['data_version'], 2)
+        # And that we didn't modify other fields
+        self.assertEquals(r[0]['update_type'], 'minor')
+        self.assertEquals(r[0]['priority'], 25)
+
+    def testPostUnsetJaws(self):
+        # Make some changes to a rule
+        ret = self._post('/rules/9', data=dict(jaws=None, data_version=1))
+        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+        load = json.loads(ret.data)
+        self.assertEquals(load['new_data_version'], 2)
+
+        # Assure the changes made it into the database
+        r = dbo.rules.t.select().where(dbo.rules.rule_id == 8).execute().fetchall()
+        self.assertEquals(len(r), 1)
+        self.assertEquals(r[0]['jaws'], None)
         self.assertEquals(r[0]['data_version'], 2)
         # And that we didn't modify other fields
         self.assertEquals(r[0]['update_type'], 'minor')
@@ -1039,7 +1086,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "version": "3.5", "buildTarget": "d", "backgroundRate": 100, "mapping": "b", "update_type": "minor",
                     "data_version": 1, "alias": None, "product": "a", "channel": "a", "buildID": None, "locale": None, "memory": None, "mig64": None,
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
-                    "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
+                    "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "jaws": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
                     "original_row": dbo.rules.getRule(1),
                 },
@@ -1047,21 +1094,21 @@ class TestRuleScheduledChanges(ViewTest):
                     "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
                     "backgroundRate": 100, "product": "baz", "mapping": "ab", "update_type": "minor", "version": None,
                     "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
-                    "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
+                    "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None, "jaws": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "insert", "signoffs": {}, "required_signoffs": {},
                 },
                 {
                     "sc_id": 3, "when": 2900000, "scheduled_by": "bill", "complete": False, "sc_data_version": 2, "rule_id": None, "priority": 150,
                     "backgroundRate": 100, "channel": "a", "mapping": "ghi", "update_type": "minor", "version": None, "memory": None, "mig64": None,
-                    "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None,
+                    "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "jaws": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
                     "change_type": "insert", "signoffs": {"bill": "releng", "mary": "relman"}, "required_signoffs": {"releng": 1},
                 },
                 {
                     "sc_id": 5, "when": 600000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 4, "priority": None,
-                    "backgroundRate": None, "channel": None, "mapping": None, "update_type": None, "version": None,
+                    "backgroundRate": None, "channel": None, "mapping": None, "update_type": None, "version": None, "jaws": None,
                     "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": 1, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
@@ -1070,7 +1117,7 @@ class TestRuleScheduledChanges(ViewTest):
                 },
                 {
                     "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
-                    "backgroundRate": 100, "product": "fake", "mapping": "ab", "update_type": "minor", "version": None,
+                    "backgroundRate": 100, "product": "fake", "mapping": "ab", "update_type": "minor", "version": None, "jaws": None,
                     "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
@@ -1078,7 +1125,7 @@ class TestRuleScheduledChanges(ViewTest):
                 },
                 {
                     "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
-                    "backgroundRate": 50, "product": "fake", "mapping": "a", "update_type": "minor", "version": None,
+                    "backgroundRate": 50, "product": "fake", "mapping": "a", "update_type": "minor", "version": None, "jaws": None,
                     "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
@@ -1099,13 +1146,13 @@ class TestRuleScheduledChanges(ViewTest):
                     "version": "3.5", "buildTarget": "d", "backgroundRate": 100, "mapping": "b", "update_type": "minor",
                     "data_version": 1, "alias": None, "product": "a", "channel": "a", "buildID": None, "locale": None, "memory": None, "mig64": None,
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
-                    "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
+                    "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "jaws": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
                     "original_row": dbo.rules.getRule(1),
                 },
                 {
                     "sc_id": 2, "when": 1500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 50,
-                    "backgroundRate": 100, "product": "baz", "mapping": "ab", "update_type": "minor", "version": None,
+                    "backgroundRate": 100, "product": "baz", "mapping": "ab", "update_type": "minor", "version": None, "jaws": None,
                     "buildTarget": None, "alias": None, "channel": None, "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
@@ -1113,7 +1160,7 @@ class TestRuleScheduledChanges(ViewTest):
                 },
                 {
                     "sc_id": 3, "when": 2900000, "scheduled_by": "bill", "complete": False, "sc_data_version": 2, "rule_id": None, "priority": 150,
-                    "backgroundRate": 100, "channel": "a", "mapping": "ghi", "update_type": "minor", "version": None,
+                    "backgroundRate": 100, "channel": "a", "mapping": "ghi", "update_type": "minor", "version": None, "jaws": None,
                     "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
@@ -1124,13 +1171,13 @@ class TestRuleScheduledChanges(ViewTest):
                     "version": "3.3", "buildTarget": "d", "backgroundRate": 0, "mapping": "c", "update_type": "minor",
                     "data_version": 1, "alias": None, "product": None, "channel": None, "buildID": None, "locale": None, "memory": None, "mig64": None,
                     "osVersion": None, "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
-                    "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
+                    "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "jaws": None,
                     "change_type": "update", "signoffs": {}, "required_signoffs": {},
                     # No original row on "complete"
                 },
                 {
                     "sc_id": 5, "when": 600000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 4, "priority": None,
-                    "backgroundRate": None, "channel": None, "mapping": None, "update_type": None, "version": None,
+                    "backgroundRate": None, "channel": None, "mapping": None, "update_type": None, "version": None, "jaws": None,
                     "buildTarget": None, "alias": None, "product": None, "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": 1, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
@@ -1139,7 +1186,7 @@ class TestRuleScheduledChanges(ViewTest):
                 },
                 {
                     "sc_id": 6, "when": 5500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": None, "priority": 100,
-                    "backgroundRate": 100, "product": "fake", "mapping": "ab", "update_type": "minor", "version": None,
+                    "backgroundRate": 100, "product": "fake", "mapping": "ab", "update_type": "minor", "version": None, "jaws": None,
                     "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
@@ -1147,7 +1194,7 @@ class TestRuleScheduledChanges(ViewTest):
                 },
                 {
                     "sc_id": 7, "when": 7500000, "scheduled_by": "bill", "complete": False, "sc_data_version": 1, "rule_id": 6, "priority": 40,
-                    "backgroundRate": 50, "product": "fake", "mapping": "a", "update_type": "minor", "version": None,
+                    "backgroundRate": 50, "product": "fake", "mapping": "a", "update_type": "minor", "version": None, "jaws": None,
                     "buildTarget": None, "alias": None, "channel": "k", "buildID": None, "locale": None, "osVersion": None, "memory": None, "mig64": None,
                     "distribution": None, "fallbackMapping": None, "distVersion": None, "headerArchitecture": None, "comment": None,
                     "data_version": None, "instructionSet": None, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
@@ -1176,7 +1223,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_mapping": "c", "base_update_type": "minor", "base_data_version": 1, "data_version": 1, "sc_id": 8, "complete": False, "base_alias": None,
             "base_product": None, "base_channel": None, "base_buildID": None, "base_locale": None, "base_osVersion": None, "base_distribution": None,
             "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None, "base_memory": None,
-            "base_mig64": None, "base_instructionSet": None, "change_type": "update",
+            "base_mig64": None, "base_instructionSet": None, "base_jaws": None, "change_type": "update",
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
@@ -1201,7 +1248,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_mapping": None, "base_update_type": None, "base_data_version": 1, "data_version": 1, "sc_id": 8, "complete": False, "base_alias": None,
             "base_product": None, "base_channel": None, "base_buildID": None, "base_locale": None, "base_osVersion": None, "base_distribution": None,
             "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None, "base_memory": None,
-            "base_mig64": None, "base_instructionSet": None, "change_type": "delete",
+            "base_mig64": None, "base_instructionSet": None, "base_jaws": None, "change_type": "delete",
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
@@ -1227,7 +1274,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_update_type": "minor", "base_mapping": "a", "sc_id": 8, "data_version": 1, "complete": False, "base_data_version": None,
             "base_rule_id": None, "base_buildTarget": None, "base_version": None, "base_alias": None, "base_buildID": None, "base_locale": None,
             "base_osVersion": None, "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None, "base_headerArchitecture": None,
-            "base_comment": None, "base_instructionSet": None, "change_type": "insert", "base_memory": None, "base_mig64": None,
+            "base_comment": None, "base_instructionSet": None, "change_type": "insert", "base_memory": None, "base_mig64": None, "base_jaws": None,
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
@@ -1341,7 +1388,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_product": "a", "base_channel": "a", "base_buildID": None, "base_locale": None, "base_osVersion": None,
             "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None,
             "base_headerArchitecture": None, "base_comment": None, "base_instructionSet": None, "base_memory": "888",
-            "base_mig64": None, "change_type": "update",
+            "base_mig64": None, "base_jaws": None, "change_type": "update",
         }
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 1).execute().fetchall()
@@ -1370,6 +1417,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_alias": None, "base_product": "a", "base_channel": "a", "base_buildID": None, "base_locale": None,
             "base_osVersion": None, "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None, "base_memory": None,
             "base_mig64": None, "base_headerArchitecture": None, "base_comment": None, "base_instructionSet": None, "change_type": "update",
+            "base_jaws": None,
         }
         self.assertEquals(db_data, expected)
 
@@ -1413,7 +1461,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_channel": "a", "base_buildID": None, "base_locale": None, "base_osVersion": None,
             "base_product": None, "base_data_version": None, "base_alias": None,
             "base_distribution": None, "base_fallbackMapping": None, "base_distVersion": None,
-            "base_headerArchitecture": None, "base_comment": None, "base_memory": None, "base_mig64": None,
+            "base_headerArchitecture": None, "base_comment": None, "base_memory": None, "base_mig64": None, "base_jaws": None,
             "base_instructionSet": None, "base_version": None, "base_rule_id": None, "base_buildTarget": None,
             "change_type": "insert",
         }
@@ -1472,7 +1520,7 @@ class TestRuleScheduledChanges(ViewTest):
             "rule_id": 1, "priority": 100, "version": "3.5", "buildTarget": "d", "backgroundRate": 100, "mapping": "b", "fallbackMapping": None,
             "update_type": "minor", "data_version": 2, "alias": None, "product": "a", "channel": "a", "buildID": None,
             "locale": None, "osVersion": None, "distribution": None, "distVersion": None, "headerArchitecture": None,
-            "comment": None, "instructionSet": None, "memory": None, "mig64": None,
+            "comment": None, "instructionSet": None, "memory": None, "mig64": None, "jaws": None,
         }
         self.assertEquals(dict(row), expected)
 
@@ -1483,12 +1531,12 @@ class TestRuleScheduledChanges(ViewTest):
         sc_row = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 2).execute().fetchall()[0]
         self.assertEquals(sc_row["complete"], True)
 
-        row = dbo.rules.t.select().where(dbo.rules.rule_id == 9).execute().fetchall()[0]
+        row = dbo.rules.t.select().where(dbo.rules.rule_id == 10).execute().fetchall()[0]
         expected = {
-            "rule_id": 9, "priority": 50, "version": None, "buildTarget": None, "backgroundRate": 100, "mapping": "ab", "fallbackMapping": None,
+            "rule_id": 10, "priority": 50, "version": None, "buildTarget": None, "backgroundRate": 100, "mapping": "ab", "fallbackMapping": None,
             "update_type": "minor", "data_version": 1, "alias": None, "product": "baz", "channel": None, "buildID": None,
             "locale": None, "osVersion": None, "distribution": None, "distVersion": None, "headerArchitecture": None,
-            "comment": None, "instructionSet": None, "memory": None, "mig64": None,
+            "comment": None, "instructionSet": None, "memory": None, "mig64": None, "jaws": None,
         }
         self.assertEquals(dict(row), expected)
 
@@ -1508,7 +1556,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "complete": False, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "rule_id": None,
                     "version": None, "product": None, "buildTarget": None, "buildID": None, "locale": None,
                     "osVersion": None, "instructionSet": None, "distribution": None, "distVersion": None, "memory": None, "mig64": None,
-                    "headerArchitecture": None, "comment": None, "alias": None, "data_version": None, "change_type": "insert",
+                    "jaws": None, "headerArchitecture": None, "comment": None, "alias": None, "data_version": None, "change_type": "insert",
                 },
                 {
                     "change_id": 2, "changed_by": "bill", "timestamp": 6, "sc_id": 3, "scheduled_by": "bill", "when": 2000000, "sc_data_version": 1,
@@ -1516,7 +1564,7 @@ class TestRuleScheduledChanges(ViewTest):
                     "complete": False, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "rule_id": None,
                     "version": None, "product": None, "buildTarget": None, "buildID": None, "locale": None,
                     "osVersion": None, "instructionSet": None, "distribution": None, "distVersion": None, "memory": None, "mig64": None,
-                    "headerArchitecture": None, "comment": None, "alias": None, "data_version": None, "change_type": "insert",
+                    "jaws": None, "headerArchitecture": None, "comment": None, "alias": None, "data_version": None, "change_type": "insert",
                 },
             ],
         }
@@ -1536,7 +1584,7 @@ class TestRuleScheduledChanges(ViewTest):
             "base_backgroundRate": 100, "base_channel": "a", "base_mapping": "def", "base_update_type": "minor", "base_version": None,
             "base_buildTarget": None, "base_alias": None, "base_product": None, "base_buildID": None, "base_locale": None, "base_osVersion": None,
             "base_distribution": None, 'base_fallbackMapping': None, "base_distVersion": None, "base_headerArchitecture": None, "base_comment": None,
-            "base_data_version": None, "base_instructionSet": None, "base_memory": None, "base_mig64": None, "change_type": "insert",
+            "base_data_version": None, "base_instructionSet": None, "base_memory": None, "base_mig64": None, "base_jaws": None, "change_type": "insert",
         }
         self.assertEquals(db_data, expected)
         self.assertEquals(dbo.rules.scheduled_changes.conditions.history.t.count().execute().first()[0], 16)

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -1913,7 +1913,7 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         expected = ["rule_id", "alias", "priority", "mapping", "fallbackMapping", "backgroundRate", "update_type",
                     "product", "version", "channel", "buildTarget", "buildID", "locale", "osVersion",
                     "instructionSet", "distribution", "distVersion", "headerArchitecture", "comment",
-                    "data_version", "memory", "mig64"]
+                    "data_version", "memory", "mig64", "jaws"]
         sc_expected = ["base_{}".format(c) for c in expected]
         self.assertEquals(set(columns), set(expected))
         # No need to test the non-base parts of history nor scheduled changes table
@@ -2294,6 +2294,146 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
 
     def testGetNumberOfRules(self):
         self.assertEquals(self.paths.countRules(), 10)
+
+
+class TestJawsRules(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
+
+    def setUp(self):
+        MemoryDatabaseMixin.setUp(self)
+        self.db = AUSDatabase(self.dburi)
+        self.db.create()
+        self.rules = self.db.rules
+        self.rules.t.insert().execute(rule_id=1, priority=90, mapping="myes", backgroundRate=100, jaws=True,
+                                      update_type="z", product="mm", channel="mm", data_version=1)
+        self.rules.t.insert().execute(rule_id=2, priority=100, mapping="mno", backgroundRate=100, jaws=False,
+                                      update_type="z", product="nn", channel="nn", data_version=1)
+
+        self.rules.t.insert().execute(rule_id=3, priority=110, mapping="anything", backgroundRate=100,
+                                      update_type="z", product="oo", channel="oo", data_version=1)
+
+    def testRuleFalseQueryFalse(self):
+        rules = self.rules.getRulesMatchingQuery(
+            dict(product="nn", version='53.0', channel="nn",
+                 buildTarget='d', buildID='', locale='', osVersion='',
+                 distribution='', distVersion='', headerArchitecture='',
+                 queryVersion=3, jaws=False, force=False,
+                 ),
+            fallbackChannel=''
+        )
+        rules = self._stripNullColumns(rules)
+        expected = [
+            dict(rule_id=2, priority=100, mapping="mno", backgroundRate=100, jaws=False, update_type="z",
+                 product="nn", channel="nn", data_version=1),
+        ]
+        self.assertEquals(rules, expected)
+
+    def testRuleFalseQueryTrue(self):
+        rules = self.rules.getRulesMatchingQuery(
+            dict(product="nn", version='53.0', channel="nn",
+                 buildTarget='d', buildID='', locale='', osVersion='',
+                 distribution='', distVersion='', headerArchitecture='',
+                 queryVersion=3, jaws=True, force=False,
+                 ),
+            fallbackChannel=''
+        )
+        self.assertEquals(rules, [])
+
+    def testRuleFalseQueryNull(self):
+        rules = self.rules.getRulesMatchingQuery(
+            dict(product="nn", version='53.0', channel="nn",
+                 buildTarget='d', buildID='', locale='', osVersion='',
+                 distribution='', distVersion='', headerArchitecture='',
+                 queryVersion=3, jaws=None, force=False,
+                 ),
+            fallbackChannel=''
+        )
+        self.assertEquals(rules, [])
+
+    def testRuleTrueQueryFalse(self):
+        rules = self.rules.getRulesMatchingQuery(
+            dict(product="mm", version='53.0', channel="mm",
+                 buildTarget='d', buildID='', locale='', osVersion='',
+                 distribution='', distVersion='', headerArchitecture='',
+                 queryVersion=3, jaws=False, force=False,
+                 ),
+            fallbackChannel=''
+        )
+        self.assertEquals(rules, [])
+
+    def testRuleTrueQueryTrue(self):
+        rules = self.rules.getRulesMatchingQuery(
+            dict(product="mm", version='53.0', channel="mm",
+                 buildTarget='d', buildID='', locale='', osVersion='',
+                 distribution='', distVersion='', headerArchitecture='',
+                 queryVersion=3, jaws=True, force=False,
+                 ),
+            fallbackChannel=''
+        )
+        rules = self._stripNullColumns(rules)
+        expected = [
+            dict(rule_id=1, priority=90, mapping="myes", backgroundRate=100, jaws=True, update_type="z",
+                 product="mm", channel="mm", data_version=1),
+        ]
+        self.assertEquals(rules, expected)
+
+    def testRuleTrueQueryNull(self):
+        rules = self.rules.getRulesMatchingQuery(
+            dict(product="mm", version='53.0', channel="mm",
+                 buildTarget='d', buildID='', locale='', osVersion='',
+                 distribution='', distVersion='', headerArchitecture='',
+                 queryVersion=3, jaws=None, force=False,
+                 ),
+            fallbackChannel=''
+        )
+        self.assertEquals(rules, [])
+
+    def testRuleNullQueryFalse(self):
+        rules = self.rules.getRulesMatchingQuery(
+            dict(product="oo", version='53.0', channel="oo",
+                 buildTarget='d', buildID='', locale='', osVersion='',
+                 distribution='', distVersion='', headerArchitecture='',
+                 queryVersion=3, jaws=False, force=False,
+                 ),
+            fallbackChannel=''
+        )
+        rules = self._stripNullColumns(rules)
+        expected = [
+            dict(rule_id=3, priority=110, mapping="anything", backgroundRate=100, update_type="z",
+                 product="oo", channel="oo", data_version=1),
+        ]
+        self.assertEquals(rules, expected)
+
+    def testRuleNullQueryTrue(self):
+        rules = self.rules.getRulesMatchingQuery(
+            dict(product="oo", version='53.0', channel="oo",
+                 buildTarget='d', buildID='', locale='', osVersion='',
+                 distribution='', distVersion='', headerArchitecture='',
+                 queryVersion=3, jaws=True, force=False,
+                 ),
+            fallbackChannel=''
+        )
+        rules = self._stripNullColumns(rules)
+        expected = [
+            dict(rule_id=3, priority=110, mapping="anything", backgroundRate=100, update_type="z",
+                 product="oo", channel="oo", data_version=1),
+        ]
+        self.assertEquals(rules, expected)
+
+    def testRuleNullQueryNull(self):
+        rules = self.rules.getRulesMatchingQuery(
+            dict(product="oo", version='53.0', channel="oo",
+                 buildTarget='d', buildID='', locale='', osVersion='',
+                 distribution='', distVersion='', headerArchitecture='',
+                 queryVersion=3, jaws=None, force=False,
+                 ),
+            fallbackChannel=''
+        )
+        rules = self._stripNullColumns(rules)
+        expected = [
+            dict(rule_id=3, priority=110, mapping="anything", backgroundRate=100, update_type="z",
+                 product="oo", channel="oo", data_version=1),
+        ]
+        self.assertEquals(rules, expected)
 
 
 class TestMig64Rules(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
@@ -4753,6 +4893,22 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
             for table_name in base_mig64_tables:
                 self.assertNotIn("base_mig64", metadata.tables[table_name].c)
 
+    def _add_jaws_test(self, db, upgrade=True):
+        metadata = self._get_reflected_metadata(db)
+        jaws_tables = ["rules", "rules_history"]
+        base_jaws_tables = ["rules_scheduled_changes", "rules_scheduled_changes_history"]
+
+        if upgrade:
+            for table_name in jaws_tables:
+                self.assertIn("jaws", metadata.tables[table_name].c)
+            for table_name in base_jaws_tables:
+                self.assertIn("base_jaws", metadata.tables[table_name].c)
+        else:
+            for table_name in jaws_tables:
+                self.assertNotIn("jaws", metadata.tables[table_name].c)
+            for table_name in base_jaws_tables:
+                self.assertNotIn("base_jaws", metadata.tables[table_name].c)
+
     def _fix_column_attributes_migration_test(self, db, upgrade=True):
         """
         Tests the upgrades and downgrades for version 22 work properly.
@@ -4805,6 +4961,7 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
             pass
 
         versions_migrate_tests_dict = {
+            29: self._add_jaws_test,
             28: self._add_mig64_test,
             27: self._remove_systemCapabilities_test,
             26: self._add_instructionSet_test,

--- a/auslib/test/web/api/test_rules.py
+++ b/auslib/test/web/api/test_rules.py
@@ -40,7 +40,8 @@ class TestPublicRulesAPI(CommonTestBase):
                         channel=None, comment=None, distVersion=None,
                         distribution=None, fallbackMapping=None,
                         headerArchitecture=None, locale=None, version=None,
-                        osVersion=None, memory=None, instructionSet=None, mig64=None)
+                        osVersion=None, memory=None, instructionSet=None, mig64=None,
+                        jaws=None)
         ret = self.public_client.get("/api/v1/rules/moz-releng")
         self.assertEqual(ret.status_code, 200, ret.data)
         got = json.loads(ret.data)

--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -28,25 +28,31 @@ class TestGetSystemCapabilities(unittest.TestCase):
     def testUnprefixedInstructionSetOnly(self):
         self.assertEquals(
             client_api.getSystemCapabilities("SSE3"),
-            {"instructionSet": "SSE3", "memory": None}
+            {"instructionSet": "SSE3", "memory": None, "jaws": None}
         )
 
     def testUnprefixedInstructionSetAndMemory(self):
         self.assertEquals(
             client_api.getSystemCapabilities("SSE3,8095"),
-            {"instructionSet": "SSE3", "memory": 8095}
+            {"instructionSet": "SSE3", "memory": 8095, "jaws": None}
         )
 
     def testPrefixedInstructionSetAndMemory(self):
         self.assertEquals(
             client_api.getSystemCapabilities("ISET:SSE2,MEM:6321"),
-            {"instructionSet": "SSE2", "memory": 6321}
+            {"instructionSet": "SSE2", "memory": 6321, "jaws": None}
+        )
+
+    def testPrefixedInstructionSetMemoryAndJaws(self):
+        self.assertEquals(
+            client_api.getSystemCapabilities("ISET:SSE2,MEM:6321,JAWS:1"),
+            {"instructionSet": "SSE2", "memory": 6321, "jaws": True}
         )
 
     def testNothingProvided(self):
         self.assertEquals(
             client_api.getSystemCapabilities("NA"),
-            {"instructionSet": "NA", "memory": None}
+            {"instructionSet": "NA", "memory": None, "jaws": None}
         )
 
     def testNonIntegerMemory(self):
@@ -55,7 +61,7 @@ class TestGetSystemCapabilities(unittest.TestCase):
     def testUnknownField(self):
         self.assertEquals(
             client_api.getSystemCapabilities("ISET:SSE3,MEM:6721,PROC:Intel"),
-            {"instructionSet": "SSE3", "memory": 6721}
+            {"instructionSet": "SSE3", "memory": 6721, "jaws": None}
         )
 
 
@@ -1223,7 +1229,7 @@ class ClientTestJaws(ClientTestCommon):
         self.assertUpdatesAreEmpty(ret)
 
     def testRuleFalseQueryFalse(self):
-        ret = self.client.get("/update/6/c/1.0/2/p/l/a/a/JAWS:0/a/a/update.xml")
+        ret = self.client.get("/update/6/c/1.0/2/p/l/a/a/ISET:SSE3,MEM:8096,JAWS:0/a/a/update.xml")
         self.assertUpdateEqual(ret, """<?xml version="1.0"?>
 <updates>
     <update type="minor" version="3.0" extensionVersion="3.0" buildID="22">
@@ -1237,7 +1243,7 @@ class ClientTestJaws(ClientTestCommon):
         self.assertUpdatesAreEmpty(ret)
 
     def testRuleTrueQueryTrue(self):
-        ret = self.client.get("/update/6/b/1.0/2/p/l/a/a/JAWS:1/a/a/update.xml")
+        ret = self.client.get("/update/6/b/1.0/2/p/l/a/a/ISET:SSE3,MEM:8096,JAWS:1/a/a/update.xml")
         self.assertUpdateEqual(ret, """<?xml version="1.0"?>
 <updates>
     <update type="minor" version="2.0" extensionVersion="2.0" buildID="12">
@@ -1247,7 +1253,7 @@ class ClientTestJaws(ClientTestCommon):
 """)
 
     def testRuleTrueQueryFalse(self):
-        ret = self.client.get("/update/6/b/1.0/2/p/l/a/a/a/JAWS:0/a/a/update.xml")
+        ret = self.client.get("/update/6/b/1.0/2/p/l/a/a/ISET:SSE3,MEM:8096,JAWS:0/a/a/update.xml")
         self.assertUpdatesAreEmpty(ret)
 
     def testRuleNullQueryNull(self):
@@ -1261,7 +1267,7 @@ class ClientTestJaws(ClientTestCommon):
 """)
 
     def testRuleNullQueryTrue(self):
-        ret = self.client.get("/update/6/a/1.0/1/p/l/a/a/JAWS:1/a/a/update.xml")
+        ret = self.client.get("/update/6/a/1.0/1/p/l/a/a/ISET:SSE3,MEM:8096,JAWS:1/a/a/update.xml")
         self.assertUpdateEqual(ret, """<?xml version="1.0"?>
 <updates>
     <update type="minor" version="1.0" extensionVersion="1.0" buildID="2">
@@ -1271,7 +1277,7 @@ class ClientTestJaws(ClientTestCommon):
 """)
 
     def testRuleNullQueryFalse(self):
-        ret = self.client.get("/update/6/a/1.0/1/p/l/a/a/JAWS:0/a/a/update.xml")
+        ret = self.client.get("/update/6/a/1.0/1/p/l/a/a/ISET:SSE3,MEM:8096,JAWS:0/a/a/update.xml")
         self.assertUpdateEqual(ret, """<?xml version="1.0"?>
 <updates>
     <update type="minor" version="1.0" extensionVersion="1.0" buildID="2">

--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -1120,7 +1120,7 @@ class ClientTestMig64(ClientTestCommon):
 
 class ClientTestJaws(ClientTestCommon):
     """Tests the expected real world scenarios for the JAWS parameter in
-    SYSTEM_REQUIREMENTS."""
+    SYSTEM_CAPABILITIES."""
 
     @classmethod
     def setUpClass(cls):

--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -1112,6 +1112,175 @@ class ClientTestMig64(ClientTestCommon):
 """)
 
 
+class ClientTestJaws(ClientTestCommon):
+    """Tests the expected real world scenarios for the JAWS parameter in
+    SYSTEM_REQUIREMENTS."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Error handlers are removed in order to give us better debug messages
+        cls.error_spec = app.error_handler_spec
+        # Ripped from https://github.com/mitsuhiko/flask/blob/1f5927eee2288b4aaf508af5dc1f148aa2140d91/flask/app.py#L394
+        app.error_handler_spec = {None: {}}
+
+    @classmethod
+    def tearDownClass(cls):
+        app.error_handler_spec = cls.error_spec
+
+    def setUp(self):
+        app.config["DEBUG"] = True
+        app.config["SPECIAL_FORCE_HOSTS"] = ("http://a.com",)
+        app.config["WHITELISTED_DOMAINS"] = {"a.com": ("a", "b", "c")}
+        dbo.setDb("sqlite:///:memory:")
+        dbo.create()
+        self.client = app.test_client()
+        dbo.setDomainWhitelist({"a.com": ("a", "b", "c")})
+        dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping="a", update_type="minor", product="a",
+                                     data_version=1)
+        dbo.releases.t.insert().execute(name="a", product="a", data_version=1, data=createBlob("""
+{
+    "name": "a",
+    "schema_version": 1,
+    "appv": "1.0",
+    "extv": "1.0",
+    "hashFunction": "sha512",
+    "platforms": {
+        "p": {
+            "buildID": "2",
+            "locales": {
+                "l": {
+                    "complete": {
+                        "filesize": "3",
+                        "from": "*",
+                        "hashValue": "4",
+                        "fileUrl": "http://a.com/z"
+                    }
+                }
+            }
+        }
+    }
+}
+"""))
+        dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping="b", update_type="minor", product="b",
+                                     jaws=True, data_version=1)
+        dbo.releases.t.insert().execute(name="b", product="b", data_version=1, data=createBlob("""
+{
+    "name": "b",
+    "schema_version": 1,
+    "appv": "2.0",
+    "extv": "2.0",
+    "hashFunction": "sha512",
+    "platforms": {
+        "p": {
+            "buildID": "12",
+            "locales": {
+                "l": {
+                    "complete": {
+                        "filesize": "13",
+                        "from": "*",
+                        "hashValue": "14",
+                        "fileUrl": "http://a.com/z1"
+                    }
+                }
+            }
+        }
+    }
+}
+"""))
+        dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping="c", update_type="minor", product="c",
+                                     jaws=False, data_version=1)
+        dbo.releases.t.insert().execute(name="c", product="c", data_version=1, data=createBlob("""
+{
+    "name": "c",
+    "schema_version": 1,
+    "appv": "3.0",
+    "extv": "3.0",
+    "hashFunction": "sha512",
+    "platforms": {
+        "p": {
+            "buildID": "22",
+            "locales": {
+                "l": {
+                    "complete": {
+                        "filesize": "23",
+                        "from": "*",
+                        "hashValue": "24",
+                        "fileUrl": "http://a.com/z2"
+                    }
+                }
+            }
+        }
+    }
+}
+"""))
+
+    def testRuleFalseQueryNull(self):
+        ret = self.client.get("/update/6/c/1.0/2/p/l/a/a/a/a/a/update.xml")
+        self.assertUpdatesAreEmpty(ret)
+
+    def testRuleFalseQueryTrue(self):
+        ret = self.client.get("/update/6/c/1.0/2/p/l/a/a/JAWS:1/a/a/update.xml")
+        self.assertUpdatesAreEmpty(ret)
+
+    def testRuleFalseQueryFalse(self):
+        ret = self.client.get("/update/6/c/1.0/2/p/l/a/a/JAWS:0/a/a/update.xml")
+        self.assertUpdateEqual(ret, """<?xml version="1.0"?>
+<updates>
+    <update type="minor" version="3.0" extensionVersion="3.0" buildID="22">
+        <patch type="complete" URL="http://a.com/z2" hashFunction="sha512" hashValue="24" size="23"/>
+    </update>
+</updates>
+""")
+
+    def testRuleTrueQueryNull(self):
+        ret = self.client.get("/update/6/b/1.0/2/p/l/a/a/a/a/a/update.xml")
+        self.assertUpdatesAreEmpty(ret)
+
+    def testRuleTrueQueryTrue(self):
+        ret = self.client.get("/update/6/b/1.0/2/p/l/a/a/JAWS:1/a/a/update.xml")
+        self.assertUpdateEqual(ret, """<?xml version="1.0"?>
+<updates>
+    <update type="minor" version="2.0" extensionVersion="2.0" buildID="12">
+        <patch type="complete" URL="http://a.com/z1" hashFunction="sha512" hashValue="14" size="13"/>
+    </update>
+</updates>
+""")
+
+    def testRuleTrueQueryFalse(self):
+        ret = self.client.get("/update/6/b/1.0/2/p/l/a/a/a/JAWS:0/a/a/update.xml")
+        self.assertUpdatesAreEmpty(ret)
+
+    def testRuleNullQueryNull(self):
+        ret = self.client.get("/update/6/a/1.0/1/p/l/a/a/a/a/a/update.xml")
+        self.assertUpdateEqual(ret, """<?xml version="1.0"?>
+<updates>
+    <update type="minor" version="1.0" extensionVersion="1.0" buildID="2">
+        <patch type="complete" URL="http://a.com/z" hashFunction="sha512" hashValue="4" size="3"/>
+    </update>
+</updates>
+""")
+
+    def testRuleNullQueryTrue(self):
+        ret = self.client.get("/update/6/a/1.0/1/p/l/a/a/JAWS:1/a/a/update.xml")
+        self.assertUpdateEqual(ret, """<?xml version="1.0"?>
+<updates>
+    <update type="minor" version="1.0" extensionVersion="1.0" buildID="2">
+        <patch type="complete" URL="http://a.com/z" hashFunction="sha512" hashValue="4" size="3"/>
+    </update>
+</updates>
+""")
+
+    def testRuleNullQueryFalse(self):
+        ret = self.client.get("/update/6/a/1.0/1/p/l/a/a/JAWS:0/a/a/update.xml")
+        self.assertUpdateEqual(ret, """<?xml version="1.0"?>
+<updates>
+    <update type="minor" version="1.0" extensionVersion="1.0" buildID="2">
+        <patch type="complete" URL="http://a.com/z" hashFunction="sha512" hashValue="4" size="3"/>
+    </update>
+</updates>
+""")
+
+
 class ClientTestWithErrorHandlers(ClientTestCommon):
     """Most of the tests are run without the error handler because it gives more
        useful output when things break. However, we still need to test that our

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -1754,6 +1754,7 @@ paths:
                   fallbackMapping: null
                   headerArchitecture: null
                   instructionSet: null
+                  jaws: null
                   locale: null
                   mapping: "Firefox-45.7.0esr-build1"
                   memory: null
@@ -3861,6 +3862,7 @@ definitions:
       - fallbackMapping
       - headerArchitecture
       - instructionSet
+      - jaws
       - locale
       - mapping
       - memory

--- a/auslib/web/common/swagger/definitions.yml
+++ b/auslib/web/common/swagger/definitions.yml
@@ -325,7 +325,7 @@ definitions:
         example: true
 
       jaws:
-        description: Whether or not the Rule should apply to queries that indicate an incompatible version of the JAWS screen reader. If set to false or true, the query and the rule must match precisely. If set to null, the jaws value in the updateQuery is ignored.
+        description: Whether or not the Rule should apply to queries that indicate a client that has an incompatible version of the JAWS screen reader installed. If set to false or true, the query and the rule must match precisely. If set to null, the jaws value in the updateQuery is ignored.
         type: ["boolean", "null"]
         example: true
 

--- a/auslib/web/common/swagger/definitions.yml
+++ b/auslib/web/common/swagger/definitions.yml
@@ -325,7 +325,7 @@ definitions:
         example: true
 
       jaws:
-        description: Whether or not the Rule should apply to queries that specify their JAWS screen reader incompatibility status. If set to false or true, the query and the rule must match precisely. If set to null, the jaws value in the updateQuery is ignored.
+        description: Whether or not the Rule should apply to queries that are incompatible with the JAWS screen reader. If set to false or true, the query and the rule must match precisely. If set to null, the jaws value in the updateQuery is ignored.
         type: ["boolean", "null"]
         example: true
 

--- a/auslib/web/common/swagger/definitions.yml
+++ b/auslib/web/common/swagger/definitions.yml
@@ -324,6 +324,11 @@ definitions:
         type: ["boolean", "null"]
         example: true
 
+      jaws:
+        description: Whether or not the Rule should apply to queries that specify their JAWS screen reader incompatibility status. If set to false or true, the query and the rule must match precisely. If set to null, the jaws value in the updateQuery is ignored.
+        type: ["boolean", "null"]
+        example: true
+
   RuleObject:
     title: GET Operations on Rules
     description: "Operations on /rules GET"
@@ -343,6 +348,7 @@ definitions:
       - fallbackMapping
       - headerArchitecture
       - instructionSet
+      - jaws
       - locale
       - mapping
       - memory
@@ -382,6 +388,7 @@ definitions:
                 fallbackMapping: null
                 headerArchitecture: null
                 instructionSet: null
+                jaws: null
                 locale: null
                 mapping: "Firefox-45.7.0esr-build1"
                 memory: null

--- a/auslib/web/common/swagger/definitions.yml
+++ b/auslib/web/common/swagger/definitions.yml
@@ -325,7 +325,7 @@ definitions:
         example: true
 
       jaws:
-        description: Whether or not the Rule should apply to queries that are incompatible with the JAWS screen reader. If set to false or true, the query and the rule must match precisely. If set to null, the jaws value in the updateQuery is ignored.
+        description: Whether or not the Rule should apply to queries that indicate an incompatible version of the JAWS screen reader. If set to false or true, the query and the rule must match precisely. If set to null, the jaws value in the updateQuery is ignored.
         type: ["boolean", "null"]
         example: true
 

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -28,7 +28,7 @@ def getHeaderArchitecture(buildTarget, ua):
 def getSystemCapabilities(systemCapabilities):
     # Set defaults for the broken-down fields, because not all query versions
     # will have all values.
-    caps = {"instructionSet": None, "memory": None}
+    caps = {"instructionSet": None, "memory": None, "jaws": None}
     # New-style SYSTEM_CAPABILITIES, as implemented in https://bugzilla.mozilla.org/show_bug.cgi?id=1373367
     if systemCapabilities.startswith("ISET:"):
         for part in systemCapabilities.split(","):
@@ -37,7 +37,9 @@ def getSystemCapabilities(systemCapabilities):
                 caps["instructionSet"] = value
             elif key == "MEM":
                 caps["memory"] = int(value)
-    # Old-style, unprefixed SYSTEM_CAPABILITIES
+            elif key == "JAWS":
+                caps["jaws"] = bool(int(value))
+    # Old-style, unprefixed SYSTEM_CAPABILITIES. Only supports instructionSet and memory.
     else:
         parts = systemCapabilities.split(",")
         # The only known valid formats for this field are either a single part,

--- a/auslib/web/public/swagger/public_api_spec.yml
+++ b/auslib/web/public/swagger/public_api_spec.yml
@@ -279,6 +279,7 @@ paths:
                   fallbackMapping: null
                   headerArchitecture: null
                   instructionSet: null
+                  jaws: null
                   locale: null
                   mapping: "Firefox-45.7.0esr-build1"
                   memory: null

--- a/docs/source/admin_api.rst
+++ b/docs/source/admin_api.rst
@@ -56,7 +56,6 @@ The following parameters are supported:
 -   buildTarget
 -   osVersion
 -   distVersion
--   whitelist
 -   comment
 -   headerArchitecture
 
@@ -99,7 +98,6 @@ The following parameters are supported:
 -   buildTarget
 -   osVersion
 -   distVersion
--   whitelist
 -   comment
 -   headerArchitecture
 

--- a/docs/source/database.rst
+++ b/docs/source/database.rst
@@ -106,9 +106,9 @@ Following tables show columns according to different Categories:
   |                        |                    |                                                  | one against                     |                            |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
   |                        | jaws               | Whether or not the the Rule should apply to      | Exact match only                | True, False, or NULL       |
-  |                        |                    | queries that are incompatible with the JAWS      |                                 |                            |
-  |                        |                    | screen reader. If set to True or False the Rule  |                                 |                            |
-  |                        |                    | and the query must match precisely.              |                                 |                            |
+  |                        |                    | queries that indicate an imcompatible version of |                                 |                            |
+  |                        |                    | the JAWS screen reader. If Set to True or False  |                                 |                            |
+  |                        |                    | the Rule and the query must match precisely.     |                                 |                            |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
   |                        | mig64              | Whether or not the Rule should apply to queries  | Exact match only                | True, False, or NULL       |
   |                        |                    | that have opted into 32 -> 64-bit migration.     |                                 |                            |

--- a/docs/source/database.rst
+++ b/docs/source/database.rst
@@ -106,9 +106,10 @@ Following tables show columns according to different Categories:
   |                        |                    |                                                  | one against                     |                            |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
   |                        | jaws               | Whether or not the the Rule should apply to      | Exact match only                | True, False, or NULL       |
-  |                        |                    | queries that indicate an imcompatible version of |                                 |                            |
-  |                        |                    | the JAWS screen reader. If Set to True or False  |                                 |                            |
-  |                        |                    | the Rule and the query must match precisely.     |                                 |                            |
+  |                        |                    | queries that indicate a client thas has an       |                                 |                            |
+  |                        |                    | incompatible version of the JAWS screen reader   |                                 |                            |
+  |                        |                    | installed. If set to True or False the Rule and  |                                 |                            |
+  |                        |                    | the query must match precisely.                  |                                 |                            |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
   |                        | mig64              | Whether or not the Rule should apply to queries  | Exact match only                | True, False, or NULL       |
   |                        |                    | that have opted into 32 -> 64-bit migration.     |                                 |                            |
@@ -150,9 +151,11 @@ Most of the Matchable database fields are present as distinct parts of the updat
 
 There are a few special cases to consider:
 
--   systemCapabilities contains comma separated data and breaks down into multple database columns (instructionSet, memory)
+-   systemCapabilities contains comma separated data and breaks down into multple database columns (instructionSet, memory, jaws)
 
 -   headerArchitecture is extracted from the User-Agent header
+
+-   mig64 is optional, and comes from the query string instead of the path
 
 
 The following logic is used to figure out which rule a request matches, and how to respond:
@@ -162,8 +165,6 @@ The following logic is used to figure out which rule a request matches, and how 
 -   Discard any rules where the rule specifies a channel, version, buildID, osVersion, any part of systemCapabilities, and/or locale, and that doesn't match the request. The method for each match is described in the table above.
 
     -   The channel has special handling to try "falling back" to a simpler channel, for example a request with release-cck-foo will also consider rules for 'release'. This only applies to channels containing '-cck-'.
-
-    -   Rules which specify a Whitelist will also be discarded if the request doesn't fall inside the Whitelist.
 
 -   Sort the remaining rules by priority, and keep the one with highest.
 
@@ -313,7 +314,7 @@ Changes that directly affect updates that clients receive (the Rules and Release
 
 Any changes to a Rule that would affect a product and channel combination specified in this table will require signoff. This includes Rules that don't specify a product or channel at all (because that is treated as a wildcard).
 
-Releases which are mapped to be a Rule's mapping, fallbackingMapping, or whitelist field require the same signoffs as the Rule. Releases that are not mapped to by a rule never require any signoff. It's important that they are inspected before mapping to them for the first time.
+Releases which are mapped to be a Rule's mapping or fallbackingMapping field require the same signoffs as the Rule. Releases that are not mapped to by a rule never require any signoff. It's important that they are inspected before mapping to them for the first time.
 
 If a change affects more than one product and channel combination, *all* affected combinations' required signoffs will be combined to find the full set of required. For example, if Firefox's release channel requires 3 signoffs from "relman" and Firefox's beta channel requires 2 signoffs from "releng", a change to a Rule that affects both channels will require 3 signoffs from "relman" and 2 from "releng". Changing a Release that is mapped to by Rules on the "release" and "beta" channel would also require the same signoffs.
 

--- a/docs/source/database.rst
+++ b/docs/source/database.rst
@@ -105,6 +105,11 @@ Following tables show columns according to different Categories:
   |                        |                    | requesting the update has                        | memory to compare the incoming  | ">=8096"                   |
   |                        |                    |                                                  | one against                     |                            |
   |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
+  |                        | jaws               | Whether or not the the Rule should apply to      | Exact match only                | True, False, or NULL       |
+  |                        |                    | queries that are incompatible with the JAWS      |                                 |                            |
+  |                        |                    | screen reader. If set to True or False the Rule  |                                 |                            |
+  |                        |                    | and the query must match precisely.              |                                 |                            |
+  |                        +--------------------+--------------------------------------------------+---------------------------------+----------------------------+
   |                        | mig64              | Whether or not the Rule should apply to queries  | Exact match only                | True, False, or NULL       |
   |                        |                    | that have opted into 32 -> 64-bit migration.     |                                 |                            |
   |                        |                    | If set to True or False the Rule and the query   |                                 |                            |

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -90,21 +90,14 @@
         </div>
       </div>
       <div class="col-md-6">
-        <div class="form-group" ng-class="{'has-error': errors.distribution}">
-          <label for="id_distribution">Distribution</label>
-          <input type="text" class="form-control" id="id_distribution" ng-model="rule.distribution">
-          <p class="help-block" ng-show="errors.distribution">{{ errors.distribution.join(', ') }}</p>
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.buildTarget}">
           <label for="id_buildTarget">Build Target</label>
           <input type="text" class="form-control" id="id_buildTarget" ng-model="rule.buildTarget">
           <p class="help-block" ng-show="errors.buildTarget">{{ errors.buildTarget.join(', ') }}</p>
         </div>
       </div>
+    </div>
+    <div class="row">
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.osVersion}">
           <label for="id_osVersion">OS Version</label>
@@ -112,8 +105,6 @@
           <p class="help-block" ng-show="errors.osVersion">{{ errors.osVersion.join(', ') }}</p>
         </div>
       </div>
-    </div>
-    <div class="row">
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.instructionSet}">
           <label for="id_instructionSet">Instruction Set</label>
@@ -121,6 +112,8 @@
           <p class="help-block" ng-show="errors.instructionSet">{{ errors.instructionSet.join(', ') }}</p>
         </div>
       </div>
+    </div>
+    <div class="row">
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.memory}">
           <label for="id_memory">Memory</label>
@@ -128,20 +121,37 @@
           <p class="help-block" ng-show="errors.memory">{{ errors.memory.join(', ') }}</p>
         </div>
       </div>
+      <div class="col-md-6">
+        <div class="form-group" ng-class="{'has-error': errors.jaws}">
+          <label for="id_jaws">
+            JAWS Screen Reader Compatibility
+            <span class="glyphicon glyphicon-question-sign"
+                  title='Whether or not to match incoming queries that indicate an incompatible version of the JAWS screen reader. "Ignore" is usually what you want.'>
+            </span>
+          </label>
+          <select id="id_jaws" ng-model="rule.jaws" class="form-control"
+                  ng-options="value as key for (key, value) in {'Ignore': null, 'Yes': true, 'No': false}">
+            <!-- Angular creates an extra entry because one of our values is null. This hides it.
+                 From https://stackoverflow.com/a/24321497 -->
+            <option value="" ng-if="false"></option>
+          </select>
+          <p class="help-block" ng-show="errors.jaws">{{ errors.jaws.join(', ') }}</p>
+        </div>
+      </div>
     </div>
     <div class="row">
       <div class="col-md-6">
-        <div class="form-group" ng-class="{'has-error': errors.distVersion}">
-          <label for="id_distVersion">Dist version</label>
-          <input type="text" class="form-control" id="id_distribution" ng-model="rule.distVersion">
-          <p class="help-block" ng-show="errors.distVersion">{{ errors.distVersion.join(', ') }}</p>
+        <div class="form-group" ng-class="{'has-error': errors.distribution}">
+          <label for="id_distribution">Distribution</label>
+          <input type="text" class="form-control" id="id_distribution" ng-model="rule.distribution">
+          <p class="help-block" ng-show="errors.distribution">{{ errors.distribution.join(', ') }}</p>
         </div>
       </div>
       <div class="col-md-6">
-        <div class="form-group" ng-class="{'has-error': errors.update_type}">
-          <label for="id_update_type">Update Type</label>
-          <input type="text" class="form-control" id="id_update_type" ng-model="rule.update_type">
-          <p class="help-block" ng-show="errors.update_type">{{ errors.update_type.join(', ') }}</p>
+        <div class="form-group" ng-class="{'has-error': errors.distVersion}">
+          <label for="id_distVersion">Dist version</label>
+          <input type="text" class="form-control" id="id_distVersion" ng-model="rule.distVersion">
+          <p class="help-block" ng-show="errors.distVersion">{{ errors.distVersion.join(', ') }}</p>
         </div>
       </div>
     </div>
@@ -174,9 +184,16 @@
     <div class="row">
       <div class="col-md-6">
         <div class="form-group" ng-class="{'has-error': errors.alias}">
-          <label for="id_distribution">Alias</label>
-          <input type="text" class="form-control" id="id_distribution" ng-model="rule.alias">
+          <label for="id_alias">Alias</label>
+          <input type="text" class="form-control" id="id_alias" ng-model="rule.alias">
           <p class="help-block" ng-show="errors.alias">{{ errors.alias.join(', ') }}</p>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="form-group" ng-class="{'has-error': errors.update_type}">
+          <label for="id_update_type">Update Type</label>
+          <input type="text" class="form-control" id="id_update_type" ng-model="rule.update_type">
+          <p class="help-block" ng-show="errors.update_type">{{ errors.update_type.join(', ') }}</p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_modal.html
+++ b/ui/app/templates/rule_modal.html
@@ -126,7 +126,7 @@
           <label for="id_jaws">
             JAWS Screen Reader Compatibility
             <span class="glyphicon glyphicon-question-sign"
-                  title='Whether or not to match incoming queries that indicate an incompatible version of the JAWS screen reader. "Ignore" is usually what you want.'>
+                  title='Whether or not to match incoming queries that indicate a client that has an incompatible version of the JAWS screen reader installed. "Ignore" is usually what you want.'>
             </span>
           </label>
           <select id="id_jaws" ng-model="rule.jaws" class="form-control"

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -144,21 +144,14 @@
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': errors.distribution}">
-        <label for="id_distribution">Distribution</label>
-        <input type="text" class="form-control" id="id_distribution" ng-model="sc.distribution">
-        <p class="help-block" ng-show="errors.distribution">{{ errors.distribution.join(', ') }}</p>
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.buildTarget}">
         <label for="id_buildTarget">Build Target</label>
         <input type="text" class="form-control" id="id_buildTarget" ng-model="sc.buildTarget">
         <p class="help-block" ng-show="errors.buildTarget">{{ errors.buildTarget.join(', ') }}</p>
         </div>
       </div>
+    </div>
+    <div class="row">
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.osVersion}">
         <label for="id_osVersion">OS Version</label>
@@ -166,8 +159,6 @@
         <p class="help-block" ng-show="errors.osVersion">{{ errors.osVersion.join(', ') }}</p>
         </div>
       </div>
-    </div>
-    <div class="row">
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.instructionSet}">
         <label for="id_instructionSet">Instruction Set</label>
@@ -175,6 +166,8 @@
         <p class="help-block" ng-show="errors.instructionSet">{{ errors.instructionSet.join(', ') }}</p>
         </div>
       </div>
+    </div>
+    <div class="row">
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.memory}">
         <label for="id_memory">Memory</label>
@@ -182,20 +175,37 @@
         <p class="help-block" ng-show="errors.memory">{{ errors.memory.join(', ') }}</p>
         </div>
       </div>
+      <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
+        <div class="form-group" ng-class="{'has-error': errors.jaws}">
+          <label for="id_jaws">
+            JAWS Screen Reader Compatibility
+            <span class="glyphicon glyphicon-question-sign"
+                  title='Whether or not to match incoming queries that indicate an incompatible version of the JAWS screen reader. "Ignore" is usually what you want.'>
+            </span>
+          </label>
+          <select id="id_jaws" ng-model="sc.jaws" class="form-control"
+                  ng-options="value as key for (key, value) in {'Ignore': null, 'Yes': true, 'No': false}">
+            <!-- Angular creates an extra entry because one of our values is null. This hides it.
+                 From https://stackoverflow.com/a/24321497 -->
+            <option value="" ng-if="false"></option>
+          </select>
+          <p class="help-block" ng-show="errors.jaws">{{ errors.jaws.join(', ') }}</p>
+        </div>
+      </div>
     </div>
     <div class="row">
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': errors.distVersion}">
-        <label for="id_distribution">Dist version</label>
-        <input type="text" class="form-control" id="id_distribution" ng-model="sc.distVersion">
-        <p class="help-block" ng-show="errors.distVersion">{{ errors.distVersion.join(', ') }}</p>
+        <div class="form-group" ng-class="{'has-error': errors.distribution}">
+        <label for="id_distribution">Distribution</label>
+        <input type="text" class="form-control" id="id_distribution" ng-model="sc.distribution">
+        <p class="help-block" ng-show="errors.distribution">{{ errors.distribution.join(', ') }}</p>
         </div>
       </div>
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
-        <div class="form-group" ng-class="{'has-error': errors.update_type}">
-        <label for="id_update_type">Update Type</label>
-        <input type="text" class="form-control" id="id_update_type" ng-model="sc.update_type">
-        <p class="help-block" ng-show="errors.update_type">{{ errors.update_type.join(', ') }}</p>
+        <div class="form-group" ng-class="{'has-error': errors.distVersion}">
+        <label for="id_distribution">Dist version</label>
+        <input type="text" class="form-control" id="id_distVersion" ng-model="sc.distVersion">
+        <p class="help-block" ng-show="errors.distVersion">{{ errors.distVersion.join(', ') }}</p>
         </div>
       </div>
     </div>
@@ -228,9 +238,16 @@
     <div class="row">
       <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
         <div class="form-group" ng-class="{'has-error': errors.alias}">
-          <label for="id_distribution">Alias</label>
-          <input type="text" class="form-control" id="id_distribution" ng-model="sc.alias">
+          <label for="id_alias">Alias</label>
+          <input type="text" class="form-control" id="id_alias" ng-model="sc.alias">
           <p class="help-block" ng-show="errors.alias">{{ errors.alias.join(', ') }}</p>
+        </div>
+      </div>
+      <div class="col-md-6" ng-show= "sc.change_type !== 'delete'">
+        <div class="form-group" ng-class="{'has-error': errors.update_type}">
+        <label for="id_update_type">Update Type</label>
+        <input type="text" class="form-control" id="id_update_type" ng-model="sc.update_type">
+        <p class="help-block" ng-show="errors.update_type">{{ errors.update_type.join(', ') }}</p>
         </div>
       </div>
     </div>

--- a/ui/app/templates/rule_scheduled_change_modal.html
+++ b/ui/app/templates/rule_scheduled_change_modal.html
@@ -180,7 +180,7 @@
           <label for="id_jaws">
             JAWS Screen Reader Compatibility
             <span class="glyphicon glyphicon-question-sign"
-                  title='Whether or not to match incoming queries that indicate an incompatible version of the JAWS screen reader. "Ignore" is usually what you want.'>
+                  title='Whether or not to match incoming queries that indicate a client that has an incompatible version of the JAWS screen reader installed. "Ignore" is usually what you want.'>
             </span>
           </label>
           <select id="id_jaws" ng-model="sc.jaws" class="form-control"

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -170,6 +170,15 @@
       </dt>
       <dd ng-if="sc.mig64 === true">Yes</dd>
       <dd ng-if="sc.mig64 === false">No</dd>
+      <dt ng-show="sc.jaws !== null && sc.jaws !== undefined">
+        JAWS Screen Reader Compatibility
+        <span class="glyphicon glyphicon-question-sign"
+           title='Whether or not to match incoming queries that indicate an incompatible version of the JAWS screen reader. "Ignore" is usually what you want.'>
+        </span>
+        :
+      </dt>
+      <dd ng-if="sc.jaws === true">Yes</dd>
+      <dd ng-if="sc.jaws === false">No</dd>
       <dt ng-show="sc.distVersion">Dist Version:</dt>
       <dd>{{ sc.distVersion }}</dd>
       <dt ng-show="sc.update_type">Update type:</dt>

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -173,7 +173,7 @@
       <dt ng-show="sc.jaws !== null && sc.jaws !== undefined">
         JAWS Screen Reader Compatibility
         <span class="glyphicon glyphicon-question-sign"
-           title='Whether or not to match incoming queries that indicate an incompatible version of the JAWS screen reader. "Ignore" is usually what you want.'>
+           title='Whether or not to match incoming queries that indicate a client that has an incompatible version of the JAWS screen reader installed. "Ignore" is usually what you want.'>
         </span>
         :
       </dt>

--- a/ui/app/templates/rules.html
+++ b/ui/app/templates/rules.html
@@ -237,6 +237,8 @@
       <rulefield showdiff="!rule_id" showsc="show_sc" rule="rule" fieldname="memory" fieldtitle="Memory"></rulefield>
       <rulefield showdiff="!rule_id" showsc="show_sc" rule="rule" fieldname="mig64" fieldtitle="64-bit Migration Opt-in"
                  help='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status.'></rulefield>
+      <rulefield showdiff="!rule_id" showsc="show_sc" rule="rule" fieldname="jaws" fieldtitle="JAWS Screen Reader Compatibility"
+                 help='Whether or not to match incoming queries that indicate an incompatible version of the JAWS screen reader. "Ignore" is usually what you want.'></rulefield>
       <rulefield showdiff="!rule_id" showsc="show_sc" rule="rule" fieldname="update_type" fieldtitle="Update type"></rulefield>
       <rulefield showdiff="!rule_id" showsc="show_sc" rule="rule" fieldname="headerArchitecture" fieldtitle="Header Architecture"></rulefield>
     </div>

--- a/ui/app/templates/rules.html
+++ b/ui/app/templates/rules.html
@@ -238,7 +238,7 @@
       <rulefield showdiff="!rule_id" showsc="show_sc" rule="rule" fieldname="mig64" fieldtitle="64-bit Migration Opt-in"
                  help='Whether or not to check a client&#39;s 32 -> 64-bit migration opt-in status.'></rulefield>
       <rulefield showdiff="!rule_id" showsc="show_sc" rule="rule" fieldname="jaws" fieldtitle="JAWS Screen Reader Compatibility"
-                 help='Whether or not to match incoming queries that indicate an incompatible version of the JAWS screen reader. "Ignore" is usually what you want.'></rulefield>
+                 help='Whether or not to match incoming queries that indicate a client that has an incompatible version of the JAWS screen reader installed. "Ignore" is usually what you want.'></rulefield>
       <rulefield showdiff="!rule_id" showsc="show_sc" rule="rule" fieldname="update_type" fieldtitle="Update type"></rulefield>
       <rulefield showdiff="!rule_id" showsc="show_sc" rule="rule" fieldname="headerArchitecture" fieldtitle="Header Architecture"></rulefield>
     </div>


### PR DESCRIPTION
There's nothing too new or interesting in this patch - the JAWS field is like instructionSet/memory in that it lives in SYSTEM_CAPABILITIES, but its matching is like mig64 in that it's a boolean.

I also did a tiny bit of renaming and refactoring in the Rules class to improve readability.

@glasserc - Since this is the first Balrog you're doing I'm going to ask @JohanLorenzo for a sanity check as well. It looks like you're not able to give this the official r+ either...