### PR TITLE
bug 1481317: Don't allow beta tags for 5.0+ versions.

### DIFF
--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -230,6 +230,20 @@ class TestRulesAPI_JSON(ViewTest):
                                                  channel="nightly", update_type="minor", version="%s5" % op))
             self.assertEquals(ret.status_code, 400)
 
+    def testVersionValidationAlphaTagsAllowedForModernVersions(self):
+        ret = self._post("/rules", data=dict(backgroundRate=42, mapping="d", priority=50, product="Firefox",
+                                             channel="nightly", update_type="minor", version="5.0a1"))
+        self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" %
+                          (ret.status_code, ret.data))
+        r = dbo.rules.t.select().where(dbo.rules.rule_id == ret.data).execute().fetchall()
+        self.assertEquals(len(r), 1)
+        self.assertEquals(r[0]['version'], '5.0a1')
+
+    def testVersionValidationNoBetaTagsAllowedForModernVersions(self):
+        ret = self._post("/rules", data=dict(backgroundRate=42, mapping="d", priority=50, product="Firefox",
+                                             channel="nightly", update_type="minor", version="5.0b4"))
+        self.assertEquals(ret.status_code, 400)
+
     def testBuildIDValidation(self):
         for op in operators:
             ret = self._post('/rules', data=dict(backgroundRate=42, mapping='d', priority=50,

--- a/auslib/util/versions.py
+++ b/auslib/util/versions.py
@@ -4,6 +4,13 @@ import re
 from auslib.errors import BadDataError
 
 
+class PostModernMozillaVersion(StrictVersion):
+    """A version class that supports Firefox versions 5.0 and up, which
+       may have "a1" but not "b2" tags in them"""
+    version_re = re.compile(r"""^(\d+) \. (\d+) (\. (\d+))?
+                                (a(\d+))?$""", re.VERBOSE)
+
+
 class ModernMozillaVersion(StrictVersion):
     """A version class that is slightly less restrictive than StrictVersion.
        Instead of just allowing "a" or "b" as prerelease tags, it allows any
@@ -26,15 +33,15 @@ class AncientMozillaVersion(StrictVersion):
 
 def MozillaVersion(version):
     try:
-        return ModernMozillaVersion(version)
-    except ValueError:
-        pass
-    try:
-        if version.count('.') == 3:
+        if version.count(".") in (1, 2):
+            if int(version[0]) > 4:
+                return PostModernMozillaVersion(version)
+            else:
+                return ModernMozillaVersion(version)
+        else:
             return AncientMozillaVersion(version)
     except ValueError:
-        pass
-    raise BadDataError("Version number %s is invalid." % version)
+        raise BadDataError("Version number %s is invalid." % version)
 
 
 def increment_version(version):


### PR DESCRIPTION
This hasn't been tested well enough yet, but it seems to work.