### PR TITLE
Fix build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER bhearsum@mozilla.com
 # Some versions of the python:2.7 Docker image remove libpcre3, which uwsgi needs for routing support to be enabled.
 # libmariadbclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
 # mysql-client is needed to import sample data, which we do in dev & stage.
-# xz-utils is needed to compress production database dumps
+# xz-utils is needed to compress production database dumps.
 RUN apt-get -q update \
     && apt-get -q --yes install libpcre3 libpcre3-dev libmariadbclient-dev mysql-client xz-utils \
     && apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:2.7-slim
+FROM python:2.7-slim-jessie
 
 MAINTAINER bhearsum@mozilla.com
 
 # Some versions of the python:2.7 Docker image remove libpcre3, which uwsgi needs for routing support to be enabled.
-# libmariadbclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
-# mysql-client is needed to import sample data, which we do in dev & stage.
-# xz-utils is needed to compress production database dumps.
+# Node and npm are to build the frontend. nodejs-legacy is needed by this version of npm. These will get removed after building.
+# libmysqlclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
+# xz-utils is needed to compress production database dumps
 RUN apt-get -q update \
-    && apt-get -q --yes install libpcre3 libpcre3-dev libmariadbclient-dev mysql-client xz-utils \
+    && apt-get -q --yes install libpcre3 libpcre3-dev libmysqlclient-dev mysql-client xz-utils \
     && apt-get clean
 
 WORKDIR /app
@@ -34,15 +34,10 @@ COPY version.json /app/
 WORKDIR /app
 
 RUN cd ui && \
-    # gnupg and curl are needed temporarily to enable the node apt repository.
-    apt-get -q --yes install curl gnupg && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-    apt-get -q update && \
-    # Node is needed to build the frontend. It will get removed after building.
-    apt-get -q --yes install nodejs && \
+    apt-get -q --yes install nodejs nodejs-legacy npm && \
     npm install && \
     npm run build && \
-    apt-get -q --yes remove nodejs gnupg curl && \
+    apt-get -q --yes remove nodejs nodejs-legacy npm && \
     apt-get -q --yes autoremove && \
     apt-get clean && \
     rm -rf /root/.npm /tmp/phantomjs && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,26 +3,19 @@
 # system locations (some system packages and some python packages).
 # Things that are fully local to /app (such as npm requirements and the built UI)
 # are done as needed in the entrypoint.
-FROM python:2.7-slim
+FROM python:2.7-slim-jessie
 
 MAINTAINER bhearsum@mozilla.com
 
 # Some versions of the python:2.7 Docker image remove libpcre3, which uwsgi needs for routing support to be enabled.
-# Nodejs is needed to build the frontend.
+# Node and npm are to build the frontend. nodejs-legacy is needed by this version of npm.
 # mysql-client is needed to import sample data
-# libmariadbclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
+# libmysqlclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
 # libfontconfig1 is required by phantomjs
 # git is needed to send coverage information
-# gcc is needed to build the mysql-connector python package
-# gnupg is needed to enable the nodejs repo (and then removed after that's done)
 RUN apt-get -q update \
-    && apt-get -q --yes install netcat libpcre3 libpcre3-dev libmariadbclient-dev mysql-client \
-                                libfontconfig1 git curl gnupg gcc \
-    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
-    && apt-get -q update \
-    && apt-get -q --yes install nodejs \
-    && apt-get -q --yes remove gnupg \
-    && apt-get -q --yes autoremove \
+    && apt-get -q --yes install netcat libpcre3 libpcre3-dev nodejs nodejs-legacy npm libmysqlclient-dev mysql-client \
+                                libfontconfig1 netcat git curl \
     && apt-get clean
 
 WORKDIR /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,14 +8,21 @@ FROM python:2.7-slim
 MAINTAINER bhearsum@mozilla.com
 
 # Some versions of the python:2.7 Docker image remove libpcre3, which uwsgi needs for routing support to be enabled.
-# Node and npm are to build the frontend. nodejs-legacy is needed by this version of npm.
+# Nodejs is needed to build the frontend.
 # mysql-client is needed to import sample data
-# libmysqlclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
+# libmariadbclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
 # libfontconfig1 is required by phantomjs
 # git is needed to send coverage information
+# gcc is needed to build the mysql-connector python package
+# gnupg is needed to enable the nodejs repo (and then removed after that's done)
 RUN apt-get -q update \
-    && apt-get -q --yes install netcat libpcre3 libpcre3-dev nodejs nodejs-legacy npm libmysqlclient-dev mysql-client \
-                                libfontconfig1 netcat git curl \
+    && apt-get -q --yes install netcat libpcre3 libpcre3-dev libmariadbclient-dev mysql-client \
+                                libfontconfig1 git curl gnupg gcc \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && apt-get -q update \
+    && apt-get -q --yes install nodejs \
+    && apt-get -q --yes remove gnupg \
+    && apt-get -q --yes autoremove \
     && apt-get clean
 
 WORKDIR /app

--- a/ui/config/application.js
+++ b/ui/config/application.js
@@ -25,7 +25,10 @@ module.exports = function(lineman) {
 
     jshint: {
       options: {
-        esnext: true
+        esnext: true,
+        // I don't understand why, but this can't be null:
+        // https://github.com/jshint/jshint/issues/2922
+        reporterOutput: "",
       },
     },
 

--- a/ui/config/application.js
+++ b/ui/config/application.js
@@ -25,10 +25,7 @@ module.exports = function(lineman) {
 
     jshint: {
       options: {
-        esnext: true,
-        // I don't understand why, but this can't be null:
-        // https://github.com/jshint/jshint/issues/2922
-        reporterOutput: "",
+        esnext: true
       },
     },
 


### PR DESCRIPTION
While looking at some PRs I noticed that all Docker builds were failing with errors like:
```
Package libmysqlclient-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

[91mE: Unable to locate package npm
E: Package 'libmysqlclient-dev' has no installation candidate
```

I'm not sure exactly when (I looked through both the Python and Debian dockerfiles and didn't see anything obvious), but it appears the underlying Debian image we're based on was updated at some point, and caused bustage with npm/node, and the mysql package we require to build our mysql connector. This PR should fix things -- I was able to "docker-compose build --no-cache" to get my local dev enviroment working again, as well as build the production image with a carefully crafted task (https://tools.taskcluster.net/groups/L3rkYJTESYmyhu6p5bKR2A/tasks/L3rkYJTESYmyhu6p5bKR2A/runs/0/artifacts).

The highlights are:
* Switch to libmariadbclient-dev, which now provides `mysql_config`
* Install node from a more official place, which means adding that as a mirror. It's not ideal to be doing this, but. This will go away with the UI rewrite.
* Add a fix for jslint, for reasons I don't fully understand (link to the issue is in comments).