### PR TITLE
bug 1431789: fix bug in validation when updateLine is unset in schema 9 blobs

### DIFF
--- a/auslib/blobs/apprelease.py
+++ b/auslib/blobs/apprelease.py
@@ -967,7 +967,7 @@ class ReleaseBlobV9(ProofXMLMixin, ReleaseBlobBase, MultipleUpdatesXMLMixin, Uni
             # Rules table to avoid confusion.
             "type": update_type,
         }
-        for group in self["updateLine"]:
+        for group in self.get("updateLine"):
             condition_results = []
             for condition, values in group["for"].items():
                 matches = False

--- a/auslib/blobs/apprelease.py
+++ b/auslib/blobs/apprelease.py
@@ -1017,7 +1017,7 @@ class ReleaseBlobV9(ProofXMLMixin, ReleaseBlobBase, MultipleUpdatesXMLMixin, Uni
         conflicts = []
         conflicting_values = set()
 
-        for (group1, group2) in itertools.product(self["updateLine"], self["updateLine"]):
+        for (group1, group2) in itertools.product(self.get("updateLine", []), self.get("updateLine", [])):
             # Skip over groups that are identical - they can't conflict
             if group1 == group2:
                 continue


### PR DESCRIPTION
I discovered this while verifying my work to switch submission to V9. When the blob is first submitted, we always end up submitting a version of it with just name, schema_version, and hashFunction before we submit the actual contents -- this makes that possible. The schema doesn't require updateLine to be set, so I think this is a bug regardless of how the submission tools work.