### PR TITLE
Give the balrog agent image-generation a unique name

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -199,8 +199,8 @@ tasks:
         branches:
           - master
     metadata:
-      name: Balrog Docker Image Creation
-      description: Balrog Docker Image Creation
+      name: Balrog Agent Docker Image Creation
+      description: Balrog Agent Docker Image Creation
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"
 


### PR DESCRIPTION
We already do this for the release-style events but missed it for the PR case.