### PR TITLE
bug 1384816: Compress production dumps with xz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ MAINTAINER bhearsum@mozilla.com
 # Some versions of the python:2.7 Docker image remove libpcre3, which uwsgi needs for routing support to be enabled.
 # Node and npm are to build the frontend. nodejs-legacy is needed by this version of npm. These will get removed after building.
 # libmysqlclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
+# xz-utils is needed to compress production database dumps
 RUN apt-get -q update \
-    && apt-get -q --yes install libpcre3 libpcre3-dev libmysqlclient-dev mysql-client \
+    && apt-get -q --yes install libpcre3 libpcre3-dev libmysqlclient-dev mysql-client xz-utils \
     && apt-get clean
 
 WORKDIR /app

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -61,7 +61,7 @@ elif [ $1 == "extract-active-data" ]; then
         exit 1
     fi
     python scripts/manage-db.py -d ${DBURI} extract dump.sql
-    xz -zc dump.sql > ${OUTPUT_FILE}
+    xz -T0 -zc dump.sql > ${OUTPUT_FILE}
 elif [ $1 == "reset-stage-db" ]; then
     if [ -z "${DBURI}" ]; then
         echo "\${DBURI} must be set!"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -56,7 +56,12 @@ elif [ $1 == "extract-active-data" ]; then
         echo "\${DBURI} must be set!"
         exit 1
     fi
-    exec python scripts/manage-db.py -d ${DBURI} extract ${OUTPUT_FILE}
+    if [ -z "${OUTPUT_FILE}" ]; then
+        echo "\${OUTPUT_FILE} must be set!"
+        exit 1
+    fi
+    python scripts/manage-db.py -d ${DBURI} extract dump.sql
+    xz -zc dump.sql > ${OUTPUT_FILE}
 elif [ $1 == "reset-stage-db" ]; then
     if [ -z "${DBURI}" ]; then
         echo "\${DBURI} must be set!"


### PR DESCRIPTION
xz gets the current production dump down to ~20MB (gzip took it to ~40MB), and extracts in less than 2 seconds on my laptop. Compression can taken awhile, but I don't think that's going to be an issue on the server since we run the cronjob at an off-hour?

@relud - there's some background on this in https://bugzilla.mozilla.org/show_bug.cgi?id=1384816. The idea is that we'd start uploading this new, compressed dump to a different location, and then update the dev set-up script to decompress + use that instead of use the uncompressed dump. Is that OK for you? I imagine it may require a change to the cronjob.