### PR TITLE
Fix exception logging

### DIFF
--- a/auslib/test/web/test_client.py
+++ b/auslib/test/web/test_client.py
@@ -1573,6 +1573,24 @@ class ClientTestWithErrorHandlers(ClientTestCommon):
             self.assertEqual(ret.mimetype, "text/plain")
             self.assertEqual('I break!', ret.get_data(as_text=True))
 
+    def testErrorMessageOn500withSimpleArgs(self):
+        with mock.patch('auslib.web.public.client.getQueryFromURL') as m:
+            m.side_effect = Exception('I break!')
+            m.side_effect.args = ("one", "two", "three")
+            ret = self.client.get('/update/4/b/1.0/1/p/l/a/a/a/a/1/update.xml')
+            self.assertEqual(ret.status_code, 500)
+            self.assertEqual(ret.mimetype, "text/plain")
+            self.assertEqual('one two three', ret.get_data(as_text=True))
+
+    def testErrorMessageOn500withComplexArgs(self):
+        with mock.patch('auslib.web.public.client.getQueryFromURL') as m:
+            m.side_effect = Exception('I break!')
+            m.side_effect.args = ("one", ("two", "three"))
+            ret = self.client.get('/update/4/b/1.0/1/p/l/a/a/a/a/1/update.xml')
+            self.assertEqual(ret.status_code, 500)
+            self.assertEqual(ret.mimetype, "text/plain")
+            self.assertEqual("one ('two', 'three')", ret.get_data(as_text=True))
+
     def testEscapedOutputOn500(self):
         with mock.patch('auslib.web.public.client.getQueryFromURL') as m:
             m.side_effect = Exception('50.1.0zibj5<img src%3da onerror%3dalert(document.domain)>')

--- a/auslib/web/public/base.py
+++ b/auslib/web/public/base.py
@@ -95,14 +95,18 @@ def generic(error):
     # both because it's ugly and potentially can leak things, but it's also
     # extremely helpful for debugging BadDataErrors, because we don't send
     # information about them to Sentry.
-    message = " ".join(getattr(error, "args", repr(error)))
+
+    if hasattr(error, "args"):
+        message = " ".join(str(a) for a in error.args)
+    else:
+        message = repr(error)
     if isinstance(error, BadDataError):
-        return Response(status=400, mimetype="text/plain", response=html.escape(message))
+        return Response(status=400, mimetype="text/plain", response=html.escape(message, quote=False))
 
     if sentry.client:
         sentry.captureException()
 
-    return Response(status=500, mimetype="text/plain", response=html.escape(message))
+    return Response(status=500, mimetype="text/plain", response=html.escape(message, quote=False))
 
 
 # Keeping static files endpoints here due to an issue when returning response for static files.


### PR DESCRIPTION
Handle case where exception arguments are not a simple tuple of strings,
e.g. on DB failures we get exceptions with args containing nested
tuples.