### PR TITLE
Use GITHUB_HEAD_* when tagging.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -162,7 +162,7 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone $GITHUB_BASE_REPO_URL balrog && cd balrog && git checkout $GITHUB_BASE_BRANCH && scripts/push-dockerimage.sh latest ${GITHUB_BASE_BRANCH}-${GITHUB_BASE_SHA}"
+        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && scripts/push-dockerimage.sh latest ${GITHUB_HEAD_BRANCH}-${GITHUB_HEAD_SHA}"
     extra:
       github:
         env: true
@@ -190,7 +190,7 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone $GITHUB_BASE_REPO_URL balrog && cd balrog/agent && git checkout $GITHUB_BASE_BRANCH && scripts/push-dockerimage.sh latest ${GITHUB_BASE_BRANCH}-${GITHUB_BASE_SHA}"
+        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog/agent && git checkout $GITHUB_HEAD_BRANCH && scripts/push-dockerimage.sh latest ${GITHUB_HEAD_BRANCH}-${GITHUB_HEAD_SHA}"
     extra:
       github:
         env: true


### PR DESCRIPTION
@oremj and I noticed this while debugging something in dev yesterday. It looks like we're using GITHUB_BASE_SHA when we should use GITHUB_HEAD_SHA. I see that I made this change in #424, but I have no idea why. My best guess is that it was paranoia around accidentally building and pushing something from a PR - but we're guarded against that by restricting this to happen on "push" events.