### PR TITLE
Experimental: Balrog UI over node-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,12 @@ COPY version.json /app/
 WORKDIR /app
 
 RUN cd ui && \
-    apt-get -q --yes install nodejs nodejs-legacy npm && \
+    apt-get -q --yes install curl git bzip2 && \
+    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get -q --yes install nodejs && \
     npm install && \
     npm run build && \
-    apt-get -q --yes remove nodejs nodejs-legacy npm && \
+    apt-get -q --yes remove nodejs && \
     apt-get -q --yes autoremove && \
     apt-get clean && \
     rm -rf /root/.npm /tmp/phantomjs && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,8 +14,10 @@ MAINTAINER bhearsum@mozilla.com
 # libfontconfig1 is required by phantomjs
 # git is needed to send coverage information
 RUN apt-get -q update \
-    && apt-get -q --yes install netcat libpcre3 libpcre3-dev nodejs nodejs-legacy npm libmysqlclient-dev mysql-client \
-                                libfontconfig1 netcat git curl xz-utils \
+    && apt-get -q --yes install netcat libpcre3 libpcre3-dev libmysqlclient-dev mysql-client \
+                                libfontconfig1 netcat git curl xz-utils bzip2 gcc \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash \
+    && apt-get -q --yes install nodejs \
     && apt-get clean
 
 WORKDIR /app

--- a/Dockerfile.py3.dev
+++ b/Dockerfile.py3.dev
@@ -6,7 +6,10 @@ MAINTAINER bhearsum@mozilla.com
 # mysql-client is needed to import sample data
 # libmysqlclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
 RUN apt-get -q update \
-    && apt-get -q --yes install netcat libpcre3 libpcre3-dev nodejs nodejs-legacy libmysqlclient-dev mysql-client curl gcc xz-utils \
+    && apt-get -q --yes install netcat libpcre3 libpcre3-dev libmysqlclient-dev \
+                                mysql-client curl gcc xz-utils bzip2 \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash \
+    && apt-get -q --yes install nodejs \
     && apt-get clean
 
 WORKDIR /app

--- a/docker-compose-py3.yml
+++ b/docker-compose-py3.yml
@@ -86,7 +86,7 @@ services:
 
 
   balrogui-py3:
-    image: node:0.10
+    image: node:8
     depends_on:
       balrogadmin-py3:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
 
 
   balrogui:
-    image: node:0.10
+    image: node:8
     depends_on:
       balrogadmin:
         condition: service_healthy

