### PR TITLE
Make the permissions API handle an empty options dict more gracefully.

### DIFF
--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -150,6 +150,19 @@ class TestPermissionsAPI_JSON(ViewTest):
         query = query.where(dbo.permissions.permission == 'admin')
         self.assertEqual(query.execute().fetchone(), ('admin', 'bob', {"products": ["a"]}, 1))
 
+    # TODO: find something that doesn't require signoff. and fix the damn ui
+    def testPermissionPutEmptyDictOptions(self):
+        # The default fixtures prevent us from creating permissions like this
+        # due to signoff requirements
+        dbo.permissionsRequiredSignoffs.t.delete().execute()
+        ret = self._put('/users/bob/permissions/admin', data=dict(options="{}"))
+        self.assertStatusCode(ret, 201)
+        self.assertEqual(ret.data, json.dumps(dict(new_data_version=1)), "Data: %s" % ret.data)
+        query = dbo.permissions.t.select()
+        query = query.where(dbo.permissions.username == 'bob')
+        query = query.where(dbo.permissions.permission == 'admin')
+        self.assertEqual(query.execute().fetchone(), ('admin', 'bob', None, 1))
+
     def testPermissionPutWithEmail(self):
         ret = self._put('/users/bob@bobsworld.com/permissions/admin', data=dict(options=json.dumps(dict(products=["a"]))))
         self.assertStatusCode(ret, 201)
@@ -518,6 +531,27 @@ class TestPermissionsScheduledChanges(ViewTest):
         expected = {
             "sc_id": 7, "scheduled_by": "bill", "change_type": "delete", "complete": False, "data_version": 1,
             "base_permission": "release", "base_username": "ashanti", "base_options": None, "base_data_version": 1,
+        }
+        self.assertEquals(db_data, expected)
+        cond = dbo.permissions.scheduled_changes.conditions.t.select().where(dbo.permissions.scheduled_changes.conditions.sc_id == 7).execute().fetchall()
+        self.assertEquals(len(cond), 1)
+        cond_expected = {"sc_id": 7, "data_version": 1, "when": 400000000}
+        self.assertEquals(dict(cond[0]), cond_expected)
+
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testAddScheduledChangeNewPermissionEmptyDictOptions(self):
+        data = {
+            "when": 400000000, "permission": "release", "username": "jill", "options": '{}', "change_type": "insert",
+        }
+        ret = self._post("/scheduled_changes/permissions", data=data)
+        self.assertEquals(ret.status_code, 200, ret.data)
+        self.assertEquals(json.loads(ret.data), {"sc_id": 7, "signoffs": {}})
+        r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 7).execute().fetchall()
+        self.assertEquals(len(r), 1)
+        db_data = dict(r[0])
+        expected = {
+            "sc_id": 7, "scheduled_by": "bill", "change_type": "insert", "complete": False, "data_version": 1,
+            "base_permission": "release", "base_username": "jill", "base_options": None, "base_data_version": None,
         }
         self.assertEquals(db_data, expected)
         cond = dbo.permissions.scheduled_changes.conditions.t.select().where(dbo.permissions.scheduled_changes.conditions.sc_id == 7).execute().fetchall()

--- a/auslib/web/admin/views/permissions.py
+++ b/auslib/web/admin/views/permissions.py
@@ -80,6 +80,8 @@ class SpecificPermissionView(AdminView):
                 options_dict = None
                 if connexion.request.get_json().get("options"):
                     options_dict = json.loads(connexion.request.get_json().get("options"))
+                    if len(options_dict) == 0:
+                        options_dict = None
 
                 dbo.permissions.update(where={"username": username, "permission": permission},
                                        what={"options": options_dict}, changed_by=changed_by,
@@ -93,6 +95,8 @@ class SpecificPermissionView(AdminView):
                 options_dict = None
                 if connexion.request.get_json().get("options"):
                     options_dict = json.loads(connexion.request.get_json().get("options"))
+                    if len(options_dict) == 0:
+                        options_dict = None
                 dbo.permissions.insert(changed_by, transaction=transaction, username=username, permission=permission,
                                        options=options_dict)
                 return Response(status=201, response=json.dumps(dict(new_data_version=1)))
@@ -112,6 +116,8 @@ class SpecificPermissionView(AdminView):
             options_dict = None
             if connexion.request.get_json().get("options"):
                 options_dict = json.loads(connexion.request.get_json().get("options"))
+                if len(options_dict) == 0:
+                    options_dict = None
 
             dbo.permissions.update(where={"username": username, "permission": permission},
                                    what={"options": options_dict}, changed_by=changed_by,
@@ -165,6 +171,8 @@ class PermissionScheduledChangesView(ScheduledChangesView):
 
         if what.get("options", None):
             what["options"] = json.loads(what.get("options"))
+            if len(what["options"]) == 0:
+                what["options"] = None
 
         if change_type in ["update", "delete"]:
             if not what.get("data_version", None):
@@ -213,6 +221,8 @@ class PermissionScheduledChangeView(ScheduledChangeView):
 
         if what.get("options", None):
             what["options"] = json.loads(what["options"])
+            if len(what["options"]) == 0:
+                what["options"] = None
 
         return super(PermissionScheduledChangeView, self)._post(sc_id, what, transaction, changed_by,
                                                                 connexion.request.get_json().get("sc_data_version"))


### PR DESCRIPTION
We need to fix the UI to stop passing dumb data at some point - but this fixes the immediate issue.