### PR TITLE
Fix new test to cast rule id to int before comparing it.

### DIFF
--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -243,9 +243,10 @@ class TestRulesAPI_JSON(ViewTest):
     def testVersionValidationAlphaTagsAllowedForModernVersions(self):
         ret = self._post("/rules", data=dict(backgroundRate=42, mapping="d", priority=50, product="Firefox",
                                              channel="nightly", update_type="minor", version="5.0a1"))
+        rule_id = int(ret.get_data())
         self.assertEquals(ret.status_code, 200, "Status Code: %d, Data: %s" %
-                          (ret.status_code, ret.data))
-        r = dbo.rules.t.select().where(dbo.rules.rule_id == ret.data).execute().fetchall()
+                          (ret.status_code, rule_id))
+        r = dbo.rules.t.select().where(dbo.rules.rule_id == rule_id).execute().fetchall()
         self.assertEquals(len(r), 1)
         self.assertEquals(r[0]['version'], '5.0a1')
 


### PR DESCRIPTION
This should fix up the test failure on master. Originally I was thinking we should return an int for this endpoint, but I discovered that Werkzeug or Flask doesn't support non-sequence types as response bodies - we end up with tracebacks such as 
```
auslib/test/admin/views/base.py:197: in _post
    return self.client.post(url, data=json.dumps(data), content_type="application/json", environ_base=self._getAuth(username), **kwargs)
.tox/py36/lib/python3.6/site-packages/werkzeug/test.py:840: in post
    return self.open(*args, **kw)
.tox/py36/lib/python3.6/site-packages/flask/testing.py:200: in open
    follow_redirects=follow_redirects
.tox/py36/lib/python3.6/site-packages/werkzeug/test.py:803: in open
    response = self.run_wsgi_app(environ, buffered=buffered)
.tox/py36/lib/python3.6/site-packages/werkzeug/test.py:716: in run_wsgi_app
    rv = run_wsgi_app(self.application, environ, buffered=buffered)
.tox/py36/lib/python3.6/site-packages/werkzeug/test.py:923: in run_wsgi_app
    app_rv = app(environ, start_response)
.tox/py36/lib/python3.6/site-packages/flask/app.py:2309: in __call__
    return self.wsgi_app(environ, start_response)
auslib/web/admin/base.py:53: in __call__
    return self.app(environ, start_response)
.tox/py36/lib/python3.6/site-packages/flask/app.py:2295: in wsgi_app
    response = self.handle_exception(e)
.tox/py36/lib/python3.6/site-packages/flask/app.py:1741: in handle_exception
    reraise(exc_type, exc_value, tb)
.tox/py36/lib/python3.6/site-packages/flask/_compat.py:35: in reraise
    raise value
.tox/py36/lib/python3.6/site-packages/flask/app.py:2292: in wsgi_app
    response = self.full_dispatch_request()
.tox/py36/lib/python3.6/site-packages/flask/app.py:1815: in full_dispatch_request
    rv = self.handle_user_exception(e)
.tox/py36/lib/python3.6/site-packages/flask/app.py:1718: in handle_user_exception
    reraise(exc_type, exc_value, tb)
.tox/py36/lib/python3.6/site-packages/flask/_compat.py:35: in reraise
    raise value
.tox/py36/lib/python3.6/site-packages/flask/app.py:1813: in full_dispatch_request
    rv = self.dispatch_request()
.tox/py36/lib/python3.6/site-packages/flask/app.py:1799: in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
.tox/py36/lib/python3.6/site-packages/connexion/decorators/decorator.py:73: in wrapper
    response = function(request)
.tox/py36/lib/python3.6/site-packages/connexion/decorators/uri_parsing.py:117: in wrapper
    response = function(request)
.tox/py36/lib/python3.6/site-packages/connexion/decorators/validation.py:129: in wrapper
    response = function(request)
.tox/py36/lib/python3.6/site-packages/connexion/decorators/validation.py:300: in wrapper
    return function(request)
.tox/py36/lib/python3.6/site-packages/connexion/decorators/response.py:105: in wrapper
    return _wrapper(request, response)
.tox/py36/lib/python3.6/site-packages/connexion/decorators/response.py:86: in _wrapper
    self.operation.api.get_connexion_response(response)
.tox/py36/lib/python3.6/site-packages/connexion/apis/flask_api.py:203: in get_connexion_response
    body=response.get_data(),
.tox/py36/lib/python3.6/site-packages/werkzeug/wrappers.py:986: in get_data
    self._ensure_sequence()
.tox/py36/lib/python3.6/site-packages/werkzeug/wrappers.py:1043: in _ensure_sequence
    self.make_sequence()
.tox/py36/lib/python3.6/site-packages/werkzeug/wrappers.py:1058: in make_sequence
    self.response = list(self.iter_encoded())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

iterable = 10, charset = 'utf-8'

    def _iter_encoded(iterable, charset):
>       for item in iterable:
E       TypeError: 'int' object is not iterable

```