### PR TITLE
bug 1461405: no option to sign off on release blob changes via frontend

### DIFF
--- a/ui/app/templates/release_scheduled_changes.html
+++ b/ui/app/templates/release_scheduled_changes.html
@@ -51,11 +51,11 @@
     <h3 class="panel-title">
       <div style="float: right">
         <i ng-if="scheduled_changes_count && $first && (currentPage == 1)">Current</i>
-        <button ng-show="!sc.sc_id && (! isEmpty(sc['required_signoffs']) &&
+        <button ng-show="!sc_id && (! isEmpty(sc['required_signoffs']) &&
           !sc['signoffs'].hasOwnProperty(current_user))" class="btn btn-xs btn-primary" ng-click="signoff(sc)">
           Signoff as...
         </button>
-        <button ng-show="!sc.sc_id && (! isEmpty(sc['required_signoffs']) &&
+        <button ng-show="!sc_id && (! isEmpty(sc['required_signoffs']) &&
           sc['signoffs'].hasOwnProperty(current_user))" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)">
           Revoke your Signoff
         </button>
@@ -69,7 +69,7 @@
     </h3>
   </div>
   <div class="panel-body">
-    <div ng-show="!sc.sc_id && ! isEmpty(sc.required_signoffs)">
+    <div ng-show="!sc_id && ! isEmpty(sc.required_signoffs)">
       <span style="float: left">
         <h4>Before it can be enacted, this change must be signed off on by:</h4>
         <ul>

--- a/ui/app/templates/rule_scheduled_changes.html
+++ b/ui/app/templates/rule_scheduled_changes.html
@@ -54,11 +54,11 @@
     <h3 class="panel-title">
       <div style="float: right">
         <i ng-if="scheduled_changes_rules_count && $first && (currentPage == 1)">Current</i>
-        <button ng-show="sc.sc_id && (!isEmpty(sc['required_signoffs']) &&
+        <button ng-show="sc_id && (!isEmpty(sc['required_signoffs']) &&
           !sc['signoffs'].hasOwnProperty(current_user))" class="btn btn-xs btn-primary" ng-click="signoff(sc)">
           Signoff as...
         </button>
-        <button ng-show="sc.sc_id && (!isEmpty(sc['signoffs']) &&
+        <button ng-show="sc_id && (!isEmpty(sc['signoffs']) &&
           sc['signoffs'].hasOwnProperty(current_user))" class="btn btn-xs btn-danger" ng-click="revokeSignoff(sc)">
           Revoke your Signoff
         </button>


### PR DESCRIPTION
Looks like this regressed in #410. Specifically, we're looking at `sc.sc_id` to determine whether or not to show the signoff button. This is wrong, because that variable refers to the current scheduled change we're processing in the loop, and our decision about whether or not to show the button should be based on which page we're on (scheduled changes vs. scheduled changes history). The correct variable should be `sc_id`, which is set in the controlled based on the URL.