### PR TITLE
Fix CSRF validation

### DIFF
--- a/agent/balrogagent/client.py
+++ b/agent/balrogagent/client.py
@@ -21,6 +21,7 @@ async def request(api_root, path, method="GET", data={}, headers=default_headers
     data = data.copy()
 
     async with aiohttp.ClientSession(loop=loop) as client:
+        # CSRF tokens are only required for POST/PUT/DELETE.
         if method not in ("HEAD", "GET"):
             logging.debug("Sending %s request to %s", "HEAD", csrf_url)
             async with client.request("HEAD", csrf_url, auth=auth) as resp:

--- a/agent/balrogagent/client.py
+++ b/agent/balrogagent/client.py
@@ -20,15 +20,15 @@ async def request(api_root, path, method="GET", data={}, headers=default_headers
     csrf_url = get_url(api_root, "/csrf_token")
     data = data.copy()
 
-    # CSRF tokens are only required for POST/PUT/DELETE.
-    if method not in ("HEAD", "GET"):
-        logging.debug("Sending %s request to %s", "HEAD", csrf_url)
-        async with aiohttp.request("HEAD", csrf_url, auth=auth, loop=loop) as resp:
-            resp.raise_for_status()
-            data["csrf_token"] = resp.headers["X-CSRF-Token"]
+    async with aiohttp.ClientSession(loop=loop) as client:
+        if method not in ("HEAD", "GET"):
+            logging.debug("Sending %s request to %s", "HEAD", csrf_url)
+            async with client.request("HEAD", csrf_url, auth=auth) as resp:
+                resp.raise_for_status()
+                data["csrf_token"] = resp.headers["X-CSRF-Token"]
 
-    logging.debug("Sending %s request to %s", method, url)
-    async with aiohttp.request(method, url, data=json.dumps(data), headers=headers, auth=auth, loop=loop) as resp:
-        # Raises on 400 code or higher, we can assume things are good if we make it past this.
-        resp.raise_for_status()
-        return (await resp.json())
+        logging.debug("Sending %s request to %s", method, url)
+        async with client.request(method, url, data=json.dumps(data), headers=headers, auth=auth) as resp:
+            # Raises on 400 code or higher, we can assume things are good if we make it past this.
+            resp.raise_for_status()
+            return (await resp.json())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - bash
       - scripts/initdb_and_run.sh
     command: admin-dev
+    ports:
+      - "7070:7070"
     expose:
       - "7070"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - bash
       - scripts/initdb_and_run.sh
     command: admin-dev
-    ports:
-      - "7070:7070"
     expose:
       - "7070"
     volumes:

--- a/ui/app/js/controllers/disable_updates_modal.js
+++ b/ui/app/js/controllers/disable_updates_modal.js
@@ -1,23 +1,25 @@
 angular.module('app').controller('DisableUpdatesModalCtrl',
-  function($scope, $modalInstance, EmergencyShutoffs, product, channel){
+  function($scope, $modalInstance, CSRF, EmergencyShutoffs, product, channel){
     $scope.product = product;
     $scope.channel = channel;
     $scope.saving = false;
 
     $scope.disableUpdates = function() {
       $scope.saving = true;
-      EmergencyShutoffs.create($scope.product, $scope.channel)
-        .success(function(response) {
-          $modalInstance.close(response);
-          sweetAlert("Disabling Updates", "Updates were disabled successfully!", "success");
-        })
-        .error(function(response, status) {
-          if (typeof response === 'object') {
-            sweetAlert("Form submission error", response.data, "error");
-          }
-        })
-        .finally(function() {
-          $scope.saving = false;
+      CSRF.getToken().then(function(csrf_token) {
+        EmergencyShutoffs.create($scope.product, $scope.channel, csrf_token)
+          .success(function(response) {
+            $modalInstance.close(response);
+            sweetAlert("Disabling Updates", "Updates were disabled successfully!", "success");
+          })
+          .error(function(response, status) {
+            if (typeof response === 'object') {
+              sweetAlert("Form submission error", response.data, "error");
+            }
+          })
+          .finally(function() {
+            $scope.saving = false;
+          });
         });
     };
 

--- a/ui/app/js/services/emergency_shutoffs.js
+++ b/ui/app/js/services/emergency_shutoffs.js
@@ -3,8 +3,8 @@ angular.module('app').factory('EmergencyShutoffs', function($http, ScheduledChan
     get: function() {
       return $http.get('/api/emergency_shutoff');
     },
-    create: function(product, channel) {
-      data = {'product': product, 'channel': channel};
+    create: function(product, channel, csrf_token) {
+      data = {'product': product, 'channel': channel, 'csrf_token': csrf_token};
       return $http.post('/api/emergency_shutoff', data);
     },
     delete: function(product, channel, data_version, csrf_token) {

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -75,13 +75,13 @@ class JSONCSRFProtect(CSRFProtect):
         from flask import current_app, request
 
         def get_token():
-            field_name = current_app.config["WTF_CSRF_FIELD_NAME"]
             token = CSRFProtect._get_csrf_token(self)
             yield token
+            field_name = current_app.config["WTF_CSRF_FIELD_NAME"]
             if request.json:
                 token = request.json.get(field_name)
                 yield token
-            token = request.args[field_name]
+            token = request.args.get(field_name)
             yield token
 
         for token in get_token():


### PR DESCRIPTION
This PR fixes:
- CSRF validation when token comes from query string;
- Add missing token in Emergency Shutoff payload;
- Add CSRF request and update request in the same client session;

While I was testing #621, realize some problems with CSRF validation, I confirm the problem with `balrog/master`. The most problems is with DELETE methods, that sends CSRF token in query string.

```
balrogadmin_1  | 2018-06-24 17:57:41,822 - ERROR - PID: 18 - Request: 140124210730448 - flask.app.log_exception#1761: Exception on /releases/CDM-15 [DELETE]
balrogadmin_1  | Traceback (most recent call last):
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 2292, in wsgi_app
balrogadmin_1  |     response = self.full_dispatch_request()
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1815, in full_dispatch_request
balrogadmin_1  |     rv = self.handle_user_exception(e)
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1718, in handle_user_exception
balrogadmin_1  |     reraise(exc_type, exc_value, tb)
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1811, in full_dispatch_request
balrogadmin_1  |     rv = self.preprocess_request()
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 2087, in preprocess_request
balrogadmin_1  |     rv = func()



balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask_wtf/csrf.py", line 221, in csrf_protect
balrogadmin_1  |     self.protect()
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask_wtf/csrf.py", line 249, in protect
balrogadmin_1  |     validate_csrf(self._get_csrf_token())
balrogadmin_1  |   File "/app/uwsgi/admin.wsgi", line 79, in _get_csrf_token
balrogadmin_1  |     token = request.json.get(field_name)
balrogadmin_1  | AttributeError: 'NoneType' object has no attribute 'get'
balrogadmin_1  | 2018-06-24 17:57:41,823 - ERROR - PID: 18 - Request: 140124210730448 - auslib.web.admin.base.ise#55: Caught ISE 500 error.



balrogadmin_1  | Traceback (most recent call last):
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 2309, in __call__
balrogadmin_1  |     return self.wsgi_app(environ, start_response)
balrogadmin_1  |   File "./auslib/web/admin/base.py", line 47, in __call__
balrogadmin_1  |     return self.app(environ, start_response)
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 2295, in wsgi_app
balrogadmin_1  |     response = self.handle_exception(e)
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1748, in handle_exception
balrogadmin_1  |     return self.finalize_request(handler(e), from_error_handler=True)
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1831, in finalize_request
balrogadmin_1  |     response = self.make_response(rv)
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1982, in make_response
balrogadmin_1  |     reraise(TypeError, new_error, sys.exc_info()[2])
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1974, in make_response
balrogadmin_1  |     rv = self.response_class.force_type(rv, request.environ)
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/werkzeug/wrappers.py", line 921, in force_type
balrogadmin_1  |     response = BaseResponse(*_run_wsgi_app(response, environ))
balrogadmin_1  |   File "/usr/local/lib/python2.7/site-packages/werkzeug/test.py", line 923, in run_wsgi_app
balrogadmin_1  |     app_rv = app(environ, start_response)
balrogadmin_1  | TypeError: 'exceptions.AttributeError' object is not callable
balrogadmin_1  | The view function did not return a valid response. The return type must be a string, tuple, Response instance, or WSGI callable, but it was a AttributeError.
```