### PR TITLE
bug 1410929: Don't put original_row into object that gets copied around.

### DIFF
--- a/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_edit_controller.js
@@ -1,6 +1,6 @@
 /*global sweetAlert */
 angular.module('app').controller('EditRuleScheduledChangeCtrl',
-function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements, Helpers) {
+function ($scope, $modalInstance, CSRF, Rules, Releases, sc, original_row, signoffRequirements, Helpers) {
 
   $scope.names = [];
   Releases.getNames().then(function(names) {
@@ -29,7 +29,7 @@ function ($scope, $modalInstance, CSRF, Rules, Releases, sc, signoffRequirements
       if ($scope.sc.change_type === "delete") {
         target = undefined;
       }
-      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired(sc.original_row, target, signoffRequirements);
+      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired(original_row, target, signoffRequirements);
     }
   }, true);
 

--- a/ui/app/js/controllers/rule_scheduled_change_new_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_change_new_controller.js
@@ -1,5 +1,5 @@
 angular.module("app").controller("NewRuleScheduledChangeCtrl",
-function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes, sc, signoffRequirements, Helpers) {
+function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes, sc, original_row, signoffRequirements, Helpers) {
   $scope.names = [];
   Releases.getNames().then(function(names) {
     $scope.names = names;
@@ -36,7 +36,7 @@ function($scope, $http, $modalInstance, CSRF, Releases, Rules, scheduled_changes
       if ($scope.sc.change_type === "delete") {
         target = undefined;
       }
-      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired($scope.sc.original_row, target, signoffRequirements);
+      $scope.scheduledChangeSignoffsRequired = Rules.ruleSignoffsRequired(original_row, target, signoffRequirements);
     }
   }, true);
 

--- a/ui/app/js/controllers/rule_scheduled_changes_controller.js
+++ b/ui/app/js/controllers/rule_scheduled_changes_controller.js
@@ -134,6 +134,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         scheduled_changes: function() {
           return $scope.scheduled_changes;
         },
+        original_row: function() {
+          return {};
+        },
         sc: function() {
           // blank new default rule
           return {
@@ -238,6 +241,9 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         sc: function() {
           sc.when = new Date(sc.when);
           return sc;
+        },
+        original_row: function() {
+          return {};
         },
         signoffRequirements: function() {
           return $scope.signoffRequirements;

--- a/ui/app/js/controllers/rules_controller.js
+++ b/ui/app/js/controllers/rules_controller.js
@@ -328,9 +328,11 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
         },
         sc: function() {
           sc = angular.copy(rule);
-          sc.original_row = rule;
           sc["change_type"] = "update";
           return sc;
+        },
+        original_row: function() {
+          return rule;
         },
         signoffRequirements: function() {
           return $scope.signoffRequirements;
@@ -379,8 +381,10 @@ function($scope, $routeParams, $location, $timeout, Rules, Search, $modal, $rout
       resolve: {
         sc: function() {
           var sc = angular.copy(rule.scheduled_change);
-          sc.original_row = rule;
           return sc;
+        },
+        original_row: function() {
+          return rule;
         },
         signoffRequirements: function() {
           return $scope.signoffRequirements;


### PR DESCRIPTION
This is a minimal fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1410929. I think there's a larger issue here around how we model data in the frontend, but fixing that is for...another day.