### PR TITLE
Bug 1403975: scheduled change modal hangs when no "when" is set and asap is not clicked

### DIFF
--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1,5 +1,7 @@
 import json
 import mock
+import datetime
+import time
 
 from auslib.global_state import dbo
 from auslib.test.admin.views.base import ViewTest
@@ -1206,10 +1208,11 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(json.loads(ret.data), expected)
 
     def testAddScheduledChangeExistingRule(self):
+        future_time = int(time.mktime((datetime.datetime.now() + datetime.timedelta(minutes=5)).timetuple()) * 1000)
         data = {
             "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "rule_id": 5,
             "priority": 80, "buildTarget": "d", "version": "3.3", "backgroundRate": 100, "mapping": "c", "update_type": "minor",
-            "data_version": 1, "change_type": "update",
+            "data_version": 1, "change_type": "update", "when": future_time
         }
         ret = self._post("/scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
@@ -1228,13 +1231,14 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "when": None}
+        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "when": future_time}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     def testAddScheduledChangeExistingDeletingRule(self):
+        future_time = int(time.mktime((datetime.datetime.now() + datetime.timedelta(minutes=5)).timetuple()) * 1000)
         data = {
             "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "data_version": 1,
-            "rule_id": 5, "change_type": "delete",
+            "rule_id": 5, "change_type": "delete", "when": future_time
         }
         ret = self._post("/scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
@@ -1253,7 +1257,7 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "when": None}
+        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "when": future_time}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1,7 +1,5 @@
 import json
 import mock
-import datetime
-import time
 
 from auslib.global_state import dbo
 from auslib.test.admin.views.base import ViewTest
@@ -1207,12 +1205,12 @@ class TestRuleScheduledChanges(ViewTest):
         }
         self.assertEquals(json.loads(ret.data), expected)
 
+    @mock.patch('time.time', mock.MagicMock(return_value=300))
     def testAddScheduledChangeExistingRule(self):
-        future_time = int(time.mktime((datetime.datetime.now() + datetime.timedelta(minutes=5)).timetuple()) * 1000)
         data = {
             "rule_id": 5, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
             "priority": 80, "buildTarget": "d", "version": "3.3", "backgroundRate": 100, "mapping": "c", "update_type": "minor",
-            "data_version": 1, "change_type": "update", "when": future_time
+            "data_version": 1, "change_type": "update", "when": 1234567
         }
         ret = self._post("/scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
@@ -1231,14 +1229,14 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "when": future_time}
+        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "when": 1234567}
         self.assertEquals(dict(cond[0]), cond_expected)
 
+    @mock.patch('time.time', mock.MagicMock(return_value=300))
     def testAddScheduledChangeExistingDeletingRule(self):
-        future_time = int(time.mktime((datetime.datetime.now() + datetime.timedelta(minutes=5)).timetuple()) * 1000)
         data = {
             "rule_id": 5, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
-            "data_version": 1, "change_type": "delete", "when": future_time
+            "data_version": 1, "change_type": "delete", "when": 1234567
         }
         ret = self._post("/scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
@@ -1257,7 +1255,7 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "when": future_time}
+        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "when": 1234567}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1210,7 +1210,7 @@ class TestRuleScheduledChanges(ViewTest):
     def testAddScheduledChangeExistingRule(self):
         future_time = int(time.mktime((datetime.datetime.now() + datetime.timedelta(minutes=5)).timetuple()) * 1000)
         data = {
-            "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "rule_id": 5,
+            "rule_id": 5, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
             "priority": 80, "buildTarget": "d", "version": "3.3", "backgroundRate": 100, "mapping": "c", "update_type": "minor",
             "data_version": 1, "change_type": "update", "when": future_time
         }
@@ -1231,14 +1231,14 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "when": future_time}
+        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "when": future_time}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     def testAddScheduledChangeExistingDeletingRule(self):
         future_time = int(time.mktime((datetime.datetime.now() + datetime.timedelta(minutes=5)).timetuple()) * 1000)
         data = {
-            "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "data_version": 1,
-            "rule_id": 5, "change_type": "delete", "when": future_time
+            "rule_id": 5, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None,
+            "data_version": 1, "change_type": "delete", "when": future_time
         }
         ret = self._post("/scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
@@ -1257,7 +1257,7 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEquals(db_data, expected)
         cond = dbo.rules.scheduled_changes.conditions.t.select().where(dbo.rules.scheduled_changes.conditions.sc_id == 8).execute().fetchall()
         self.assertEquals(len(cond), 1)
-        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": "foo", "telemetry_channel": "bar", "telemetry_uptake": 42, "when": future_time}
+        cond_expected = {"sc_id": 8, "data_version": 1, "telemetry_product": None, "telemetry_channel": None, "telemetry_uptake": None, "when": future_time}
         self.assertEquals(dict(cond[0]), cond_expected)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))

