### PR TITLE
Use fixtures for current DB metadata

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -600,7 +600,7 @@ class AUSTable(object):
         return ret
 
     def update(self, where, what, changed_by=None, old_data_version=None, transaction=None, dryrun=False):
-        """Perform an UPDATE statement on this stable. See AUSTable._updateStatement for
+        """Perform an UPDATE statement on this table. See AUSTable._updateStatement for
            a description of `where' and `what'. This method can only update a single row
            per invocation. If the where clause given would update zero or multiple rows, a
            WrongNumberOfRowsError is raised.
@@ -1624,7 +1624,7 @@ class Rules(AUSTable):
             else:
                 where.extend([(self.distVersion == null())])
 
-            self.log.debug("where: %s" % where)
+            self.log.debug("where: %s", where)
             return self.select(where=where, transaction=transaction)
 
         # This cache key is constructed from all parts of the updateQuery that

--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -4,6 +4,8 @@ import simplejson as json
 from tempfile import mkstemp
 import unittest
 
+import pytest
+
 from auslib.global_state import dbo, cache
 from auslib.web.admin.base import app
 from auslib.blobs.base import createBlob
@@ -14,6 +16,7 @@ def setUpModule():
     logging.getLogger('migrate').setLevel(logging.CRITICAL)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class ViewTest(unittest.TestCase):
     """Base class for all view tests. Sets up some sample data, and provides
        some helper methods."""
@@ -37,7 +40,7 @@ class ViewTest(unittest.TestCase):
 """)
         dbo.setDb('sqlite:///:memory:')
         dbo.setDomainWhitelist({'good.com': ('a', 'b', 'c', 'd')})
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.permissions.t.insert().execute(permission='admin', username='bill', data_version=1)
         dbo.permissions.t.insert().execute(permission='permission', username='bob', data_version=1)
         dbo.permissions.t.insert().execute(permission='release', username='bob',

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -108,12 +108,13 @@ class TestReleaseBlobBase(unittest.TestCase):
     # XXX: should we support the locale overriding the platform? this should probably be invalid
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestReleaseBlobV1(unittest.TestCase):
 
     def setUp(self):
         self.whitelistedDomains = {'a.com': ('a',), 'boring.com': ('b',)}
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.setDomainWhitelist(self.whitelistedDomains)
         self.sampleReleaseBlob = ReleaseBlobV1()
         self.sampleReleaseBlob.loadJSON("""
