### PR TITLE
bug 1457893: stop accepting unicode input to fields that don't support it

### DIFF
--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -239,6 +239,12 @@ class TestRulesAPI_JSON(ViewTest):
             self.assertEquals(len(r), 1)
             self.assertEquals(r[0]['buildID'], '%s20010101000000' % op)
 
+    def testBuildIDDoesntAcceptStrings(self):
+        for buildid in ('abcdef', '<abcdef'):
+            ret = self._post('/rules', data=dict(backgroundRate=42, mapping='d', priority=50,
+                             product='Firefox', channel="nightly", update_type='minor', buildID=buildid))
+            self.assertEquals(ret.status_code, 400, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+
     def testVersionListValidInput(self):
         for validVersionList in ('3.3,4.2', '3.1.3,4.2'):
             ret = self._post('/rules', data=dict(backgroundRate=42, mapping='d', priority=50,

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1,3 +1,4 @@
+# This Python file uses the following encoding: utf-8
 import json
 import mock
 
@@ -54,6 +55,11 @@ class TestRulesAPI_JSON(ViewTest):
         self.assertEquals(r[0]['backgroundRate'], 31)
         self.assertEquals(r[0]['priority'], 33)
         self.assertEquals(r[0]['data_version'], 1)
+
+    def testNewRulePostWithUnicode(self):
+        ret = self._post('/rules', data=dict(backgroundRate=31, mapping='c', priority=33,
+                                             product='Firefox', update_type='minor', channel='nightlyÁ'))
+        self.assertEquals(ret.status_code, 400, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
 
     def testBackgroundRateZero(self):
         ret = self._post('/rules', data=dict(backgroundRate=0, mapping='c', priority=33,

--- a/auslib/util/jsonschema_validators.py
+++ b/auslib/util/jsonschema_validators.py
@@ -4,7 +4,7 @@ from jsonschema.compat import str_types
 import logging
 import operator
 
-from auslib.util.comparison import get_op
+from auslib.util.comparison import get_op, strip_operator
 from auslib.util.versions import MozillaVersion
 
 logger = logging.getLogger(__name__)
@@ -24,6 +24,10 @@ def operator_validator(field_value):
     except TypeError:
         # get_op field returns None if no operator or no match, can't be unpacked
         raise jsonschema.ValidationError("Invalid input for buildID : %s. No Operator or Match found." % field_value)
+    try:
+        int(strip_operator(field_value))
+    except ValueError:
+        raise jsonschema.ValidationError("Invalid input for buildID: must be an integer.")
     return True
 
 
@@ -148,6 +152,6 @@ def ascii_validator(field_value):
     try:
         field_value.encode("ascii")
     except UnicodeEncodeError:
-        return False
+        raise jsonschema.ValidationError("value must be ascii")
 
     return True

--- a/auslib/util/jsonschema_validators.py
+++ b/auslib/util/jsonschema_validators.py
@@ -137,3 +137,17 @@ def signoffs_required_validator(field_value):
     if field_value is not None and field_value != '':
         logger.debug('starting in signoffs_required_validator: signoffs_required is %s' % field_value)
     return integer_and_range_validator("signoffs_required", field_value, 1)
+
+
+# TODO: Remove this after Balrog properly supports unicode. This is kindof a hacky workaround
+# for the problem described in https://bugzilla.mozilla.org/show_bug.cgi?id=1457893.
+@jsonschema.draft4_format_checker.checks(format="ascii", raises=jsonschema.ValidationError)
+def ascii_validator(field_value):
+    if field_value is None or field_value == '':
+        return True
+    try:
+        field_value.encode("ascii")
+    except UnicodeEncodeError:
+        return False
+
+    return True

--- a/auslib/web/admin/base.py
+++ b/auslib/web/admin/base.py
@@ -60,6 +60,10 @@ def ise(error):
     return error
 
 
+# Connexion's error handling sometimes breaks when parameters contain
+# unicode characters (https://github.com/zalando/connexion/issues/604).
+# To work around, we catch them and return a 400 (which is what Connexion
+# would do if it didn't hit this error).
 @app.errorhandler(UnicodeEncodeError)
 def unicode(error):
     return problem(400, "Unicode Error", "Connexion was unable to parse some unicode data correctly.")

--- a/auslib/web/admin/base.py
+++ b/auslib/web/admin/base.py
@@ -7,6 +7,7 @@ import auslib
 from os import path
 from flask import request
 from flask_compress import Compress
+from auslib.web.admin.views.problem import problem
 from auslib.web.admin.views.validators import BalrogRequestBodyValidator
 from raven.contrib.flask import Sentry
 from specsynthase.specbuilder import SpecBuilder
@@ -57,6 +58,11 @@ def ise(error):
     log.debug("Request environment is: %s", request.environ)
     log.debug("Request headers are: %s", request.headers)
     return error
+
+
+@app.errorhandler(UnicodeEncodeError)
+def unicode(error):
+    return problem(400, "Unicode Error", "Connexion was unable to parse some unicode data correctly.")
 
 
 @app.after_request

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -85,6 +85,7 @@ parameters:
     in: path
     description: unique identifier name of the user
     type: string
+    format: ascii
     maxLength: 100
     required: true
 
@@ -93,6 +94,7 @@ parameters:
     in: query
     description: unique identifier name of the user
     type: string
+    format: ascii
     minLength: 1
     maxLength: 100
     x-nullable: true
@@ -103,6 +105,7 @@ parameters:
     in: query
     description: valid csrf token
     type: string
+    format: ascii
     required: true
 
   dataVersionParam:
@@ -119,6 +122,7 @@ parameters:
     in: path
     description: Name of defined column in DB.
     type: string
+    format: ascii
     maxLength: 50
     required: true
 
@@ -135,6 +139,7 @@ parameters:
     in: query
     description: Name of the product to filter the rules/releases against.
     type: string
+    format: ascii
     minLength: 1
     maxLength: 15
     required: true
@@ -144,6 +149,7 @@ parameters:
     in: query
     description: roles are used when signing off on Scheduled Changes
     type: string
+    format: ascii
     minLength: 1
     maxLength: 50
     required: true
@@ -153,6 +159,7 @@ parameters:
     in: query
     description: The update channel of the application request an update.
     type: string
+    format: ascii
     minLength: 1
     maxLength: 75
     required: true
@@ -180,6 +187,7 @@ parameters:
     in: path
     description: user role to grant access to
     type: string
+    format: ascii
     maxLength: 50
     required: true
 
@@ -204,6 +212,7 @@ parameters:
     in: path
     description: name of DB column whose history is requested
     type: string
+    format: ascii
     required: true
 
   change_id_body_param:
@@ -257,6 +266,7 @@ parameters:
     in: query
     description: The username who made the requested changes.
     type: string
+    format: ascii
     x-nullable: true
     required: false
 
@@ -305,6 +315,7 @@ parameters:
     in: query
     description: channel stirng for filtering history.
     type: string
+    format: ascii
     x-nullable: true
     required: false
 
@@ -404,6 +415,7 @@ paths:
             X-CSRF-Token:
               description: token
               type: string
+              format: ascii
           examples:
             text/html: "csrf_token: 1491342563##c4e6fef0b978e6c89af9ff1015e67b9ca7c45d14"
 
@@ -519,6 +531,7 @@ paths:
           in: query
           description: The role(s) required for product signoff
           type: string
+          format: ascii
           x-nullable: true
           required: false
       responses:
@@ -553,6 +566,7 @@ paths:
           in: query
           description: The role(s) required for permission signoff
           type: string
+          format: ascii
           x-nullable: true
           required: false
       responses:
@@ -658,6 +672,7 @@ paths:
           in: query
           description: "If 'name_prefix' is passed, only Releases whose name starts with the given prefix will be returned."
           type: string
+          format: ascii
           x-nullable: true
           required: false
         - name: names_only
@@ -694,6 +709,7 @@ paths:
                 uniqueItems: true
                 items:
                   type: string
+                  format: ascii
                   maxLength: 100
           examples:
             application/json:
@@ -1079,10 +1095,12 @@ paths:
                               minItems: 0
                               items:
                                 type: string
+                                format: ascii
                               example: ["product", "data"]
                             _time_ago:
                               description: Time passed since the particular change
                               type: string
+                              format: ascii
                               example: "1 day ago"
                       required:
                         - name
@@ -1464,6 +1482,7 @@ paths:
                 minItems: 0
                 items:
                   type: string
+                  format: ascii
                 example: ["balrogadmin"]
 
   /users/{username}:
@@ -1495,6 +1514,7 @@ paths:
               username:
                 description: unique identifier name of the user
                 type: string
+                format: ascii
                 maxLength: 100
                 minLength: 1
                 example: balrogadmin
@@ -2121,6 +2141,7 @@ paths:
           in: query
           description: "'change_type' value for a scheduled change."
           type: string
+          format: ascii
           enum:
             - insert
             - delete
@@ -3955,6 +3976,7 @@ paths:
               change_type:
                 description: type of change
                 type: string
+                format: ascii
                 enum:
                   - delete
                 minLength: 1
@@ -4118,6 +4140,7 @@ definitions:
     properties:
       csrf_token:
         type: string
+        format: ascii
         example: "1491342563##c4e6fef0b978e6c89af9ff1015e67b9ca7c45d14"
 
   DataVersionNullable:
@@ -4175,6 +4198,7 @@ definitions:
       role:
         description: roles are used when signing off on Scheduled Changes
         type: string
+        format: ascii
         minLength: 1
         maxLength: 50
         example: releng
@@ -4187,6 +4211,7 @@ definitions:
       product:
         description: The product name that the client must send in order for the rule to match. Only full string matches are supported.
         type: ["string", "null"]
+        format: ascii
         minLength: 1
         maxLength: 15
         example: Firefox
@@ -4199,6 +4224,7 @@ definitions:
       permission:
         description: Permission name
         type: string
+        format: ascii
         minLength: 1
         maxLength: 50
         enum:
@@ -4214,6 +4240,7 @@ definitions:
       username:
         description: user name
         type: string
+        format: ascii
         minLength: 1
         maxLength: 100
         example: balrogadmin
@@ -4246,6 +4273,7 @@ definitions:
         example: false
       scheduled_by:
         type: string
+        format: ascii
         description: user who scheduled the change
         minLength: 1
         maxLength: 100
@@ -4278,11 +4306,13 @@ definitions:
       telemetry_product:
         description: Name of telemetry product
         type: ["string", "null"]
+        format: ascii
         minLength: 1
         maxLength: 15
       telemetry_channel:
         description: Name of telemetry channel
         type: ["string", "null"]
+        format: ascii
         minLength: 1
         maxLength: 75
       telemetry_uptake:
@@ -4310,6 +4340,7 @@ definitions:
       change_type:
         description: type of change
         type: string
+        format: ascii
         enum:
           - insert
           - update
@@ -4386,6 +4417,7 @@ definitions:
           hashFunction:
             description: cryptographic hash function to assure integrity of transmitted data
             type: string
+            format: ascii
             example: sha512
           schema_version:
             description: The version number of release
@@ -4396,10 +4428,12 @@ definitions:
           copyTo:
             description: List names of releases which the updated data must be copied to
             type: string
+            format: ascii
             format: JSONStringField
           alias:
             description: id of the release
             type: string
+            format: ascii
             format: JSONStringField
     required:
       - product
@@ -4430,12 +4464,14 @@ definitions:
             uniqueItems: true
             items:
               type: string
+              format: ascii
             example: ["Firefox"]
           actions:
             type: array
             uniqueItems: true
             items:
               type: string
+              format: ascii
             example: ["modify"]
 
   UserPermissionsModel:
@@ -4470,6 +4506,7 @@ definitions:
                     uniqueItems: true
                     items:
                       type: string
+                      format: ascii
 
         required:
           - data_version
@@ -4508,6 +4545,7 @@ definitions:
                     uniqueItems: true
                     items:
                       type: string
+                      format: ascii
         required:
           - data_version
 
@@ -4526,6 +4564,7 @@ definitions:
                     uniqueItems: true
                     items:
                       type: string
+                      format: ascii
         required:
           - data_version
 

--- a/auslib/web/admin/views/validators.py
+++ b/auslib/web/admin/views/validators.py
@@ -24,11 +24,13 @@ class BalrogRequestBodyValidator(RequestBodyValidator):
             for i in exception.path:
                 exception_field = i + ': '
             if exception.__cause__ is not None:
-                exception_message = str(exception.__cause__.message) + ' ' + exception_field + str(exception.message)
+                exception_message = exception.__cause__.message + ' ' + exception_field + exception.message
             else:
-                exception_message = exception_field + str(exception.message)
+                exception_message = exception_field + exception.message
+            # Some exceptions could contain unicode characters - if we don't replace them
+            # we could end up with a UnicodeEncodeError.
             logger.error("{url} validation error: {error}".
-                         format(url=url, error=exception_message))
+                         format(url=url, error=exception_message.encode("utf-8", "replace")))
             return problem(400, 'Bad Request', exception_message)
 
         return None

--- a/auslib/web/common/swagger/definitions.yml
+++ b/auslib/web/common/swagger/definitions.yml
@@ -239,6 +239,7 @@ definitions:
       channel:
         description: The update channel that the client must send in order for the rule to match. "*" can be used to glob at the end of the channel name.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 75
         example: beta

--- a/auslib/web/common/swagger/definitions.yml
+++ b/auslib/web/common/swagger/definitions.yml
@@ -79,6 +79,7 @@ definitions:
         example: 10
       changed_by:
         type: string
+        format: ascii
         minimum: 1
         maximum: 100
         example: "balrogadmin"
@@ -91,6 +92,7 @@ definitions:
       product:
         description: The product name that the client must send in order for the rule to match. Only full string matches are supported.
         type: string
+        format: ascii
         minLength: 1
         maxLength: 15
         example: Firefox
@@ -103,6 +105,7 @@ definitions:
       channel:
         description: The update channel of the application request an update.
         type: string
+        format: ascii
         minLength: 1
         maxLength: 75
         example: beta
@@ -115,6 +118,7 @@ definitions:
       name:
         description: Release name
         type: string
+        format: ascii
         minLength: 1
         maxLength: 100
         example: "Firefox-47.0.2-build2-43.0.1"
@@ -208,6 +212,7 @@ definitions:
       mapping:
         description: The Release to construct an update out of if the user is on the right side of a background rate dice roll, or if the background rate is 100. This is a foreign key to the "name" column of the Releases table.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 100
         example: No-Update
@@ -223,6 +228,7 @@ definitions:
       product:
         description: The product name that the client must send in order for the rule to match. Only full string matches are supported.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 15
         example: Firefox
@@ -247,6 +253,7 @@ definitions:
       buildTarget:
         description: The “build target” that the client must send in order for the rule to match. This is usually related to the target platform the app was built for. Only full string matches are supported.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 75
         example: Darwin_x86_64-gcc3-u-i386-x86_64
@@ -262,6 +269,7 @@ definitions:
       locale:
         description: The locale that the client must send in order for the rule to match. A comma separated list may be used to list multiple locales.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 200
         example: de
@@ -270,6 +278,7 @@ definitions:
         description: >
           The OS Version requirements that the client must meet in order for the rule to match. && may be used to match multiple substrings at once (eg: "Windows && (websense-"). Commas may be used to match any of a list of substrings.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 1000
         example: 'Windows_NT 5.0'
@@ -277,6 +286,7 @@ definitions:
       distribution:
         description: The partner distributions names that the application must send in order for the rule to match. A comma separated list may be used to list multiple distributions.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 2000
         example: default
@@ -284,6 +294,7 @@ definitions:
       distVersion:
         description: The version of the partner distribution that the application must send in order for the rule to match.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 100
         example: '1.19'
@@ -291,6 +302,7 @@ definitions:
       headerArchitecture:
         description: The client architecture (as guessed based on the User Agent) that the client must provide in order for the rule to match. This field is deprecated in favour of build target.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 10
         example: 'PPC'
@@ -298,6 +310,7 @@ definitions:
       comment:
         description: A string describing the purpose of the rule. Not always necessary for obvious rules.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 500
         example: lorem ipso facto
@@ -314,6 +327,7 @@ definitions:
         description: >
           The most modern CPU instruction set that the client must support in order for the rule to match. A comma separated list may be used to list multiple instruction sets.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 1000
         example: 'SSE'
@@ -321,6 +335,7 @@ definitions:
       memory:
         description: The amount of RAM, in megabytes, that the client must have for the rule to match. Comparisons such as "<8000" may be used.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 100
         example: '<8000'
@@ -328,6 +343,7 @@ definitions:
       fallbackMapping:
         description: The Release to construct an update out of when the user is on the wrong side of a background rate dice roll. This is a foreign key to the “name” column of the Releases table.
         type: ["string", "null"]
+        format: ascii
         minLength: 0
         maxLength: 100
         example: null

--- a/auslib/web/common/swagger/parameters.yml
+++ b/auslib/web/common/swagger/parameters.yml
@@ -4,6 +4,7 @@ parameters:
     in: query
     description: Name of the product to filter the rules/releases against.
     type: string
+    format: ascii
     x-nullable: true
     required: false
 
@@ -12,6 +13,7 @@ parameters:
     in: path
     description: Name of the product.
     type: string
+    format: ascii
     required: true
 
   channelQueryParam:
@@ -19,6 +21,7 @@ parameters:
     in: query
     description: Name of the channel to filter.
     type: string
+    format: ascii
     x-nullable: true
     required: false
 
@@ -27,6 +30,7 @@ parameters:
     in: path
     description: Release channel.
     type: string
+    format: ascii
     required: true
 
   releaseParam:
@@ -34,6 +38,7 @@ parameters:
     in: path
     description: release name
     type: string
+    format: ascii
     maxLength: 100
     required: true
   
@@ -68,6 +73,7 @@ parameters:
     in: path
     description: platform name
     type: string
+    format: ascii
     required: true
 
   localeParam:
@@ -75,6 +81,7 @@ parameters:
     in: path
     description: locale identifier
     type: string
+    format: ascii
     required: true
 
   rule_id_or_alias_param:

--- a/auslib/web/public/swagger/api.yml
+++ b/auslib/web/public/swagger/api.yml
@@ -101,6 +101,7 @@ paths:
           description: Platform Version.
           required: true
           type: string
+          format: ascii
         - $ref: '#/parameters/avast'
         - $ref: '#/parameters/force'
         - $ref: '#/parameters/mig64'
@@ -129,6 +130,7 @@ paths:
           description: IMEI
           required: true
           type: string
+          format: ascii
         - $ref: '#/parameters/avast'
         - $ref: '#/parameters/force'
         - $ref: '#/parameters/mig64'
@@ -156,6 +158,7 @@ paths:
             The supported hardware features of the application requesting an update. This field is primarily used to point desupported users based on their hardware. Eg: users who do not support SSE2.
           required: true
           type: string
+          format: ascii
         - $ref: '#/parameters/distribution'
         - $ref: '#/parameters/distVersion'
         - $ref: '#/parameters/avast'
@@ -227,6 +230,7 @@ parameters:
     description: The name of the application requesting an update.
     required: true
     type: string
+    format: ascii
 
   productQuery:
     name: product
@@ -234,6 +238,7 @@ parameters:
     in: query
     required: false
     type: string
+    format: ascii
 
   version:
     name: version
@@ -241,6 +246,7 @@ parameters:
     description: The version of the application requesting an update.
     required: true
     type: string
+    format: ascii
 
   buildID:
     name: buildID
@@ -255,6 +261,7 @@ parameters:
     description: The “build target” of the application requesting an update. This is usually related to the target platform the app was built for.
     required: true
     type: string
+    format: ascii
 
   locale:
     name: locale
@@ -262,6 +269,7 @@ parameters:
     description: The locale of the application requesting an update.
     required: true
     type: string
+    format: ascii
 
   channel:
     name: channel
@@ -269,6 +277,7 @@ parameters:
     description: The update channel of the application request an update.
     required: true
     type: string
+    format: ascii
 
   osVersion:
     name: osVersion
@@ -276,6 +285,7 @@ parameters:
     description: The OS Version of the application requesting an update. This field is primarily used to point desupported operating systems to their last supported build.
     required: true
     type: string
+    format: ascii
     default: ""
 
   distribution:
@@ -284,6 +294,7 @@ parameters:
     description: The partner distribution name of the application requesting an update or “default” if the application is not a partner build.
     required: true
     type: string
+    format: ascii
 
   distVersion:
     name: distVersion
@@ -291,6 +302,7 @@ parameters:
     description: The version of the partner distribution of the application requesting an update or “default” if the application is not a partner build.
     required: true
     type: string
+    format: ascii
 
   avast:
     name: avast

--- a/auslib/web/public/swagger/public_api_spec.yml
+++ b/auslib/web/public/swagger/public_api_spec.yml
@@ -19,6 +19,7 @@ paths:
           in: query
           description: "If 'name_prefix' is passed, only Releases whose name starts with the given prefix will be returned."
           type: string
+          format: ascii
           x-nullable: true
           required: false
         - name: names_only
@@ -49,6 +50,7 @@ paths:
                 uniqueItems: true
                 items:
                   type: string
+                  format: ascii
                   maxLength: 100
           examples:
             application/json:
@@ -136,10 +138,12 @@ paths:
                               minItems: 0
                               items:
                                 type: string
+                                format: ascii
                               example: ["product", "data"]
                             _time_ago:
                               description: Time passed since the particular change
                               type: string
+                              format: ascii
                               example: "1 day ago"
                       required:
                         - name


### PR DESCRIPTION
This patch should prevent unicode input to all fields, enforced via new custom format that connexion validates. I don't really think this is the ideal solution (we should probably support unicode, because I strongly suspect we'll have a use case for unicode in the update URL at some point), but doing this for now prevents the footgun/attack of DoS by putting unicode into the database.

I think it's mostly straightforward, but I did hit a couple of notable issues:
* Some of our error handling code was using `str()` when constructing some error messages. This causes `UnicodeEncodeError`s when the string contains unicode characters. I switched these to explicit UTF-8 encodes instead.
* Some of `connexion`'s error handling code also has a similar issue. The best way I could come up with to workaround this was to catch the errors and return a proper 400 (without it, it's an ISE 500). I filed https://github.com/zalando/connexion/issues/604 for this, too. I think this can be removed after we upgrade to Python 3, because the default encoding is smarter:
```
Python 2.7.15rc1 (default, Apr 15 2018, 21:51:34) 
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.getdefaultencoding()
'ascii'
```
```
Python 3.6.5 (default, Apr  1 2018, 05:46:30) 
[GCC 7.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.getdefaultencoding()
'utf-8'
```

I didn't write too many tests for this because this is primarily going through connexion code paths. I did a bunch of manual testing though, and got reasonable error messages in those.

I also discovered that we accept non-integer buildids, which I figured I'd fix.