### PR TITLE
Green up flake8

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -40,26 +40,6 @@ def rows_to_dicts(rows):
     return [dict(row) for row in rows]
 
 
-def _matchesRegex(foo, bar):
-    # Expand wildcards and use ^/$ to make sure we don't succeed on partial
-    # matches. Eg, 3.6* matches 3.6, 3.6.1, 3.6b3, etc.
-    # Channel length must be strictly greater than two
-    # And globbing is allowed at the end of channel-name only
-    if foo.endswith('*'):
-        if(len(foo) >= 3):
-            test = foo.replace('.', '\.').replace('*', '\*', foo.count('*') - 1)
-            test = '^{}.*$'.format(test[:-1])
-            if re.match(test, bar):
-                return True
-            return False
-        else:
-            return False
-    elif (foo == bar):
-        return True
-    else:
-        return False
-
-
 class AlreadySetupError(Exception):
 
     def __str__(self):
@@ -2469,7 +2449,7 @@ class EmergencyShutoffs(AUSTable):
         row = affected_rows[-1]
         where = {"product": row["product"]}
         for rs in self.db.productRequiredSignoffs.select(where=where, transaction=transaction):
-            if not row.get("channel") or _matchesRegex(row["channel"], rs["channel"]):
+            if not row.get("channel") or matchRegex(row["channel"], rs["channel"]):
                 potential_required_signoffs['rs'].append(rs)
         return potential_required_signoffs
 

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -4617,7 +4617,7 @@ class TestChangeNotifiers(unittest.TestCase):
         mock_conn = self._runTest(doit)
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("INSERT"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("Row to be inserted:"))
-        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString("'channel':\s[b|u]?'bar'"))
+        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString(r"'channel':\s[b|u]?'bar'"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("'rule_id':"))
 
     def testOnInsertPermission(self):
@@ -4637,11 +4637,11 @@ class TestChangeNotifiers(unittest.TestCase):
         mock_conn.sendmail.assert_any_call("fake@from.com", "fake@to.com", PartialString("UPDATE to rules"))
         mock_conn.sendmail.assert_any_call("fake@from.com", "fake@to.com", PartialString("Row(s) to be updated as follows:"))
         mock_conn.sendmail.assert_any_call("fake@from.com", "fake@to.com", PartialString("'product': None ---> 'blah'"))
-        mock_conn.sendmail.assert_any_call("fake@from.com", "fake@to.com", RegexPartialString("'channel':\s[b|u]?\"?'release'\"?"))
+        mock_conn.sendmail.assert_any_call("fake@from.com", "fake@to.com", RegexPartialString(r"'channel':\s[b|u]?\"?'release'\"?"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("UPDATE to rules_scheduled_changes"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("Row(s) to be updated as follows:"))
-        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString("'base_product':\s[b|u]?\"?None ---> 'blah'\"?"))
-        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString("'base_channel':\s[u|b]?\"?'release'\"?,"))
+        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString(r"'base_product':\s[b|u]?\"?None ---> 'blah'\"?"))
+        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString(r"'base_channel':\s[u|b]?\"?'release'\"?,"))
 
     def testOnDelete(self):
         def doit():
@@ -4650,7 +4650,7 @@ class TestChangeNotifiers(unittest.TestCase):
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("DELETE"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("Row(s) to be removed:"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("'rule_id': 3"))
-        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString("'channel':\s[b|u]?'release'"))
+        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString(r"'channel':\s[b|u]?'release'"))
 
     def testOnInsertRuleSC(self):
         def doit():
@@ -4659,8 +4659,8 @@ class TestChangeNotifiers(unittest.TestCase):
         mock_conn = self._runTest(doit)
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("INSERT"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("Row to be inserted:"))
-        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString("'scheduled_by':\s[u|b]?'bob'"))
-        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString("'base_channel':\s[u|b]?'bar'"))
+        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString(r"'scheduled_by':\s[u|b]?'bob'"))
+        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString(r"'base_channel':\s[u|b]?'bar'"))
 
     def testOnUpdateRuleSC(self):
         def doit():
@@ -4669,7 +4669,7 @@ class TestChangeNotifiers(unittest.TestCase):
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("UPDATE"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("Row(s) to be updated as follows:"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("'base_product': None ---> 'blah'"))
-        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString("'base_channel':\s[b|u]?\"?'release'\"?"))
+        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString(r"'base_channel':\s[b|u]?\"?'release'\"?"))
 
     def testOnDeleteRuleSC(self):
         def doit():
