### PR TITLE
export db dump path in reset script to make sure download script puts it in the right place

### DIFF
--- a/scripts/reset-stage-db.sh
+++ b/scripts/reset-stage-db.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-LOCAL_DUMP="/app/scripts/prod_db_dump.sql"
+export LOCAL_DUMP="/app/scripts/prod_db_dump.sql"
 
 DBURI=$1
 MAGIC_WORD=$2


### PR DESCRIPTION
We discovered this while trying to do a reset of dev earlier today.

This variable gets used by https://github.com/mozbhearsum/balrog/blob/e117fb175e235ce9fa4d78db349fbed3aaeb8ce9/scripts/get-prod-db-dump.py#L15, which we call further down. Without it, we end up putting the db dump in the wrong place and failing to import it.