### PR TITLE
Disable response validation for the admin app.

### DIFF
--- a/auslib/web/admin/base.py
+++ b/auslib/web/admin/base.py
@@ -32,7 +32,7 @@ validator_map = {
 }
 
 connexion_app = connexion.App(__name__, validator_map=validator_map, debug=False)
-connexion_app.add_api(spec, validate_responses=True, strict_validation=True)
+connexion_app.add_api(spec, strict_validation=True)
 app = connexion_app.app
 sentry = Sentry()
 


### PR DESCRIPTION
Rail discovered that after https://bugzilla.mozilla.org/show_bug.cgi?id=1481317 landed, the Rule Scheduled Changes page was returning 500s like:
```
{
  "detail": "u'<56.0b8' is not a 'version'\n\nFailed validating 'format' in schema['allOf'][1]['properties']['scheduled_changes']['items']['allOf'][1]['allOf'][4]['properties']['version']:\n    {'description': 'The version requirements that the client must meet in order for the rule to match. Exact matches, comma separated lists (eg: \"36.0,36.0.1\") and comparisons (eg: \"<45.0\") are allowed.\\n',\n     'example': '36.0',\n     'format': 'version',\n     'maxLength': 75,\n     'minLength': 0,\n     'type': ['string', 'null']}\n\nOn instance['scheduled_changes'][233]['version']:\n    u'<56.0b8'",
  "status": 500,
  "title": "Response body does not conform to specification",
  "type": "about:blank"
}
```

This is because we're loading Scheduled Changes history that includes versions with beta numbers in them, and we have response validation enabled on the admin app.

This is definitely the quick fix, and possibly the correct one - I don't think response validation can be disabled for specific endpoints...