### PR TITLE
Revert "Bug 1416606 - apply poll interval hack to new location"

### DIFF
--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -7,6 +7,6 @@ cd /app
 # fully track it down, but jlorenzo discovered that adjusting this setInterval has made a
 # huge difference without affecting the responsiveness of the UI rebuilding.
 # This really needs a deeper investigation, and a more robust fix.
-sed -i -e 's/200/10000/' /app/node_modules/grunt-watch-nospawn/tasks/watch.js
+sed -i -e 's/200/10000/' /app/node_modules/lineman/node_modules/grunt-watch-nospawn/tasks/watch.js
 /usr/local/bin/npm build
 /usr/local/bin/npm start


### PR DESCRIPTION
This reverts commit b2412eaf40bb26eb609c9f7460a444b5841eed51 from #448.

I'm wondering if that was just wrong due to some local screwup in my ui/node_modules, or maybe something got reverted in JS land. At any rate, my fans have been running far too much when Balrog was mostly-idle, and lo-and-behold the sed command wasn't having any effect.