### PR TITLE
Run flake8 again

### DIFF
--- a/auslib/AUS.py
+++ b/auslib/AUS.py
@@ -3,7 +3,7 @@ from random import randint
 
 try:
     from urlparse import urlparse
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     from urllib.parse import urlparse
 
 import logging

--- a/auslib/config.py
+++ b/auslib/config.py
@@ -2,7 +2,7 @@ import logging
 
 try:
     from ConfigParser import RawConfigParser, NoSectionError, NoOptionError
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     from configparser import RawConfigParser, NoSectionError, NoOptionError
 
 

--- a/auslib/log.py
+++ b/auslib/log.py
@@ -35,9 +35,9 @@ class BalrogLogger(logging.Logger):
             except RuntimeError:
                 pass
             extra['requestid'] = requestid
-        if six.PY2: # pragma: no cover
+        if six.PY2:  # pragma: no cover
             return logging.Logger.makeRecord(self, name, level, fn, lno, msg, args, exc_info, func, extra)
-        return logging.Logger.makeRecord(self, name, level, fn, lno, msg, args, exc_info, func, extra, sinfo) # pragma: no cover
+        return logging.Logger.makeRecord(self, name, level, fn, lno, msg, args, exc_info, func, extra, sinfo)  # pragma: no cover
 
 
 class JsonLogFormatter(logging.Formatter):

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1,5 +1,4 @@
 import mock
-import simplejson as json
 
 from sqlalchemy import select
 

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1,4 +1,5 @@
 import mock
+import simplejson as json
 
 from sqlalchemy import select
 

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1,5 +1,4 @@
 # This Python file uses the following encoding: utf-8
-import json
 import mock
 
 from six import assertCountEqual

--- a/auslib/test/web/api/test_releases.py
+++ b/auslib/test/web/api/test_releases.py
@@ -1,4 +1,3 @@
-import json
 import mock
 
 from auslib.test.web.api.base import CommonTestBase

--- a/auslib/web/admin/base.py
+++ b/auslib/web/admin/base.py
@@ -13,7 +13,7 @@ from specsynthase.specbuilder import SpecBuilder
 
 try:
     from urllib import unquote
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     from urllib.parse import unquote
 
 

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -14,7 +14,7 @@ import logging
 
 try:
     from urllib import unquote
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     from urllib.parse import unquote
 
 

--- a/scripts/get-prod-db-dump.py
+++ b/scripts/get-prod-db-dump.py
@@ -10,9 +10,8 @@ import time
 
 try:
     from urllib2 import urlopen, HTTPError, URLError
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     from urllib.error import HTTPError, URLError
-    from urllib.parse import unquote
     from urllib.request import urlopen
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,22 +7,12 @@ envlist = py27, py36
 ignore_errors=True
 setenv =
     PYTHONDONTWRITEBYTECODE=1
-
+deps = -rrequirements-test.txt
 commands=
     flake8 auslib scripts uwsgi
-
-[testenv:py27]
-basepython=python2.7
-deps = -rrequirements-test.txt
-commands=
-    py.test -n2 --cov=auslib --doctest-modules {posargs:auslib}
-    coverage run -a scripts/test-rules.py
-
-[testenv:py36]
-basepython=python3.6
-deps = -rrequirements-test.txt
-commands=
-    py.test -n2 --no-cov {posargs:auslib}
+    py36: py.test -n2 --no-cov {posargs:auslib}
+    py27: py.test -n2 --cov=auslib --doctest-modules {posargs:auslib}
+    py27: coverage run -a scripts/test-rules.py
 
 [flake8]
 max-line-length = 160


### PR DESCRIPTION
Flake8 was accidentally removed from the test runs in #621 so lets get it going again.  The `commands` definition in an env block overrides the top level where flake8 is specified. We'll need another revision to fix the issues that have crept in.