--- a/auslib/web/admin/views/rules.py
+++ b/auslib/web/admin/views/rules.py
@@ -202,7 +202,7 @@ class RuleScheduledChangesView(ScheduledChangesView):
     def _post(self, transaction, changed_by):
         if connexion.request.get_json().get("when", None) is None:
             return problem(400, "Bad Request", "'when' cannot be set to null when scheduling a new change "
-                                               "for a Release")
+                                               "for a Rule")
         if connexion.request.get_json():
             change_type = connexion.request.get_json().get("change_type")
         else:

--- a/auslib/web/admin/views/rules.py
+++ b/auslib/web/admin/views/rules.py
@@ -200,6 +200,9 @@ class RuleScheduledChangesView(ScheduledChangesView):
 
     @requirelogin
     def _post(self, transaction, changed_by):
+        if connexion.request.get_json().get("when", None) is None:
+            return problem(400, "Bad Request", "'when' cannot be set to null when scheduling a new change "
+                                               "for a Release")
         if connexion.request.get_json():
             change_type = connexion.request.get_json().get("change_type")
         else:

--- a/ui/app/js/services/releases_service.js
+++ b/ui/app/js/services/releases_service.js
@@ -89,11 +89,11 @@ angular.module("app").factory('Releases', function($http, $q, ScheduledChanges, 
     addScheduledChange: function(data, csrf_token) {
       data = jQuery.extend({}, data);
       data = Helpers.replaceEmptyStrings(data);
-      if (!data.when) {
-        data.when = null;
+      if (!!data.when) {
+        data.when = data.when.getTime();
       }
       else {
-        data.when = data.when.getTime();
+        data.when = null;
       }
       data.csrf_token = csrf_token;
       return $http.post("/api/scheduled_changes/releases", data);
@@ -104,6 +104,8 @@ angular.module("app").factory('Releases', function($http, $q, ScheduledChanges, 
       data = Helpers.replaceEmptyStrings(data);
       if (!!data.when) {
         data.when = data.when.getTime();
+      }else{
+        data.when = null;
       }
       data.csrf_token = csrf_token;
       return $http.post("/api/scheduled_changes/releases/" + sc_id, data);

--- a/ui/app/js/services/releases_service.js
+++ b/ui/app/js/services/releases_service.js
@@ -89,8 +89,8 @@ angular.module("app").factory('Releases', function($http, $q, ScheduledChanges, 
     addScheduledChange: function(data, csrf_token) {
       data = jQuery.extend({}, data);
       data = Helpers.replaceEmptyStrings(data);
-      if (data.when === null) {
-        data.when = "";
+      if (!data.when) {
+        data.when = null;
       }
       else {
         data.when = data.when.getTime();
@@ -102,7 +102,7 @@ angular.module("app").factory('Releases', function($http, $q, ScheduledChanges, 
     updateScheduledChange: function(sc_id, data, csrf_token) {
       data = jQuery.extend({}, data);
       data = Helpers.replaceEmptyStrings(data);
-      if (data.when !== null) {
+      if (!!data.when) {
         data.when = data.when.getTime();
       }
       data.csrf_token = csrf_token;

--- a/ui/app/js/services/rules_service.js
+++ b/ui/app/js/services/rules_service.js
@@ -55,7 +55,7 @@ angular.module("app").factory('Rules', function($http, ScheduledChanges, Helpers
       if (!!data.when) {
         data.when = data.when.getTime();
       }else{
-          data.when = "";
+          data.when = null;
       }
       data.csrf_token = csrf_token;
       return $http.post("/api/scheduled_changes/rules", data);
@@ -66,11 +66,11 @@ angular.module("app").factory('Rules', function($http, ScheduledChanges, Helpers
     updateScheduledChange: function(sc_id, data, csrf_token) {
       data = jQuery.extend({}, data);
       data = Helpers.replaceEmptyStrings(data);
-      if (!data.when) {
-        data.when = "";
+      if (!!data.when) {
+        data.when = data.when.getTime();
       }
       else {
-        data.when = data.when.getTime();
+        data.when = null;
       }
       data.csrf_token = csrf_token;
       return $http.post("/api/scheduled_changes/rules/" + sc_id, data);

--- a/ui/app/js/services/rules_service.js
+++ b/ui/app/js/services/rules_service.js
@@ -52,8 +52,10 @@ angular.module("app").factory('Rules', function($http, ScheduledChanges, Helpers
     addScheduledChange: function(data, csrf_token) {
       data = jQuery.extend({}, data);
       data = Helpers.replaceEmptyStrings(data);
-      if (data.when !== null) {
+      if (!!data.when) {
         data.when = data.when.getTime();
+      }else{
+          data.when = "";
       }
       data.csrf_token = csrf_token;
       return $http.post("/api/scheduled_changes/rules", data);
@@ -64,7 +66,7 @@ angular.module("app").factory('Rules', function($http, ScheduledChanges, Helpers
     updateScheduledChange: function(sc_id, data, csrf_token) {
       data = jQuery.extend({}, data);
       data = Helpers.replaceEmptyStrings(data);
-      if (data.when === null) {
+      if (!data.when) {
         data.when = "";
       }
       else {


### PR DESCRIPTION
Fixes `Error: b.when is undefined` which occurs when adding scheduled changes without setting time/date.