### PR TITLE
Bug 1492600 - Prevent signoffs by system accounts

### DIFF
--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -6,7 +6,7 @@ from flask_wtf.csrf import CSRFProtect
 
 from auslib.log import configure_logging
 
-SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "seabld"]
+SYSTEM_ACCOUNTS = ["balrogagent", "balrog-ffxbld", "balrog-tbirdbld", "seabld"]
 DOMAIN_WHITELIST = {
     "download.mozilla.org": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
     "archive.mozilla.org": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
@@ -19,7 +19,7 @@ DOMAIN_WHITELIST = {
     "ftp.mozilla.org": ("SystemAddons",),
 }
 if os.environ.get("STAGING"):
-    SYSTEM_ACCOUNTS.extend(["stage-ffxbld", "stage-tbirdbld", "stage-seabld"])
+    SYSTEM_ACCOUNTS.extend(["balrog-stage-ffxbld", "balrog-stage-tbirdbld"])
     DOMAIN_WHITELIST.update({
         "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
         "bouncer-bouncer-releng.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
@@ -66,6 +66,7 @@ if os.environ.get("NOTIFY_TO_ADDR"):
         os.environ["NOTIFY_FROM_ADDR"],
         use_tls,
     )
+dbo.setSystemAccounts(SYSTEM_ACCOUNTS)
 dbo.setDomainWhitelist(DOMAIN_WHITELIST)
 application.config["WHITELISTED_DOMAINS"] = DOMAIN_WHITELIST
 application.config["PAGE_TITLE"] = "Balrog Administration"

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -4,7 +4,6 @@ import os
 from auslib.log import configure_logging
 
 
-SYSTEM_ACCOUNTS = ["ffxbld", "tbirdbld", "seabld"]
 SPECIAL_FORCE_HOSTS = ["http://download.mozilla.org"]
 DOMAIN_WHITELIST = {
     "download.mozilla.org": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
@@ -18,7 +17,6 @@ DOMAIN_WHITELIST = {
     "ftp.mozilla.org": ("SystemAddons",),
 }
 if os.environ.get("STAGING"):
-    SYSTEM_ACCOUNTS.extend(["stage-ffxbld", "stage-tbirdbld", "stage-seabld"])
     DOMAIN_WHITELIST.update({
         "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
         "bouncer-bouncer-releng.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),


### PR DESCRIPTION
This adds a block based on a hard-coded account list. I've updated the list in the admin wsgi config from last time we used this (email notifications of changes, excluding SYSTEM_ACCOUNTS), and removed them from the public config since signoffs are admin-only. System accounts are then blocked them at the db level from making or removing signoffs.