@@ -4678,7 +4678,7 @@ class TestChangeNotifiers(unittest.TestCase):
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("DELETE"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("Row(s) to be removed:"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", PartialString("'sc_id': 1"))
-        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString("'base_channel':\s[b|u]?'release'"))
+        mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com", RegexPartialString(r"'base_channel':\s[b|u]?'release'"))
 
     def testOnChangeReadOnly(self):
         def doit():
@@ -4686,11 +4686,11 @@ class TestChangeNotifiers(unittest.TestCase):
         mock_conn = self._runTest(doit)
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com",
                                               RegexPartialString("Read only release"
-                                                                 "\s[b|u]?'a' changed to modifiable"))
+                                                                 r"\s[b|u]?'a' changed to modifiable"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com",
-                                              RegexPartialString("'name':\s[b|u]?'a'"))
+                                              RegexPartialString(r"'name':\s[b|u]?'a'"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com",
-                                              RegexPartialString("'product':\s[b|u]?'a'"))
+                                              RegexPartialString(r"'product':\s[b|u]?'a'"))
         mock_conn.sendmail.assert_called_with("fake@from.com", "fake@to.com",
                                               PartialString("'read_only': True"
                                                             " ---> False"))

--- a/auslib/util/comparison.py
+++ b/auslib/util/comparison.py
@@ -21,10 +21,10 @@ def has_operator(value):
 
 def get_op(pattern):
     # only alphanumeric characters means no operator
-    if re.match('\w+', pattern):
+    if re.match(r'\w+', pattern):
         return operator.eq, pattern
     for op in operators:
-        m = re.match('(%s)([\.\w]+)' % op, pattern)
+        m = re.match(r'(%s)([\.\w]+)' % op, pattern)
         if m:
             op, operand = m.groups()
             return operators[op], operand

--- a/auslib/util/rulematching.py
+++ b/auslib/util/rulematching.py
@@ -11,7 +11,7 @@ def matchRegex(foo, bar):
     # And globbing is allowed at the end of channel-name only
     if foo.endswith('*'):
         if(len(foo) >= 3):
-            test = foo.replace('.', '\.').replace('*', '\*', foo.count('*') - 1)
+            test = foo.replace('.', r'\.').replace('*', r'\*', foo.count('*') - 1)
             test = '^{}.*$'.format(test[:-1])
             if re.match(test, bar):
                 return True

--- a/auslib/web/public/client.py
+++ b/auslib/web/public/client.py
@@ -126,7 +126,7 @@ def getQueryFromURL(url):
 
 def extract_query_version(request_url):
     version = 0
-    pattern = '^.*/update/(\d+)/.*\.xml.*$'
+    pattern = r'^.*/update/(\d+)/.*\.xml.*$'
     match = re.match(pattern, request_url)
     if match:
         version = int(match.group(1))

--- a/scripts/generate-json.py
+++ b/scripts/generate-json.py
@@ -86,8 +86,8 @@ def isMac64(platform, version):
 
 
 def cmpVersions(left, right):
-    left = StrictVersion(re.sub('rc(\d+)', 'b9999999\\1', left))
-    right = StrictVersion(re.sub('rc(\d+)', 'b9999999\\1', right))
+    left = StrictVersion(re.sub(r'rc(\d+)', 'b9999999\\1', left))
+    right = StrictVersion(re.sub(r'rc(\d+)', 'b9999999\\1', right))
     return (left > right) - (left < right)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands=
 max-line-length = 160
 exclude = .ropeproject,.tox,sandbox,build
 show-source = True
-ignore = E402
+ignore = E402,W504
 
 [pytest]
 norecursedirs = .tox .git .hg sandbox build


### PR DESCRIPTION
Flake8 now complains about escapes in regexp if they aren't raw strings, which helped me notice that `auslib.db._matchesRegex` is exactly the same as `auslib.util.rulematching.matchRegex`, which was already being imported.

pycodestyle v2.4.0 also added W504 to check for line breaks after a binary operator, but it's disabled by default. Our use of `ignore = E402` in tox.ini actually means we are much more strict that the default of `E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505` because it [overrides the default](https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes). We could switch to the new `extend-ignore` but that would relax code quality and we've done the work already. We have some three line conditions for if's in db.py, so we can either disable W503 (newlines before a binary operator) or W504 (newlines after a binary operator), but not both. Decided to disable the new check to avoid code changes.
