### PR TITLE
bug 1468638: fix some non-determinism in test coverage

### DIFF
--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1703,6 +1703,7 @@ class TestReleasesScheduledChanges(ViewTest):
         }
         self.assertEquals(ret, expected)
 
+    @mock.patch("time.time", mock.MagicMock(return_value=300000))
     def testGetReleaseHistoryWithinTimeRange(self):
         ret = self._get("/releases/history", qs={"timestamp_from": 15, "timestamp_to": 33})
         self.assertEquals(ret.status_code, 200, ret.data)
@@ -1847,6 +1848,7 @@ class TestReleaseHistoryView(ViewTest):
         with self.assertRaises(KeyError):
             data['data']
 
+    @mock.patch("time.time", mock.MagicMock(return_value=300000))
     def testGetHistory(self):
         url = '/releases/history'
         ret = self._get(url)

--- a/auslib/test/blobs/test_base.py
+++ b/auslib/test/blobs/test_base.py
@@ -118,6 +118,44 @@ json = st.dictionaries(st.text(),
                        max_size=10)
 
 
+def test_merge_dicts_simple_additions():
+    base = {
+        "nothing": "nothing",
+    }
+    left = deepcopy(base)
+    right = deepcopy(base)
+    expected = deepcopy(base)
+    left["foo"] = "foo"
+    right["bar"] = "bar"
+    got = merge_dicts(base, left, right)
+    expected = {
+        "foo": "foo",
+        "bar": "bar",
+        "nothing": "nothing",
+    }
+    assert got == expected
+
+
+def test_merge_dicts_simple_changes():
+    base = {
+        "foo": "oof",
+        "bar": "rab",
+        "nothing": "nothing",
+    }
+    left = deepcopy(base)
+    right = deepcopy(base)
+    expected = deepcopy(base)
+    left["foo"] = "foo"
+    right["bar"] = "bar"
+    got = merge_dicts(base, left, right)
+    expected = {
+        "foo": "foo",
+        "bar": "bar",
+        "nothing": "nothing",
+    }
+    assert got == expected
+
+
 # too_slow health checks are repressed because tests can be slow in CI, and we
 # don't want CI failures due to this.
 @settings(max_examples=50, suppress_health_check=[HealthCheck.too_slow])


### PR DESCRIPTION
I dug into the coverage reports a bit and found a few lines that were inconsistently covered. Some were what we talked about yesterday -- blob merging code that was only being tested by hypothesis. The other was https://github.com/mozilla/balrog/blob/master/auslib/util/timesince.py#L97 -- which appears as if it will only be hit on certain days of the week. I think other lines in that file are subject to similar inconsistency - but the fix provided here should prevent them, too.

I did find one inconsistency that I haven't been able to track down, which can be seen by comparing https://coveralls.io/builds/17398077/source?filename=auslib/log.py to https://coveralls.io/builds/17398286/source?filename=auslib/log.py. It seems pretty rare, and I couldn't think of an easy way to force it into coverage, so I didn't address it here.