### PR TITLE
Automatic signoff is broken when a user holds multiple roles and only one of them is required

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1132,8 +1132,8 @@ class ScheduledChangeTable(AUSTable):
         self._checkBaseTablePermissions(base_table_where, base_columns, changed_by, transaction)
 
     def auto_signoff(self, changed_by, transaction, sc_id, dryrun, columns):
-        # - If the User scheduling a change only holds one Role, record a signoff with it.
-        # - If the User scheduling a change holds more than one Role, we cannot a Signoff, because
+        # - If the User scheduling a change only holds one of the required Roles, record a signoff with it.
+        # - If the User scheduling a change holds more than one of the required Roles, we cannot a Signoff, because
         #   we don't know which Role we'd want to signoff with. The user will need to signoff
         #   manually in these cases.
         user_roles = self.db.getUserRoles(username=changed_by, transaction=transaction)

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1140,9 +1140,10 @@ class ScheduledChangeTable(AUSTable):
         if len(user_roles):
             required_roles = set()
             required_signoffs = self.baseTable.getPotentialRequiredSignoffs([columns], transaction=transaction)
-            required_roles.update([rs["role"] for rs in [obj for v in required_signoffs.values() for obj in v] if required_signoffs])
+            if required_signoffs:
+                required_roles.update([rs["role"] for rs in [obj for v in required_signoffs.values() for obj in v]])
             possible_signoffs = list(filter(lambda role: role["role"] in required_roles, user_roles))
-            if required_signoffs and len(possible_signoffs) == 1:
+            if len(possible_signoffs) == 1:
                 self.signoffs.insert(changed_by=changed_by, transaction=transaction, dryrun=dryrun,
                                      sc_id=sc_id, role=possible_signoffs[0].get("role"))
 

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1137,14 +1137,14 @@ class ScheduledChangeTable(AUSTable):
         #   we don't know which Role we'd want to signoff with. The user will need to signoff
         #   manually in these cases.
         user_roles = self.db.getUserRoles(username=changed_by, transaction=transaction)
-        if len(user_roles) == 1:
+        if len(user_roles):
             required_roles = set()
             required_signoffs = self.baseTable.getPotentialRequiredSignoffs([columns], transaction=transaction)
-            if required_signoffs:
-                required_roles.update([rs["role"] for rs in [obj for v in required_signoffs.values() for obj in v]])
-                if user_roles[0]["role"] in required_roles:
-                    self.signoffs.insert(changed_by=changed_by, transaction=transaction, dryrun=dryrun,
-                                         sc_id=sc_id, role=user_roles[0].get("role"))
+            required_roles.update([rs["role"] for rs in [obj for v in required_signoffs.values() for obj in v] if required_signoffs])
+            possible_signoffs = list(filter(lambda role: role["role"] in required_roles, user_roles))
+            if required_signoffs and len(possible_signoffs) == 1:
+                self.signoffs.insert(changed_by=changed_by, transaction=transaction, dryrun=dryrun,
+                                     sc_id=sc_id, role=possible_signoffs[0].get("role"))
 
     def select(self, where=None, transaction=None, **kwargs):
         ret = []

--- a/auslib/test/admin/views/test_permissions.py
+++ b/auslib/test/admin/views/test_permissions.py
@@ -489,7 +489,7 @@ class TestPermissionsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/permissions", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 7, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"sc_id": 7, "signoffs": {"bill": "releng"}})
         r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 7).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
@@ -531,7 +531,7 @@ class TestPermissionsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/permissions", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 7, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"sc_id": 7, "signoffs": {"bill": "releng"}})
         r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 7).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
@@ -552,7 +552,7 @@ class TestPermissionsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/permissions", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 7, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"sc_id": 7, "signoffs": {"bill": "releng"}})
         r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 7).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])
@@ -959,7 +959,7 @@ class TestPermissionsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/permissions", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 7, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"sc_id": 7, "signoffs": {"bill": "releng"}})
         r = dbo.permissions.scheduled_changes.t.select().where(dbo.permissions.scheduled_changes.sc_id == 7).execute().fetchall()
         self.assertEquals(len(r), 1)
         db_data = dict(r[0])

--- a/auslib/test/admin/views/test_required_signoffs.py
+++ b/auslib/test/admin/views/test_required_signoffs.py
@@ -780,7 +780,7 @@ class TestPermissionsRequiredSignoffsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/required_signoffs/permissions", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 5, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"sc_id": 5, "signoffs": {"bill": "releng"}})
         r = dbo.permissionsRequiredSignoffs.scheduled_changes.t.select().where(dbo.permissionsRequiredSignoffs.scheduled_changes.sc_id == 5)\
                                                                         .execute().fetchall()
         self.assertEquals(len(r), 1)
@@ -826,7 +826,7 @@ class TestPermissionsRequiredSignoffsScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/required_signoffs/permissions", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 5, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"sc_id": 5, "signoffs": {"bill": "releng"}})
         r = dbo.permissionsRequiredSignoffs.scheduled_changes.t.select().where(dbo.permissionsRequiredSignoffs.scheduled_changes.sc_id == 5)\
                                                                         .execute().fetchall()
         self.assertEquals(len(r), 1)

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1289,7 +1289,7 @@ class TestRuleScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 8, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"sc_id": 8, "signoffs": {"bill": "releng"}})
 
         r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 8).execute().fetchall()
         self.assertEquals(len(r), 1)
@@ -1315,7 +1315,7 @@ class TestRuleScheduledChanges(ViewTest):
         }
         ret = self._post("/scheduled_changes/rules", data=data)
         self.assertEquals(ret.status_code, 200, ret.data)
-        self.assertEquals(json.loads(ret.data), {"sc_id": 8, "signoffs": {}})
+        self.assertEquals(json.loads(ret.data), {"sc_id": 8, "signoffs": {"bill": "releng"}})
 
         r = dbo.rules.scheduled_changes.t.select().where(dbo.rules.scheduled_changes.sc_id == 8).execute().fetchall()
         self.assertEquals(len(r), 1)

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -915,7 +915,7 @@ class TestScheduledChangesTable(unittest.TestCase, ScheduledChangesTableMixin, M
         what = {"fooid": 3, "foo": "signofftest", "bar": "thing2", "data_version": 2, "when": 999000, "change_type": "update"}
         self.sc_table.insert(changed_by="mary", **what)
         user_role_rows = self.table.scheduled_changes.signoffs.select(where={"username": "mary", "sc_id": 7})
-        self.assertEquals(len(user_role_rows), 0)
+        self.assertEquals(len(user_role_rows), 1)
 
     @mock.patch("time.time", mock.MagicMock(return_value=200))
     def testInsertRecordSignOffUnneededRole(self):


### PR DESCRIPTION
PR fixes issue of not autosigning off when user holds more than one role but only one of the required signoffs.