### PR TITLE
Add sha256 for swagger wheel added 2018-01-04

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,8 @@ clickclick==1.2.1 \
 strict-rfc3339==0.7 \
     --hash=sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277
 swagger-spec-validator==2.1.0 \
-    --hash=sha256:dc9219c6572ce0def6e1c160ca253c0e7fcde75812628f0c0199334f85bd138e
+    --hash=sha256:dc9219c6572ce0def6e1c160ca253c0e7fcde75812628f0c0199334f85bd138e \
+    --hash=sha256:aedacb6c6b475026a1b5ac218fb590382d08064e227da254eb961d17cfd2b7c1
 pathlib==1.0.1 \
     --hash=sha256:6940718dfc3eff4258203ad5021090933e5c04707d5ca8cc9e73c94a7894ea9f
 inflection==0.3.1 \


### PR DESCRIPTION
Going by https://pypi.python.org/pypi/swagger-spec-validator a wheel for v2.1.0 was added in early January, and pip prefers that when docker-compose is building balrogadmin. We have just the sha256 of the tar.gz so that's a fatal error.

Not sure what checks we do in these cases, so I verified that the swagger_spec_validator directory has the same contents in both tar.gz and .whl.