### PR TITLE
Stop using docker-in-docker for test jobs.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -42,7 +42,7 @@ tasks:
         - "-c"
         - >
           apt-get -q --yes update && apt-get -q --yes install git libmysqlclient-dev gcc &&
-          git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && pip install -r requirements-tox.ini && tox
+          git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && pip install -r requirements-tox.txt && tox
       features:
         taskclusterProxy: true
     extra:
@@ -98,7 +98,7 @@ tasks:
         - "-c"
         - >
           apt-get -q --yes update && apt-get -q --yes install git &&
-          git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd agent && pip install -r requirements-tox.ini && tox
+          git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd agent && pip install -r requirements-tox.txt && tox
     extra:
       github:
         env: true

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -40,8 +40,9 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "apt-get -q --yes update && apt-get -q --yes install git libmysqlclient-dev gcc && "
-        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && pip install -r requirements-tox.ini && tox"
+        - >
+          apt-get -q --yes update && apt-get -q --yes install git libmysqlclient-dev gcc &&
+          git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && pip install -r requirements-tox.ini && tox
       features:
         taskclusterProxy: true
     extra:
@@ -68,8 +69,9 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "apt-get -q --yes update && apt-get -q --yes install git nodejs nodejs-legacy npm libfontconfig1 && "
-        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd ui && npm install && npm run build && npm test"
+        - >
+          apt-get -q --yes update && apt-get -q --yes install git nodejs nodejs-legacy npm libfontconfig1 &&
+          git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd ui && npm install && npm run build && npm test
     extra:
       github:
         env: true
@@ -94,8 +96,9 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "apt-get -q --yes update && apt-get -q --yes install git && "
-        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd agent && pip install -r requirements-tox.ini && tox"
+        - >
+          apt-get -q --yes update && apt-get -q --yes install git &&
+          git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd agent && pip install -r requirements-tox.ini && tox
     extra:
       github:
         env: true
@@ -120,8 +123,9 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "apt-get -q --yes update && apt-get -q --yes install git && "
-        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd client && tox"
+        - >
+          apt-get -q --yes update && apt-get -q --yes install git &&
+          git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd client && tox
     extra:
       github:
         env: true

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -123,9 +123,7 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - >
-          apt-get -q --yes update && apt-get -q --yes install git &&
-          git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd client && tox
+        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd client && tox"
     extra:
       github:
         env: true

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -35,16 +35,14 @@ tasks:
     scopes:
       - secrets:get:repo:github.com/mozilla/balrog:coveralls
     payload:
-      maxRunTime: 1200
-      image: "mozillareleases/python-test-runner"
-      env:
-        NO_VOLUME_MOUNT: 1
+      maxRunTime: 3600
+      image: "python:2.7-slim-jessie"
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && bash run-tests.sh backend"
+        - "apt-get -q --yes update && apt-get -q --yes install git libmysqlclient-dev gcc && "
+        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && pip install -r requirements-tox.ini && tox"
       features:
-        dind: true
         taskclusterProxy: true
     extra:
       github:
@@ -66,15 +64,12 @@ tasks:
     workerType: "{{ taskcluster.docker.workerType }}"
     payload:
       maxRunTime: 1200
-      image: "mozillareleases/python-test-runner"
-      env:
-        NO_VOLUME_MOUNT: 1
+      image: "python:2.7-slim-jessie"
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && bash run-tests.sh frontend"
-      features:
-        dind: true
+        - "apt-get -q --yes update && apt-get -q --yes install git nodejs nodejs-legacy npm libfontconfig1 && "
+        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd ui && npm install && npm run build && npm test"
     extra:
       github:
         env: true
@@ -95,15 +90,12 @@ tasks:
     workerType: "{{ taskcluster.docker.workerType }}"
     payload:
       maxRunTime: 1200
-      image: "mozillareleases/python-test-runner"
-      env:
-        NO_VOLUME_MOUNT: 1
+      image: "python:3.6-slim"
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd agent && bash run-tests.sh"
-      features:
-        dind: true
+        - "apt-get -q --yes update && apt-get -q --yes install git && "
+        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd agent && pip install -r requirements-tox.ini && tox"
     extra:
       github:
         env: true
@@ -125,14 +117,11 @@ tasks:
     payload:
       maxRunTime: 1200
       image: "mozillareleases/python-test-runner"
-      env:
-        NO_VOLUME_MOUNT: 1
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd client && bash run-tests.sh"
-      features:
-        dind: true
+        - "apt-get -q --yes update && apt-get -q --yes install git && "
+        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && cd client && tox"
     extra:
       github:
         env: true


### PR DESCRIPTION
This turned out to be pretty simple - I just needed to:
- replace the python-test-runner images with the appropriate one for each test
- install some dependencies with apt-get
- run tox/npm instead of run-tests.sh

It doesn't get rid of the docker-in-docker usage for the image building tasks, because we actually do need Docker to do it!

I tested this with some manually tweaked jobs (I'm not sure the PR will use the new yml or not, we'll see!). They are:
https://tools.taskcluster.net/groups/NgUBXgnrSe2dMTxOgaFqZg/tasks/NgUBXgnrSe2dMTxOgaFqZg/details
https://tools.taskcluster.net/groups/a41RD1BLT36wNpMUMqSqrw/tasks/a41RD1BLT36wNpMUMqSqrw/details
https://tools.taskcluster.net/groups/ZsuCYyD5SQiZP5TN7-4x0w/tasks/ZsuCYyD5SQiZP5TN7-4x0w/details
https://tools.taskcluster.net/groups/GZfc-asiRaKXvFUMBSSXBw/tasks/GZfc-asiRaKXvFUMBSSXBw/details

There seems to be a bit of traction on https://bugzilla.mozilla.org/show_bug.cgi?id=1472913 now, so I'm not sure we want to do this. Or maybe we should do it, and then back it out once dind is more stable.