@@ -627,13 +628,14 @@ class TestSpecialQueryParams(unittest.TestCase):
         self.assertEqual(returned_footer.strip(), expected_footer.strip())
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestSchema2Blob(unittest.TestCase):
 
     def setUp(self):
         self.specialForceHosts = ["http://a.com"]
         self.whitelistedDomains = {'a.com': ('j', 'k')}
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.setDomainWhitelist(self.whitelistedDomains)
         dbo.releases.t.insert().execute(name='j1', product='j', version='39.0', data_version=1, data=createBlob("""
 {
@@ -943,6 +945,7 @@ class TestSchema2Blob(unittest.TestCase):
                                                      self.whitelistedDomains))
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestSchema2BlobNightlyStyle(unittest.TestCase):
 
     maxDiff = 2000
@@ -951,7 +954,7 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
         self.specialForceHosts = ["http://a.com"]
         self.whitelistedDomains = {'a.com': ('j',)}
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.setDomainWhitelist(self.whitelistedDomains)
         dbo.releases.t.insert().execute(name='j1', product='j', version='0.5', data_version=1, data=createBlob("""
 {
@@ -1067,13 +1070,14 @@ class TestSchema2BlobNightlyStyle(unittest.TestCase):
                                                      self.whitelistedDomains))
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestSchema3Blob(unittest.TestCase):
 
     def setUp(self):
         self.specialForceHosts = ["http://a.com"]
         self.whitelistedDomains = {'a.com': ('f', 'g')}
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.setDomainWhitelist(self.whitelistedDomains)
         dbo.releases.t.insert().execute(name='f1', product='f', version='22.0', data_version=1, data=createBlob("""
 {
@@ -1531,13 +1535,14 @@ class TestSchema3Blob(unittest.TestCase):
                                                      self.whitelistedDomains))
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestSchema4Blob(unittest.TestCase):
 
     def setUp(self):
         self.specialForceHosts = ["http://a.com"]
         self.whitelistedDomains = {'a.com': ('h', 'g',)}
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.setDomainWhitelist(self.whitelistedDomains)
         dbo.releases.t.insert().execute(name='h0', product='h', version='29.0', data_version=1, data=createBlob("""
 {
@@ -2180,6 +2185,7 @@ class TestSchema4Blob(unittest.TestCase):
                                                      self.whitelistedDomains))
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestSchema5Blob(unittest.TestCase):
 
     def setUp(self):
@@ -2189,7 +2195,7 @@ class TestSchema5Blob(unittest.TestCase):
         app.config['SPECIAL_FORCE_HOSTS'] = self.specialForceHosts
         app.config['WHITELISTED_DOMAINS'] = self.whitelistedDomains
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.releases.t.insert().execute(name='h1', product='h', version='30.0', data_version=1, data=createBlob("""
 {
     "name": "h1",
@@ -2459,6 +2465,7 @@ class TestSchema5Blob(unittest.TestCase):
         self.assertEqual(returned_footer.strip(), expected_footer.strip())
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestSchema6Blob(unittest.TestCase):
 
     def setUp(self):
@@ -2468,7 +2475,7 @@ class TestSchema6Blob(unittest.TestCase):
         app.config['SPECIAL_FORCE_HOSTS'] = self.specialForceHosts
         app.config['WHITELISTED_DOMAINS'] = self.whitelistedDomains
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.releases.t.insert().execute(name='h1', product='h', data_version=1, data=createBlob("""
 {
     "name": "h1",
@@ -2727,6 +2734,7 @@ class TestSchema6Blob(unittest.TestCase):
         self.assertRaises(BlobValidationError, self.blobH3.validate, 'h', self.whitelistedDomains)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestSchema8Blob(unittest.TestCase):
 
     def setUp(self):
@@ -2736,7 +2744,7 @@ class TestSchema8Blob(unittest.TestCase):
         app.config['SPECIAL_FORCE_HOSTS'] = self.specialForceHosts
         app.config['WHITELISTED_DOMAINS'] = self.whitelistedDomains
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.releases.t.insert().execute(name='h1', product='h', data_version=1, data=createBlob("""
 {
     "name": "h1",
@@ -2852,6 +2860,7 @@ class TestSchema8Blob(unittest.TestCase):
         self.assertEqual(returned_footer.strip(), expected_footer.strip())
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestSchema9Blob(unittest.TestCase):
 
     def setUp(self):
@@ -2861,7 +2870,7 @@ class TestSchema9Blob(unittest.TestCase):
         app.config['SPECIAL_FORCE_HOSTS'] = self.specialForceHosts
         app.config['WHITELISTED_DOMAINS'] = self.whitelistedDomains
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.releases.t.insert().execute(name='h1', product='h', data_version=1, data=createBlob("""
 {
     "name": "h1",
@@ -3258,6 +3267,7 @@ def testSchema9CannotCreateBlobWithConflictingFields(for1, for2):
     assert "Multiple values found for updateLine items: detailsURL" in str(excinfo.value)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestDesupportBlob(unittest.TestCase):
 
     def setUp(self):
@@ -3267,7 +3277,7 @@ class TestDesupportBlob(unittest.TestCase):
         app.config['SPECIAL_FORCE_HOSTS'] = self.specialForceHosts
         app.config['WHITELISTED_DOMAINS'] = self.whitelistedDomains
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         self.blob = DesupportBlob()
         self.blob.loadJSON("""
 {

--- a/auslib/test/conftest.py
+++ b/auslib/test/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+
+from auslib.global_state import dbo
+
+
+@pytest.fixture(scope='session')
+def db_schema():
+    """This fixture creates a fresh in-memory database, and then runs all the
+    schema migration logic, and returns the schema metadata of the final DB
+    state. It runs once per test session.
+    """
+    dbo.setDb('sqlite:///:memory:')
+    dbo.create()
+    return dbo.metadata
+
+
+@pytest.fixture(scope='class')
+def current_db_schema(request, db_schema):
+    """This fixture is meant to be used as a class decorator, and adds a
+    `metadata` attribute to the class. In the class' initialization (e.g. in
+    the setUp() method), the metadata can be used to quickly create the table
+    scheams without having to run all the migration logic. For example:
+
+    @pytest.mark.usefixtures('current_db_schema')
+    class TestFoo(unittest.TestCase):
+        def setUp(self):
+            self.db = AUSDatabase(self.dburi)
+            self.metadata.create_all(self.db.engine)
+    """
+    request.cls.metadata = db_schema

--- a/auslib/test/test_AUS.py
+++ b/auslib/test/test_AUS.py
@@ -2,6 +2,8 @@ import logging
 import mock
 import unittest
 
+import pytest
+
 from auslib.global_state import dbo
 from auslib.AUS import AUS, SUCCEED, FAIL
 from auslib.blobs.base import createBlob
@@ -15,11 +17,12 @@ def setUpModule():
     logging.getLogger('migrate').setLevel(logging.CRITICAL)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestAUSThrottlingWithoutFallback(unittest.TestCase):
 
     def setUp(self):
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.releases.t.insert().execute(
             name='b', product='b', data_version=1,
             data=createBlob({"name": "b", "extv": "1.0", "schema_version": 1, "platforms": {"a": {"buildID": "1", "locales": {"a": {}}}}}))

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -16,6 +16,8 @@ from six.moves import xrange
 from sqlalchemy import create_engine, MetaData, Table, Column, Integer, select, String
 from sqlalchemy.engine.reflection import Inspector
 
+import pytest
+
 import migrate.versioning.api
 
 from auslib.global_state import cache, dbo
@@ -720,10 +722,11 @@ class TestMultiplePrimaryHistoryTable(unittest.TestCase, TestMultiplePrimaryTabl
         self.assertRaises(ValueError, self.test.history.getChange, data_version=1, column_values={'id1': 4, 'foo': 4})
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class ScheduledChangesTableMixin(object):
     def setUp(self):
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.engine = self.db.engine
         self.metadata = self.db.metadata
 
@@ -1440,12 +1443,13 @@ class TestScheduledChangesTable(unittest.TestCase, ScheduledChangesTableMixin, M
         self.assertRaises(UpdateMergeError, self.sc_table.mergeUpdate, old_row, what, changed_by="bob")
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestScheduledChangesWithConfigurableConditions(unittest.TestCase, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.engine = self.db.engine
         self.metadata = self.db.metadata
 
@@ -1610,12 +1614,13 @@ class TestScheduledChangesWithConfigurableConditions(unittest.TestCase, MemoryDa
         assertRaisesRegex(self, ValueError, "uptake condition is disabled", self.sc_table.update, where, what, changed_by="bob", old_data_version=1)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestSignoffsTable(unittest.TestCase, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.engine = self.db.engine
         self.metadata = self.db.metadata
         self.signoffs = SignoffsTable(self.db, self.metadata, "sqlite", "test_table")
@@ -1679,12 +1684,13 @@ class TestSignoffsTable(unittest.TestCase, MemoryDatabaseMixin):
                           self.signoffs.delete, {"sc_id": 1, "username": "nancy"}, changed_by="bob")
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestProductRequiredSignoffsTable(unittest.TestCase, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.engine = self.db.engine
         self.metadata = self.db.metadata
         self.rs = self.db.productRequiredSignoffs
@@ -1783,12 +1789,13 @@ class TestProductRequiredSignoffsTable(unittest.TestCase, MemoryDatabaseMixin):
         self.assertEqual(len(got), 0)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestPermissionsRequiredSignoffsTable(unittest.TestCase, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.engine = self.db.engine
         self.metadata = self.db.metadata
         self.rs = self.db.permissionsRequiredSignoffs
@@ -1892,12 +1899,13 @@ class RulesTestMixin(object):
         return rules
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.paths = self.db.rules
         self.paths.t.insert().execute(rule_id=1, priority=100, version='3.5', buildTarget='d', backgroundRate=100, mapping='c', update_type='z',
                                       product="a", channel="a", data_version=1)
@@ -2323,12 +2331,13 @@ class TestRulesSimple(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         self.assertEqual(self.paths.count(), 10)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestJawsRules(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.rules = self.db.rules
         self.rules.t.insert().execute(rule_id=1, priority=90, mapping="myes", backgroundRate=100, jaws=True,
                                       update_type="z", product="mm", channel="mm", data_version=1)
@@ -2463,12 +2472,13 @@ class TestJawsRules(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         self.assertEqual(rules, expected)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestMig64Rules(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.rules = self.db.rules
         self.rules.t.insert().execute(rule_id=1, priority=90, mapping="myes", backgroundRate=100, mig64=True,
                                       update_type="z", product="mm", channel="mm", data_version=1)
@@ -2603,12 +2613,13 @@ class TestMig64Rules(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         self.assertEqual(rules, expected)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestRulesSpecial(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.rules = self.db.rules
         self.rules.t.insert().execute(rule_id=1, priority=100, version='>=4.0b1', backgroundRate=100, update_type='z', data_version=1)
         self.rules.t.insert().execute(rule_id=2, priority=100, channel='release*', backgroundRate=100, update_type='z', data_version=1)
@@ -2804,12 +2815,13 @@ class TestRulesSpecial(unittest.TestCase, RulesTestMixin, MemoryDatabaseMixin):
         self.assertEqual(rules, [])
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         dbo.setDb(self.dburi)
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         self.rules = dbo.rules
         self.releases = dbo.releases
         self.permissions = dbo.permissions
@@ -3062,6 +3074,7 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.assertEqual(rules, expected)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestRulesCaching(unittest.TestCase, MemoryDatabaseMixin, RulesTestMixin):
 
     def setUp(self):
@@ -3070,7 +3083,7 @@ class TestRulesCaching(unittest.TestCase, MemoryDatabaseMixin, RulesTestMixin):
         cache.make_copies = True
         cache.make_cache("rules", 20, 4)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.rules = self.db.rules
         self.rules.t.insert().execute(rule_id=1, priority=100, version='3.5', buildTarget='d', backgroundRate=100, mapping='c', update_type='z', data_version=1)
         self.rules.t.insert().execute(rule_id=2, priority=100, version='3.3', buildTarget='d', backgroundRate=100, mapping='b', update_type='z', data_version=1)
@@ -3204,12 +3217,13 @@ class TestRulesCaching(unittest.TestCase, MemoryDatabaseMixin, RulesTestMixin):
             self._checkCacheStats(cache.caches["rules"], 5, 3, 2)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestBlobCaching(unittest.TestCase, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         dbo.setDb(self.dburi)
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         cache.reset()
         cache.make_copies = True
         cache.make_cache("blob", 10, 10)
@@ -3414,6 +3428,7 @@ class TestBlobCaching(unittest.TestCase, MemoryDatabaseMixin):
             self._checkCacheStats(cache.caches["blob_version"], 3, 2, 1)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestReleasesAppReleaseBlobs(unittest.TestCase, MemoryDatabaseMixin):
     """Tests for the Releases class that are interwoven with AppRelease blob schemas"""
 
@@ -3422,7 +3437,7 @@ class TestReleasesAppReleaseBlobs(unittest.TestCase, MemoryDatabaseMixin):
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.releases = self.db.releases
         self.releases.t.insert().execute(name='a', product='a', data_version=1, data=createBlob("""
 {
@@ -4290,12 +4305,13 @@ class TestReleasesAppReleaseBlobs(unittest.TestCase, MemoryDatabaseMixin):
         self.assertEqual(history_rows[3]["data"], result_blob)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestPermissions(unittest.TestCase, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.permissions = self.db.permissions
         self.user_roles = self.db.permissions.user_roles
         self.permissions.t.insert().execute(permission='admin', username='bill', data_version=1)
@@ -4533,12 +4549,13 @@ class TestPermissions(unittest.TestCase, MemoryDatabaseMixin):
         self.assertFalse(self.permissions.isKnownUser('adams'))
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestDockerflow(unittest.TestCase, MemoryDatabaseMixin):
 
     def setUp(self):
         MemoryDatabaseMixin.setUp(self)
         self.db = AUSDatabase(self.dburi)
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.dockerflow = self.db.dockerflow
 
     def testInitAndIncrementValue(self):
@@ -4595,11 +4612,12 @@ class RegexPartialString(object):
         return "RegexPartialString %s" % self.pattern
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class TestChangeNotifiers(unittest.TestCase):
 
     def setUp(self):
         self.db = AUSDatabase('sqlite:///:memory:')
-        self.db.create()
+        self.metadata.create_all(self.db.engine)
         self.db.rules.t.insert().execute(rule_id=2, priority=100, channel='release', backgroundRate=100, update_type='z', data_version=1)
         self.db.rules.t.insert().execute(rule_id=3, priority=100, channel='release', backgroundRate=100, update_type='y', data_version=1)
         self.db.rules.scheduled_changes.t.insert().execute(sc_id=1, complete=0, scheduled_by="bob", base_rule_id=2, base_priority=100,
@@ -5091,7 +5109,7 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
         """
         Tests that downgrades and upgrades work as expected. Since the DB will never
         be rolled back beyond version 21 we treat it as the base version for all future versions from now.
-        Note: These tests run and verify migrations on a sqllite DB
+        Note: These tests run and verify migrations on a sqlite DB
         whereas the actual migration happens on a mySQL DB.
         """
         # TODO Remove these tests when we upgrade sqlalchemy so that these per-version tests are no longer required.

--- a/auslib/test/test_logging.py
+++ b/auslib/test/test_logging.py
@@ -1,0 +1,103 @@
+import logging
+import json
+
+from six import StringIO
+
+from auslib.log import configure_logging
+
+
+def test_logger(caplog):
+    stream = StringIO()
+    configure_logging(stream=stream)
+
+    logging.info("TEST OUTPUT")
+
+    assert len(caplog.records) == 1
+    r = caplog.records[0]
+    assert r.levelno == 20
+    assert r.message == 'TEST OUTPUT'
+
+    o = json.loads(stream.getvalue())
+    assert o['Severity'] == 6
+    assert o['Fields']['message'] == 'TEST OUTPUT'
+
+
+def test_exception(caplog):
+    stream = StringIO()
+    configure_logging(stream=stream)
+
+    try:
+        raise ValueError("Oh noes!")
+    except ValueError as e:
+        logging.error("TEST OUTPUT", exc_info=e)
+
+    assert len(caplog.records) == 1
+    r = caplog.records[0]
+    assert r.levelno == 40
+    assert r.message == 'TEST OUTPUT'
+    assert r.exc_info
+
+    o = json.loads(stream.getvalue())
+    assert o['Severity'] == 3
+    assert o['Fields']['message'] == 'TEST OUTPUT'
+    assert o['Fields']['error'].startswith("ValueError")
+
+
+def test_extra(caplog):
+    configure_logging()
+
+    # We need to explicitly create a new logger here so that the BalrogLogger is instantiated
+    logger = logging.getLogger("{}.{}".format(__name__, 'test_extra'))
+
+    logger.info("TEST OUTPUT", extra={"foo": "bar"})
+
+    assert len(caplog.records) == 1
+    r = caplog.records[0]
+    assert r.message == 'TEST OUTPUT'
+    assert r.foo == 'bar'
+    assert r.requestid == 'None'
+
+
+def test_noextra(caplog):
+    configure_logging()
+
+    # We need to explicitly create a new logger here so that the BalrogLogger is instantiated
+    logger = logging.getLogger("{}.{}".format(__name__, 'test_onextra'))
+
+    logger.info("TEST OUTPUT")
+
+    assert len(caplog.records) == 1
+    r = caplog.records[0]
+    assert r.message == 'TEST OUTPUT'
+    assert r.requestid == 'None'
+
+
+def test_json_output(caplog):
+    stream = StringIO()
+    configure_logging(stream=stream)
+
+    logging.info('{"foo": "bar"}')
+
+    assert len(caplog.records) == 1
+    r = caplog.records[0]
+
+    assert r.levelno == 20
+    assert r.message == '{"foo": "bar"}'
+
+    o = json.loads(stream.getvalue())
+    assert 'message' not in o['Fields']
+
+
+def test_no_message(caplog):
+    stream = StringIO()
+    configure_logging(stream=stream)
+
+    logging.info('')
+
+    assert len(caplog.records) == 1
+    r = caplog.records[0]
+
+    assert r.levelno == 20
+
+    o = json.loads(stream.getvalue())
+    assert 'message' not in o['Fields']

--- a/auslib/test/web/api/base.py
+++ b/auslib/test/web/api/base.py
@@ -1,6 +1,8 @@
 import unittest
 import logging
 
+import pytest
+
 from auslib.blobs.base import createBlob
 from auslib.global_state import dbo
 from auslib.web.public.base import app
@@ -11,6 +13,7 @@ def setUpModule():
     logging.getLogger('migrate').setLevel(logging.CRITICAL)
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class CommonTestBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -28,7 +31,7 @@ class CommonTestBase(unittest.TestCase):
         self.public_client = app.test_client()
 
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.rules.t.insert().execute(rule_id=1, priority=90, backgroundRate=100, mapping='Fennec.55.0a1', update_type='minor', product='Fennec',
                                      data_version=1, alias="moz-releng")
         dbo.releases.t.insert().execute(name='Fennec.55.0a1', product='Fennec', data_version=1, data=createBlob("""

--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -9,6 +9,8 @@ from xml.dom import minidom
 from hypothesis import assume, example, given
 from hypothesis.strategies import characters, integers, just, text
 
+import pytest
+
 import auslib.web.public.client as client_api
 from auslib.web.public.client import extract_query_version
 
@@ -65,6 +67,7 @@ class TestGetSystemCapabilities(unittest.TestCase):
         )
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class ClientTestCommon(unittest.TestCase):
     def assertHttpResponse(self, http_response):
         self.assertEqual(http_response.status_code, 200, http_response.get_data())
@@ -114,7 +117,7 @@ class ClientTestBase(ClientTestCommon):
 }
 """)
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         dbo.setDomainWhitelist({'a.com': ('b', 'c', 'e', 'distTest')})
         self.client = app.test_client()
         dbo.permissions.t.insert().execute(permission='admin', username='bill', data_version=1)
@@ -1141,7 +1144,7 @@ class ClientTestMig64(ClientTestCommon):
         app.config["SPECIAL_FORCE_HOSTS"] = ("http://a.com",)
         app.config["WHITELISTED_DOMAINS"] = {"a.com": ("a", "b", "c")}
         dbo.setDb("sqlite:///:memory:")
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         self.client = app.test_client()
         dbo.setDomainWhitelist({"a.com": ("a", "b", "c")})
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping="a", update_type="minor", product="a",
@@ -1286,7 +1289,7 @@ class ClientTestJaws(ClientTestCommon):
         app.config["SPECIAL_FORCE_HOSTS"] = ("http://a.com",)
         app.config["WHITELISTED_DOMAINS"] = {"a.com": ("a", "b", "c")}
         dbo.setDb("sqlite:///:memory:")
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         self.client = app.test_client()
         dbo.setDomainWhitelist({"a.com": ("a", "b", "c")})
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping="a", update_type="minor", product="a",
@@ -1478,7 +1481,7 @@ class ClientTestWithErrorHandlers(ClientTestCommon):
         app.config['DEBUG'] = True
         app.config["WHITELISTED_DOMAINS"] = {"a.com": ("a",)}
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         self.client = app.test_client()
 
     def testCacheControlIsSet(self):

--- a/auslib/test/web/test_unicode.py
+++ b/auslib/test/web/test_unicode.py
@@ -1,13 +1,17 @@
 import unittest
 from six import unichr
+
+import pytest
+
 from auslib.global_state import dbo
 from auslib.web.public.base import app
 
 
+@pytest.mark.usefixtures("current_db_schema")
 class UnicodeTest(unittest.TestCase):
     def setUp(self):
         dbo.setDb('sqlite:///:memory:')
-        dbo.create()
+        self.metadata.create_all(dbo.engine)
         self.client = app.test_client()
 
     def testUnicodeInRoute(self):

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ setenv =
 deps = -rrequirements-test.txt
 commands=
     flake8 auslib scripts uwsgi
-    py36: py.test -n2 --no-cov {posargs:auslib}
-    py27: py.test -n2 --cov=auslib --doctest-modules {posargs:auslib}
+    py36: py.test -n auto --no-cov {posargs:auslib}
+    py27: py.test -n auto --cov --doctest-modules {posargs:auslib}
     py27: coverage run -a scripts/test-rules.py
 
 [flake8]


### PR DESCRIPTION
This avoids having to run the DB schema migration for each test
fix typo.

also:
* silence coverage warnings

* let pytest choose how many processes to run