### PR TITLE
Slow endpoint when looking up Rules.getPotentialRequiredSignoffs

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1542,29 +1542,30 @@ class Rules(AUSTable):
 
     def getPotentialRequiredSignoffs(self, affected_rows, transaction=None):
         potential_required_signoffs = {}
+        rows = []
         # The new row may change the product or channel, so we must look for
         # Signoffs for both.
-        rows = []
         for row in affected_rows:
             if not row:
                 continue
             rows.append(row)
-        # If product isn't present, or is None, it means the Rule affects
-        # all products, and we must leave it out of the where clause. If
-        # we included it, the query would only match rows where product is
-        # NULL.
+
         where = {}
         cond = []
         for row in rows:
             if not row.get('product'):
+                # If product isn't present, or is None, it means the Rule affects
+                # all products, and we must leave it out of the where clause. If
+                # we included it, the query would only match rows where product is
+                # NULL. Since we are returning all rs, we can safely breakout of this loop
                 break
             cond.append(row["product"])
-        else:
+        else:  # nobreak
             where = [self.product.in_(tuple(cond))]
 
         q = self.db.productRequiredSignoffs.select(where=where, transaction=transaction)
 
-        # map query result using product as key
+        # map query result using product as the key
         q_map = {}
         for rs in q:
             if rs["product"] in q_map:


### PR DESCRIPTION
PR is a continuation of #462 . Cuts down `/releases` lookup time to about `~ 130ms`

_**[BEFORE]**_
<img width="494" alt="before" src="https://user-images.githubusercontent.com/11579108/37054729-ae8892e0-2190-11e8-936c-6858878161a9.png">

_**[AFTER]**_
<img width="520" alt="after" src="https://user-images.githubusercontent.com/11579108/37054759-c28c51f0-2190-11e8-87d8-6ac534f79df6.png">
