### PR TITLE
Pin "debug" package to less than 4.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "commander": "2.16.0",
+    "debug": "<4.0",
     "grunt": "0.4.5",
     "grunt-contrib-copy": "0.7.0",
     "grunt-contrib-jasmine": "0.8.2",


### PR DESCRIPTION
Over in #826 @allan-silva discovered that we can't build the Balrog UI from scratch, which is a big deal because that's how we build our images for deployment. This is a quick patch to pin an older version of the node package called `debug`, so that we could deploy an emergency fix to Balrog code if needed.

The root cause is that we're using older Node (v0.10) that doesn't support arrow functions, which the `debug` package started using in 4.0. `debug` is pulled in indirectly by other packages, the usual vipers nest of package deps. We'll test upgrading to Node v8 over in #826 but can't deploy that so close to 63.0 shipping.