### PR TITLE
Use a single transaction for public client endpoint

### DIFF
--- a/auslib/AUS.py
+++ b/auslib/AUS.py
@@ -56,17 +56,17 @@ class AUS:
         self.rand = functools.partial(randint, 0, 99)
         self.log = logging.getLogger(self.__class__.__name__)
 
-    def updates_are_disabled(self, product, channel):
+    def updates_are_disabled(self, product, channel, transaction=None):
         where = dict(product=product, channel=channel)
-        emergency_shutoffs = dbo.emergencyShutoffs.select(where=where)
+        emergency_shutoffs = dbo.emergencyShutoffs.select(where=where, transaction=transaction)
         return bool(emergency_shutoffs)
 
-    def evaluateRules(self, updateQuery):
+    def evaluateRules(self, updateQuery, transaction=None):
         self.log.debug("Looking for rules that apply to:")
         self.log.debug(updateQuery)
 
-        if self.updates_are_disabled(updateQuery['product'], updateQuery['channel']) or \
-           self.updates_are_disabled(updateQuery['product'], getFallbackChannel(updateQuery['channel'])):
+        if self.updates_are_disabled(updateQuery['product'], updateQuery['channel'], transaction) or \
+           self.updates_are_disabled(updateQuery['product'], getFallbackChannel(updateQuery['channel']), transaction):
             log_message = 'Updates are disabled for {}/{}.'.format(
                 updateQuery['product'], updateQuery['channel'])
             self.log.debug(log_message)
@@ -74,7 +74,8 @@ class AUS:
 
         rules = dbo.rules.getRulesMatchingQuery(
             updateQuery,
-            fallbackChannel=getFallbackChannel(updateQuery['channel'])
+            fallbackChannel=getFallbackChannel(updateQuery['channel']),
+            transaction=transaction,
         )
 
         # TODO: throw any N->N update rules and keep the highest priority remaining one?
@@ -101,7 +102,7 @@ class AUS:
             if updateQuery['force'] == FAIL or self.rand() >= rule['backgroundRate']:
                 fallbackReleaseName = rule['fallbackMapping']
                 if fallbackReleaseName:
-                    release = dbo.releases.getReleases(name=fallbackReleaseName, limit=1)[0]
+                    release = dbo.releases.getReleases(name=fallbackReleaseName, limit=1, transaction=transaction)[0]
                     blob = release['data']
                     if not blob.shouldServeUpdate(updateQuery):
                         return None, None
@@ -114,7 +115,7 @@ class AUS:
         # 3) Incoming release is older than the one in the mapping, defined as one of:
         #    * version decreases
         #    * version is the same and buildID doesn't increase
-        release = dbo.releases.getReleases(name=rule['mapping'], limit=1)[0]
+        release = dbo.releases.getReleases(name=rule['mapping'], limit=1, transaction=transaction)[0]
         blob = release['data']
         if not blob.shouldServeUpdate(updateQuery):
             return None, None


### PR DESCRIPTION
Hopefully avoids multiple COMMITs to the DB for a client request