--- a/ui/config/application.js
+++ b/ui/config/application.js
@@ -25,7 +25,8 @@ module.exports = function(lineman) {
 
     jshint: {
       options: {
-        esnext: true
+        esnext: true,
+        reporterOutput: ''
       },
     },
 


### PR DESCRIPTION
While I was trying to made a fresh installation (when node_modules does not exists yet) of development env of Balrog, I was not able to start Balrog UI successfully. Probably some packages that our dependencies use was updated and it is not supported by node-0.10 anymore.

The container logs not help to discover which of packages is broken due ES6 syntax:
```
ex-dev@exdev-moz:~/code.exdev/mozilla/releng/balrog$ docker logs balrog_balrogui_1
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
npm WARN deprecated coffee-script@1.7.1: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
npm WARN deprecated coffee-script@1.3.3: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
npm WARN deprecated coffee-script@1.6.3: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
npm WARN engine request@2.81.0: wanted: {"node":">= 4"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN deprecated exec@0.1.4: deprecated in favor of builtin child_process.execFile
npm WARN deprecated graceful-fs@1.2.3: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
npm WARN engine http-proxy@1.17.0: wanted: {"node":">=4.0.0"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN engine form-data@2.1.4: wanted: {"node":">= 0.12"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN engine har-validator@4.2.1: wanted: {"node":">=4"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated ejs@0.8.8: Critical security bugs fixed in 2.5.5
npm WARN engine request@2.88.0: wanted: {"node":">= 4"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN deprecated connect@2.9.0: connect 2.x series is deprecated
npm WARN engine har-schema@1.0.5: wanted: {"node":">=4"} (current: {"node":"0.10.48","npm":"2.15.1"})

> js2coffee@0.3.3 preinstall /app/node_modules/lineman/node_modules/js2coffee
> node ./cyclic.js

npm WARN engine esprima@4.0.1: wanted: {"node":">=4"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN deprecated graceful-fs@1.1.14: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
npm WARN deprecated graceful-fs@3.0.11: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
npm WARN deprecated minimatch@1.0.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated node-uuid@1.4.8: Use uuid module instead
npm WARN deprecated tough-cookie@2.2.2: ReDoS vulnerability parsing Set-Cookie https://nodesecurity.io/advisories/130
npm WARN engine form-data@2.3.2: wanted: {"node":">= 0.12"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN engine har-validator@5.1.0: wanted: {"node":">=4"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN deprecated hoek@2.16.3: The major version is no longer supported. Please update to 4.x or newer
npm WARN engine follow-redirects@1.5.9: wanted: {"node":">=4.0"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN engine har-schema@2.0.0: wanted: {"node":">=4"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN deprecated aws-sign@0.2.1: Incorrectly published ES6 version into the 0.x branch
npm WARN engine hawk@0.10.2: wanted: {"node":"0.8.x"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN deprecated hoek@0.7.6: The major version is no longer supported. Please update to 4.x or newer
npm WARN engine cryptiles@0.1.3: wanted: {"node":"0.8.x"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN engine sntp@0.1.4: wanted: {"node":"0.8.x"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN engine hoek@0.7.6: wanted: {"node":"0.8.x"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN engine boom@0.3.8: wanted: {"node":"0.8.x"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN engine co@4.6.0: wanted: {"iojs":">= 1.0.0","node":">= 0.12.0"} (current: {"node":"0.10.48","npm":"2.15.1"})
npm WARN deprecated hoek@0.9.1: The major version is no longer supported. Please update to 4.x or newer
npm WARN engine co@4.6.0: wanted: {"iojs":">= 1.0.0","node":">= 0.12.0"} (current: {"node":"0.10.48","npm":"2.15.1"})

> phantomjs-prebuilt@2.1.15 install /app/node_modules/phantomjs-prebuilt
> node install.js

PhantomJS not found on PATH
Downloading https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2
Saving to /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
Receiving...

Received 22866K total.
Extracting tar contents (via spawned process)
Removing /app/node_modules/phantomjs-prebuilt/lib/phantom
Copying extracted folder /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2-extract-1539530677315/phantomjs-2.1.1-linux-x86_64 -> /app/node_modules/phantomjs-prebuilt/lib/phantom
Writing location.js file
Done. Phantomjs binary available at /app/node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs
npm WARN deprecated minimatch@0.4.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN cannot run in wd phantomjs@1.9.20 node install.js (wd=/app/node_modules/grunt-contrib-jasmine/node_modules/grunt-lib-phantomjs/node_modules/phantomjs)
npm WARN engine xmlbuilder@10.1.0: wanted: {"node":">=4.0"} (current: {"node":"0.10.48","npm":"2.15.1"})

> lineman-less@0.1.0 postinstall /app/node_modules/lineman-less
> node script/postinstall.js


> ws@0.4.32 install /app/node_modules/lineman/node_modules/testem/node_modules/socket.io/node_modules/socket.io-client/node_modules/ws
> (node-gyp rebuild 2> builderror.log) || (exit 0)

make: Entering directory '/app/node_modules/lineman/node_modules/testem/node_modules/socket.io/node_modules/socket.io-client/node_modules/ws/build'
  CXX(target) Release/obj.target/bufferutil/src/bufferutil.o
  SOLINK_MODULE(target) Release/obj.target/bufferutil.node
  COPY Release/bufferutil.node
  CXX(target) Release/obj.target/validation/src/validation.o
  SOLINK_MODULE(target) Release/obj.target/validation.node
  COPY Release/validation.node
make: Leaving directory '/app/node_modules/lineman/node_modules/testem/node_modules/socket.io/node_modules/socket.io-client/node_modules/ws/build'
commander@2.16.0 node_modules/commander

grunt-contrib-copy@0.7.0 node_modules/grunt-contrib-copy
└── chalk@0.5.1 (ansi-styles@1.1.0, escape-string-regexp@1.0.5, supports-color@0.2.0, strip-ansi@0.3.0, has-ansi@0.1.0)

jasmine-given@2.6.4 node_modules/jasmine-given
├── jasmine-matcher-wrapper@0.0.4
├── minijasminenode@0.2.7
└── coffee-script@1.6.3

grunt@0.4.5 node_modules/grunt
├── dateformat@1.0.2-1.2.3
├── which@1.0.9
├── getobject@0.1.0
├── eventemitter2@0.4.14
├── rimraf@2.2.8
├── colors@0.6.2
├── async@0.1.22
├── grunt-legacy-util@0.2.0
├── hooker@0.2.3
├── exit@0.1.2
├── nopt@1.0.10 (abbrev@1.1.1)
├── minimatch@0.2.14 (sigmund@1.0.1, lru-cache@2.7.3)
├── glob@3.1.21 (inherits@1.0.2, graceful-fs@1.2.3)
├── lodash@0.9.2
├── coffee-script@1.3.3
├── underscore.string@2.2.1
├── iconv-lite@0.2.11
├── findup-sync@0.1.3 (glob@3.2.11, lodash@2.4.2)
├── grunt-legacy-log@0.1.3 (grunt-legacy-log-utils@0.1.1, underscore.string@2.3.3, lodash@2.4.2)
└── js-yaml@2.0.5 (argparse@0.1.16, esprima@1.0.4)

grunt-webfont@0.4.8 node_modules/grunt-webfont
├── exec@0.1.4
├── async@0.9.2
├── chalk@0.5.1 (ansi-styles@1.1.0, escape-string-regexp@1.0.5, supports-color@0.2.0, strip-ansi@0.3.0, has-ansi@0.1.0)
├── temp@0.8.3 (os-tmpdir@1.0.2, rimraf@2.2.8)
├── mkdirp@0.5.1 (minimist@0.0.8)
├── underscore.string@2.3.3
├── ttf2eot@1.3.0 (argparse@0.1.16)
├── glob@4.0.6 (inherits@2.0.3, once@1.4.0, graceful-fs@3.0.11, minimatch@1.0.0)
├── lodash@2.4.2
├── ttf2woff@1.3.0 (argparse@0.1.16, pako@0.2.9)
├── svg2ttf@1.1.2 (svgpath@1.0.7, xmldom@0.1.27, argparse@0.1.16, lodash@2.1.0)
├── svgicons2svgfont@0.1.1 (readable-stream@1.1.14, sax@0.6.1, svg-pathdata@0.0.6)
└── winston@0.7.3 (cycle@1.0.3, stack-trace@0.0.10, eyes@0.1.8, colors@0.6.2, async@0.2.10, pkginfo@0.3.1, request@2.16.6)

lineman-angular@0.3.0 node_modules/lineman-angular
├── underscore@1.9.1
├── grunt-angular-templates@0.3.12 (html-minifier@0.5.6)
├── coffee-script@1.12.7
└── grunt-ng-annotate@0.3.2 (ng-annotate@0.9.11)

testem@1.18.4 node_modules/testem
├── styled_string@0.0.1
├── lodash.assignin@4.2.0
├── spawn-args@0.2.0
├── rimraf@2.6.2
├── printf@0.2.5
├── lodash.clonedeep@4.5.0
├── consolidate@0.14.5
├── lodash.uniqby@4.7.0
├── lodash.find@4.6.0
├── xmldom@0.1.27
├── charm@1.0.2 (inherits@2.0.3)
├── mustache@2.3.2
├── mkdirp@0.5.1 (minimist@0.0.8)
├── cross-spawn@5.1.0 (shebang-command@1.2.0, which@1.3.1, lru-cache@4.1.3)
├── backbone@1.3.3 (underscore@1.9.1)
├── tap-parser@5.4.0 (events-to-array@1.1.2, readable-stream@2.3.6)
├── glob@7.1.3 (inherits@2.0.3, path-is-absolute@1.0.1, fs.realpath@1.0.0, inflight@1.0.6, once@1.4.0, minimatch@3.0.4)
├── fireworm@0.7.1 (async@0.2.10, lodash.debounce@3.1.1, is-type@0.0.1, minimatch@3.0.4, lodash.flatten@3.0.2)
├── npmlog@4.1.2 (set-blocking@2.0.0, console-control-strings@1.1.0, are-we-there-yet@1.1.5, gauge@2.7.4)
├── bluebird@3.5.2
├── js-yaml@3.12.0 (esprima@4.0.1, argparse@1.0.10)
├── http-proxy@1.17.0 (requires-port@1.0.0, eventemitter3@3.1.0, follow-redirects@1.5.9)
├── express@4.16.4 (escape-html@1.0.3, array-flatten@1.1.1, setprototypeof@1.1.0, cookie-signature@1.0.6, utils-merge@1.0.1, merge-descriptors@1.0.1, methods@1.1.2, path-to-regexp@0.1.7, range-parser@1.2.0, encodeurl@1.0.2, vary@1.1.2, fresh@0.5.2, parseurl@1.3.2, content-type@1.0.4, etag@1.8.1, statuses@1.4.0, cookie@0.3.1, content-disposition@0.5.2, safe-buffer@5.1.2, serve-static@1.13.2, depd@1.1.2, on-finished@2.3.0, finalhandler@1.1.1, proxy-addr@2.0.4, debug@2.6.9, qs@6.5.2, send@0.16.2, type-is@1.6.16, accepts@1.3.5, body-parser@1.18.3)
├── node-notifier@5.2.1 (shellwords@0.1.1, growly@1.3.0, semver@5.6.0, which@1.3.1)
└── socket.io@1.6.0 (object-assign@4.1.0, socket.io-adapter@0.5.0, has-binary@0.1.7, debug@2.3.3, socket.io-parser@2.3.1, engine.io@1.8.0, socket.io-client@1.6.0)

grunt-contrib-jasmine@0.8.2 node_modules/grunt-contrib-jasmine
├── chalk@0.4.0 (has-color@0.1.7, ansi-styles@1.0.0, strip-ansi@0.1.1)
├── rimraf@2.1.4 (graceful-fs@1.2.3)
├── jasmine-core@3.2.1
├── es5-shim@4.0.6
├── lodash@2.4.2
└── grunt-lib-phantomjs@0.6.0 (eventemitter2@0.4.14, semver@1.0.14, temporary@0.0.8, phantomjs@1.9.20)

protractor@1.8.0 node_modules/protractor
├── jasminewd@1.1.0
├── jasminewd2@0.0.2
├── saucelabs@0.1.1
├── html-entities@1.1.3
├── q@1.0.0
├── minijasminenode@1.1.1
├── adm-zip@0.4.4
├── optimist@0.6.1 (wordwrap@0.0.3, minimist@0.0.10)
├── glob@3.2.11 (inherits@2.0.3, minimatch@0.3.0)
├── accessibility-developer-tools@2.6.0
├── source-map-support@0.2.10 (source-map@0.1.32)
├── lodash@2.4.2
├── request@2.36.0 (tunnel-agent@0.4.3, forever-agent@0.5.2, aws-sign2@0.5.0, qs@0.6.6, oauth-sign@0.3.0, json-stringify-safe@5.0.1, mime@1.2.11, node-uuid@1.4.8, form-data@0.1.4, hawk@1.0.0, tough-cookie@2.4.3, http-signature@0.10.1)
├── jasmine@2.1.1 (jasmine-core@2.1.3)
└── selenium-webdriver@2.44.0 (tmp@0.0.24, xml2js@0.4.4)

phantomjs-prebuilt@2.1.15 node_modules/phantomjs-prebuilt
├── progress@1.1.8
├── kew@0.7.0
├── which@1.2.14 (isexe@2.0.0)
├── request-progress@2.0.1 (throttleit@1.0.0)
├── hasha@2.2.0 (is-stream@1.1.0, pinkie-promise@2.0.1)
├── fs-extra@1.0.0 (klaw@1.3.1, jsonfile@2.4.0, graceful-fs@4.1.11)
├── es6-promise@4.0.5
├── extract-zip@1.6.7 (debug@2.6.9, mkdirp@0.5.1, yauzl@2.4.1, concat-stream@1.6.2)
└── request@2.81.0 (is-typedarray@1.0.0, aws-sign2@0.6.0, oauth-sign@0.8.2, stringstream@0.0.6, forever-agent@0.6.1, tunnel-agent@0.6.0, caseless@0.12.0, isstream@0.1.2, json-stringify-safe@5.0.1, safe-buffer@5.1.2, performance-now@0.2.0, aws4@1.8.0, extend@3.0.2, uuid@3.3.2, combined-stream@1.0.7, qs@6.4.0, form-data@2.1.4, mime-types@2.1.20, tough-cookie@2.3.4, hawk@3.1.3, http-signature@1.1.1, har-validator@4.2.1)

lineman-less@0.1.0 node_modules/lineman-less
├── find-root-package@0.0.1
├── coffee-script@1.7.1 (mkdirp@0.3.5)
└── grunt-contrib-less@0.10.0 (chalk@0.4.0, grunt-lib-contrib@0.6.1, less@1.7.5)

lineman@0.34.4 node_modules/lineman
├── connect-livereload@0.4.1
├── config-extend@0.0.6
├── grunt-contrib-copy@0.4.1
├── grunt-contrib-sass@0.5.0 (dargs@0.1.0)
├── semver@2.1.0
├── grunt-contrib-clean@0.5.0 (rimraf@2.2.8)
├── commander@1.3.2 (keypress@0.1.0)
├── grunt-contrib-coffee@0.7.0
├── resolve@0.6.3
├── lodash@0.9.2
├── normalize-package-data@0.2.13 (github-url-from-git@1.1.1, github-url-from-username-repo@0.1.0)
├── grunt-contrib-cssmin@0.6.1 (clean-css@1.0.12, grunt-lib-contrib@0.6.1)
├── coffee-script@1.6.3
├── watch_r-structr-lock@0.0.1 (async@0.2.10, structr@0.2.3, commander@1.1.1, underscore@1.4.4, ejs@0.8.8, tq@0.2.5)
├── underscore.string@2.3.3
├── grunt-concat-sourcemap@0.4.3 (source-map@0.1.31)
├── grunt-contrib-jst@0.5.1 (grunt-lib-contrib@0.5.3, lodash@1.0.2)
├── grunt-watch-nospawn@0.0.8 (tiny-lr-fork@0.0.5, gaze@0.3.3)
├── js2coffee@0.3.3 (file@0.2.2, underscore@1.6.0, nopt@3.0.6, coffee-script@1.7.1)
├── grunt-asset-fingerprint@0.2.1 (lodash@2.4.2)
├── http-proxy@0.10.3 (colors@0.6.2, pkginfo@0.2.3, optimist@0.3.7, utile@0.1.7)
├── grunt-contrib-uglify@0.2.4 (grunt-lib-contrib@0.6.1, uglify-js@2.4.24)
├── grunt-contrib-handlebars@0.8.0 (chalk@0.4.0, grunt-lib-contrib@0.5.3, handlebars@1.3.0)
├── fetcher@0.2.0 (which@1.3.1, async@0.9.2, underscore@1.9.1, mkdirp@0.5.1, cpr@0.2.0, rimraf@2.6.2, coffee-script@1.12.7, decompress@0.2.5, request@2.88.0, cson-safe@0.1.1)
├── grunt-contrib-jshint@0.11.0 (hooker@0.2.3, jshint@2.6.3)
├── express@3.4.0 (methods@0.0.1, cookie-signature@1.0.1, range-parser@0.0.4, fresh@0.2.0, buffer-crc32@0.2.1, cookie@0.1.0, mkdirp@0.3.5, commander@1.2.0, debug@4.1.0, send@0.1.4, connect@2.9.0)
└── testem@0.6.15 (styled_string@0.0.1, did_it_work@0.0.6, growl@1.7.0, mustache@0.4.0, rimraf@2.2.8, colors@0.6.2, consolidate@0.8.0, charm@0.0.8, async@0.2.10, backbone@1.0.0, fileset@0.1.8, glob@3.1.21, npmlog@0.0.6, fireworm@0.6.6, js-yaml@2.1.3, tap@0.4.13, socket.io@0.9.19)

> balrog-ui@0.0.1 start /app
> lineman run


/app/node_modules/lineman/node_modules/express/node_modules/debug/src/node.js:120
exports.inspectOpts = Object.keys(process.env).filter(key => {
                                                           ^
Loading "server.coffee" tasks...ERROR
>> SyntaxError: Unexpected token >

Running "common" task

Running "ngtemplates:app" (ngtemplates) task
File generated/angular/template-cache.js created.

Running "less:compile" (less) task
File generated/css/app.less.css created.

Running "coffee:compile" (coffee) task
>> Destination (generated/js/app.coffee.js) not written because compiled files were empty.
>> Destination (generated/js/spec.coffee.js) not written because compiled files were empty.
>> Destination (generated/js/spec-helpers.coffee.js) not written because compiled files were empty.

Running "jshint:files" (jshint) task
>> 71 files lint free.

Running "concat_sourcemap:js" (concat_sourcemap) task
File "generated/js/app.js" created.

Running "concat_sourcemap:spec" (concat_sourcemap) task
File "generated/js/spec.js" created.

Running "concat_sourcemap:css" (concat_sourcemap) task
File "generated/css/app.css" created.

Running "copy:dev" (copy) task
Copied 4 files

Running "images:dev" (images) task
Copying images to 'generated/img'

Running "webfonts:dev" (webfonts) task
Copying webfonts to 'generated/webfonts'

Running "pages:dev" (pages) task
generated/index.html generated from app/pages/index.us

Running "dev" task
Warning: Task "server" not found. Used --force, continuing.

Done, but with warnings.
```

Talking with @jbuck, the first suggestion was upgrade the Balrog UI to node-8. This PR upgrades the Balrog UI to run over node8.

I made superficial tests in Rules and Releases, UI seems works fine in development environment. The next steps would be to upgrade deprecated dependencies...

@nthomas-mozilla what you think? There are any known limitation for upgrade?