### PR TITLE
Bug 1492603 - require signoff to change releases from read only -> read write 

### DIFF
--- a/agent/balrogagent/cmd.py
+++ b/agent/balrogagent/cmd.py
@@ -7,7 +7,15 @@ from . import client
 from .changes import get_telemetry_uptake, telemetry_is_ready, time_is_ready
 from .log import configure_logging
 
-SCHEDULED_CHANGE_ENDPOINTS = ["rules", "releases", "permissions", "emergency_shutoff", "required_signoffs/product", "required_signoffs/permissions"]
+SCHEDULED_CHANGE_ENDPOINTS = [
+    "rules",
+    "releases",
+    "releases_readonly",
+    "permissions",
+    "emergency_shutoff",
+    "required_signoffs/product",
+    "required_signoffs/permissions",
+]
 
 
 async def run_agent(loop, balrog_api_root, telemetry_api_root, auth0_secrets, sleeptime=30, once=False, raise_exceptions=False):

--- a/agent/balrogagent/test/test_cmd.py
+++ b/agent/balrogagent/test/test_cmd.py
@@ -34,7 +34,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 0)
-        self.assertEqual(request.call_count, 6)
+        self.assertEqual(request.call_count, 7)
 
     @asynctest.patch("time.time")
     async def testTimeBasedNotReadyRules(self, time, time_is_ready, telemetry_is_ready, request):
@@ -44,7 +44,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 1)
-        self.assertEqual(request.call_count, 6)
+        self.assertEqual(request.call_count, 7)
 
     @asynctest.patch("time.time")
     async def testTimeBasedNotReadyReleases(self, time, time_is_ready, telemetry_is_ready, request):
@@ -54,7 +54,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 1)
-        self.assertEqual(request.call_count, 6)
+        self.assertEqual(request.call_count, 7)
 
     @asynctest.patch("time.time")
     async def testTimeBasedNotReadyPermissions(self, time, time_is_ready, telemetry_is_ready, request):
@@ -64,7 +64,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 1)
-        self.assertEqual(request.call_count, 6)
+        self.assertEqual(request.call_count, 7)
 
     @asynctest.patch("time.time")
     async def testTimeBasedIsNotReadyRequiredSignoffs(self, time, time_is_ready, telemetry_is_ready, request):
@@ -77,7 +77,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 2)
-        self.assertEqual(request.call_count, 6)
+        self.assertEqual(request.call_count, 7)
 
     @asynctest.patch("time.time")
     async def testTimeBasedIsReadyRules(self, time, time_is_ready, telemetry_is_ready, request):
@@ -87,7 +87,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 1)
-        self.assertEqual(request.call_count, 7)
+        self.assertEqual(request.call_count, 8)
 
     @asynctest.patch("time.time")
     async def testTimeBasedIsReadyReleases(self, time, time_is_ready, telemetry_is_ready, request):
@@ -97,7 +97,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 1)
-        self.assertEqual(request.call_count, 7)
+        self.assertEqual(request.call_count, 8)
 
     @asynctest.patch("time.time")
     async def testTimeBasedIsReadyPermissions(self, time, time_is_ready, telemetry_is_ready, request):
@@ -107,7 +107,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 1)
-        self.assertEqual(request.call_count, 7)
+        self.assertEqual(request.call_count, 8)
 
     @asynctest.patch("time.time")
     async def testTimeBasedIsReadyRequiredSignoffs(self, time, time_is_ready, telemetry_is_ready, request):
@@ -120,7 +120,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 2)
-        self.assertEqual(request.call_count, 8)
+        self.assertEqual(request.call_count, 9)
 
     @asynctest.patch("balrogagent.cmd.get_telemetry_uptake")
     async def testTelemetryBasedNotReady(self, get_telemetry_uptake, time_is_ready, telemetry_is_ready, request):
@@ -130,7 +130,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 1)
         self.assertEqual(time_is_ready.call_count, 0)
-        self.assertEqual(request.call_count, 6)
+        self.assertEqual(request.call_count, 7)
 
     @asynctest.patch("balrogagent.cmd.get_telemetry_uptake")
     async def testTelemetryBasedIsReady(self, get_telemetry_uptake, time_is_ready, telemetry_is_ready, request):
@@ -140,7 +140,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 1)
         self.assertEqual(time_is_ready.call_count, 0)
-        self.assertEqual(request.call_count, 7)
+        self.assertEqual(request.call_count, 8)
 
     @asynctest.patch("time.time")
     async def testMultipleEndpointsAtOnce(self, time, time_is_ready, telemetry_is_ready, request):
@@ -154,7 +154,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 3)
-        self.assertEqual(request.call_count, 9)
+        self.assertEqual(request.call_count, 10)
 
     @asynctest.patch("time.time")
     async def testMultipleChangesOneEndpoint(self, time, time_is_ready, telemetry_is_ready, request):
@@ -170,9 +170,10 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 3)
-        self.assertEqual(request.call_count, 9)
+        self.assertEqual(request.call_count, 10)
         called_endpoints = [call[0][1] for call in request.call_args_list]
         self.assertIn("/scheduled_changes/releases", called_endpoints)
+        self.assertIn("/scheduled_changes/releases_readonly", called_endpoints)
         self.assertIn("/scheduled_changes/permissions", called_endpoints)
         self.assertIn("/scheduled_changes/rules", called_endpoints)
         self.assertIn("/scheduled_changes/emergency_shutoff", called_endpoints)
@@ -200,7 +201,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 1)
-        self.assertEqual(request.call_count, 7)
+        self.assertEqual(request.call_count, 8)
 
     @asynctest.patch("time.time")
     async def testSignoffsAbsent(self, time, time_is_ready, telemetry_is_ready, request):
@@ -222,7 +223,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 1)
-        self.assertEqual(request.call_count, 6)
+        self.assertEqual(request.call_count, 7)
 
     @asynctest.patch("time.time")
     async def testRightEnactOrderForMultipleEndpointsAtOnce(self, time, time_is_ready, telemetry_is_ready, request):
@@ -250,7 +251,7 @@ class TestRunAgent(asynctest.TestCase):
         await self._runAgent(sc, request)
         self.assertEqual(telemetry_is_ready.call_count, 0)
         self.assertEqual(time_is_ready.call_count, 11)
-        self.assertEqual(request.call_count, 17)
+        self.assertEqual(request.call_count, 18)
         called_endpoints = [call[0][1] for call in request.call_args_list]
         self.assertLess(called_endpoints.index("/scheduled_changes/rules"), called_endpoints.index("/scheduled_changes/releases"))
         self.assertLess(called_endpoints.index("/scheduled_changes/rules/1/enact"), called_endpoints.index("/scheduled_changes/rules/4/enact"))

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -2101,7 +2101,7 @@ class Releases(AUSTable):
             cache.invalidate("blob_version", release["name"])
 
     def isReadOnly(self, name, transaction=None):
-        return self.db.releasesReadonly.is_readonly(name, transaction=None)
+        return self.db.releasesReadonly.is_readonly(name, transaction=transaction)
 
     def _proceedIfNotReadOnly(self, name, transaction=None):
         if self.isReadOnly(name, transaction):
@@ -2445,7 +2445,7 @@ class ReleasesReadonly(AUSTable):
         return self.db.releases.getPotentialRequiredSignoffs(affected_rows, transaction=transaction)
 
     def is_readonly(self, release_name, transaction=None):
-        release_readonly = self.select(where={"release_name": release_name}, columns=[self.release_name], limit=1)
+        release_readonly = self.select(where={"release_name": release_name}, columns=[self.release_name], limit=1, transaction=transaction)
         return bool(release_readonly)
 
     def insert(self, changed_by, transaction=None, dryrun=False, **columns):

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -1856,7 +1856,7 @@ class Releases(AUSTable):
                     row["rule_ids"] = [ref[1] for ref in refs]
                 else:
                     row['rule_ids'] = []
-                row['read_only'] = self.is_readonly(row['name'], transaction=transaction)
+                row['read_only'] = self.isReadOnly(row['name'], transaction=transaction)
 
         return rows
 

--- a/auslib/migrate/versions/033_add_release_readonly.py
+++ b/auslib/migrate/versions/033_add_release_readonly.py
@@ -1,0 +1,211 @@
+from sqlalchemy import (
+    Table, Column, Integer, BigInteger, String, Boolean, MetaData)
+
+
+metadata = MetaData()
+
+
+releases_readonly = Table(
+    'releases_readonly', metadata,
+    Column('release_name', String(100), nullable=False, primary_key=True),
+    Column("data_version", Integer, nullable=False))
+
+
+releases_readonly_history = Table(
+    'releases_readonly_history', metadata,
+    Column('change_id', Integer, primary_key=True, autoincrement=True),
+    Column('release_name', String(100), nullable=False),
+    Column('changed_by', String(100), nullable=False),
+    Column("data_version", Integer))
+
+
+releases_readonly_scheduled_changes = Table(
+    'releases_readonly_scheduled_changes', metadata,
+    Column("sc_id", Integer, primary_key=True, autoincrement=True),
+    Column("scheduled_by", String(100), nullable=False),
+    Column("complete", Boolean, default=False),
+    Column("change_type", String(50), nullable=False),
+    Column("data_version", Integer, nullable=False),
+    Column('base_release_name', String(100), nullable=False),
+    Column("base_data_version", Integer))
+
+
+releases_readonly_scheduled_changes_history = Table(
+    'releases_readonly_scheduled_changes_history', metadata,
+    Column("change_id", Integer, primary_key=True, autoincrement=True),
+    Column("changed_by", String(100), nullable=False),
+    Column("sc_id", Integer, nullable=False),
+    Column("scheduled_by", String(100)),
+    Column("complete", Boolean, default=False),
+    Column("change_type", String(50)),
+    Column("data_version", Integer),
+    Column('base_release_name', String(100)),
+    Column("base_data_version", Integer))
+
+
+releases_readonly_scheduled_changes_conditions = Table(
+    'releases_readonly_scheduled_changes_conditions', metadata,
+    Column("sc_id", Integer, primary_key=True, autoincrement=True),
+    Column("data_version", Integer, nullable=False))
+
+
+releases_readonly_scheduled_changes_conditions_history = Table(
+    'releases_readonly_scheduled_changes_conditions_history', metadata,
+    Column("change_id", Integer, primary_key=True, autoincrement=True),
+    Column("changed_by", String(100), nullable=False),
+    Column("sc_id", Integer, nullable=False),
+    Column("data_version", Integer))
+
+
+releases_readonly_scheduled_changes_signoffs = Table(
+    'releases_readonly_scheduled_changes_signoffs', metadata,
+    Column("sc_id", Integer, primary_key=True, autoincrement=False),
+    Column("username", String(100), primary_key=True),
+    Column("role", String(50), nullable=False))
+
+
+releases_readonly_scheduled_changes_signoffs_history = Table(
+    'releases_readonly_scheduled_changes_signoffs_history', metadata,
+    Column("change_id", Integer, primary_key=True, autoincrement=True),
+    Column("changed_by", String(100), nullable=False),
+    Column("sc_id", Integer, nullable=False),
+    Column("username", String(100), nullable=False),
+    Column("role", String(50)))
+
+
+def upgrade_data(migrate_engine):
+    insert_query = """
+        INSERT INTO releases_readonly(release_name, data_version)
+        SELECT name, data_version FROM releases WHERE read_only = 1;
+    """
+    migrate_engine.execute(insert_query)
+
+    insert_history_query = """
+        INSERT INTO releases_readonly_history(release_name, data_version, changed_by, `timestamp`)
+        SELECT name, data_version, changed_by, `timestamp`
+        FROM releases_history where read_only = 1;
+    """
+    migrate_engine.execute(insert_history_query)
+
+
+def drop_releases_readonly_columns_sqlite(metadata):
+    tables = ['releases',
+              'releases_history',
+              'releases_scheduled_changes',
+              'releases_scheduled_changes_history']
+
+    new_tables = []
+
+    for table in tables:
+        db_table = Table(table, metadata, autoload=True)
+        new_columns = []
+        for column in db_table.c:
+            if column.name not in ['read_only', 'base_read_only']:
+                new_columns.append(column.copy())
+        db_table.drop()
+        metadata.remove(db_table)
+        new_tables.append(Table(table, metadata, *new_columns))
+
+    metadata.create_all(tables=new_tables)
+
+
+def drop_releases_readonly_columns(metadata):
+    releases = Table('releases', metadata, autoload=True)
+    releases.c.read_only.drop()
+
+    releases_history = Table('releases_history', metadata, autoload=True)
+    releases_history.c.read_only.drop()
+
+    releases_scheduled_changes = Table('releases_scheduled_changes', metadata, autoload=True)
+    releases_scheduled_changes.c.base_read_only.drop()
+
+    releases_scheduled_changes_history = Table('releases_scheduled_changes_history', metadata, autoload=True)
+    releases_scheduled_changes_history.c.base_read_only.drop()
+
+
+def upgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    bigintType = BigInteger
+
+    if migrate_engine.name == 'sqlite':
+        bigintType = Integer
+
+    releases_readonly_history.append_column(
+        Column('timestamp', bigintType, nullable=False))
+
+    releases_readonly_scheduled_changes_history.append_column(
+        Column('timestamp', bigintType, nullable=False))
+
+    releases_readonly_scheduled_changes_conditions.append_column(
+        Column("when", bigintType))
+
+    releases_readonly_scheduled_changes_conditions_history.append_column(
+        Column('when', bigintType))
+    releases_readonly_scheduled_changes_conditions_history.append_column(
+        Column('timestamp', bigintType, nullable=False))
+
+    releases_readonly_scheduled_changes_signoffs_history.append_column(
+        Column('timestamp', bigintType, nullable=False))
+
+    metadata.create_all()
+    upgrade_data(migrate_engine)
+
+    if migrate_engine.name == 'sqlite':
+        drop_releases_readonly_columns_sqlite(metadata)
+    else:
+        drop_releases_readonly_columns(metadata)
+
+
+def create_releases_readonly_columns(metadata):
+    releases = Table('releases', metadata, autoload=True)
+    read_only_column = Column('read_only', Boolean)
+    read_only_column.create(releases, default=False)
+
+    releases_history = Table('releases_history', metadata, autoload=True)
+    read_only_column_history = Column('read_only', Boolean)
+    read_only_column_history.create(releases_history, default=False)
+
+    releases_scheduled_changes = Table('releases_scheduled_changes', metadata, autoload=True)
+    read_only_column_scheduled_changes = Column('read_only', Boolean)
+    read_only_column_scheduled_changes.create(releases_scheduled_changes, default=False)
+
+    releases_scheduled_changes_history = Table('releases_scheduled_changes_history', metadata, autoload=True)
+    read_only_column_scheduled_changes_history = Column('read_only', Boolean)
+    read_only_column_scheduled_changes_history.create(releases_scheduled_changes_history, default=False)
+
+
+def downgrade_data(migrate_engine):
+    update_query = """
+        UPDATE releases as R
+        INNER JOIN releases_readonly AS RR
+        ON R.name = RR.release_name
+        SET R.read_only = 1
+    """
+    migrate_engine.execute(update_query)
+
+    update_history_query = """
+        UPDATE releases_history as R
+        INNER JOIN releases_readonly_history AS RR
+        ON R.name = RR.release_name
+        SET R.read_only = 1
+        where R.data_version = RR.data_version
+    """
+    migrate_engine.execute(update_history_query)
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+
+    create_releases_readonly_columns(metadata)
+
+    if migrate_engine.name != 'sqlite':
+        downgrade_data(migrate_engine)
+
+    Table('releases_readonly', metadata, autoload=True).drop()
+    Table('releases_readonly_history', metadata, autoload=True).drop()
+    Table('releases_readonly_scheduled_changes', metadata, autoload=True).drop()
+    Table('releases_readonly_scheduled_changes_history', metadata, autoload=True).drop()
+    Table('releases_readonly_scheduled_changes_conditions', metadata, autoload=True).drop()
+    Table('releases_readonly_scheduled_changes_conditions_history', metadata, autoload=True).drop()
+    Table('releases_readonly_scheduled_changes_signoffs', metadata, autoload=True).drop()
+    Table('releases_readonly_scheduled_changes_signoffs_history', metadata, autoload=True).drop()

--- a/auslib/migrate/versions/033_add_release_readonly.py
+++ b/auslib/migrate/versions/033_add_release_readonly.py
@@ -1,37 +1,40 @@
-from sqlalchemy import (
-    Table, Column, Integer, BigInteger, String, Boolean, MetaData)
+from sqlalchemy import Table, Column, Integer, BigInteger, String, Boolean, MetaData
 
 
 metadata = MetaData()
 
 
 releases_readonly = Table(
-    'releases_readonly', metadata,
-    Column('release_name', String(100), nullable=False, primary_key=True),
-    Column("data_version", Integer, nullable=False))
+    "releases_readonly", metadata, Column("release_name", String(100), nullable=False, primary_key=True), Column("data_version", Integer, nullable=False)
+)
 
 
 releases_readonly_history = Table(
-    'releases_readonly_history', metadata,
-    Column('change_id', Integer, primary_key=True, autoincrement=True),
-    Column('release_name', String(100), nullable=False),
-    Column('changed_by', String(100), nullable=False),
-    Column("data_version", Integer))
+    "releases_readonly_history",
+    metadata,
+    Column("change_id", Integer, primary_key=True, autoincrement=True),
+    Column("release_name", String(100), nullable=False),
+    Column("changed_by", String(100), nullable=False),
+    Column("data_version", Integer),
+)
 
 
 releases_readonly_scheduled_changes = Table(
-    'releases_readonly_scheduled_changes', metadata,
+    "releases_readonly_scheduled_changes",
+    metadata,
     Column("sc_id", Integer, primary_key=True, autoincrement=True),
     Column("scheduled_by", String(100), nullable=False),
     Column("complete", Boolean, default=False),
     Column("change_type", String(50), nullable=False),
     Column("data_version", Integer, nullable=False),
-    Column('base_release_name', String(100), nullable=False),
-    Column("base_data_version", Integer))
+    Column("base_release_name", String(100), nullable=False),
+    Column("base_data_version", Integer),
+)
 
 
 releases_readonly_scheduled_changes_history = Table(
-    'releases_readonly_scheduled_changes_history', metadata,
+    "releases_readonly_scheduled_changes_history",
+    metadata,
     Column("change_id", Integer, primary_key=True, autoincrement=True),
     Column("changed_by", String(100), nullable=False),
     Column("sc_id", Integer, nullable=False),
@@ -39,38 +42,47 @@ releases_readonly_scheduled_changes_history = Table(
     Column("complete", Boolean, default=False),
     Column("change_type", String(50)),
     Column("data_version", Integer),
-    Column('base_release_name', String(100)),
-    Column("base_data_version", Integer))
+    Column("base_release_name", String(100)),
+    Column("base_data_version", Integer),
+)
 
 
 releases_readonly_scheduled_changes_conditions = Table(
-    'releases_readonly_scheduled_changes_conditions', metadata,
+    "releases_readonly_scheduled_changes_conditions",
+    metadata,
     Column("sc_id", Integer, primary_key=True, autoincrement=True),
-    Column("data_version", Integer, nullable=False))
+    Column("data_version", Integer, nullable=False),
+)
 
 
 releases_readonly_scheduled_changes_conditions_history = Table(
-    'releases_readonly_scheduled_changes_conditions_history', metadata,
+    "releases_readonly_scheduled_changes_conditions_history",
+    metadata,
     Column("change_id", Integer, primary_key=True, autoincrement=True),
     Column("changed_by", String(100), nullable=False),
     Column("sc_id", Integer, nullable=False),
-    Column("data_version", Integer))
+    Column("data_version", Integer),
+)
 
 
 releases_readonly_scheduled_changes_signoffs = Table(
-    'releases_readonly_scheduled_changes_signoffs', metadata,
+    "releases_readonly_scheduled_changes_signoffs",
+    metadata,
     Column("sc_id", Integer, primary_key=True, autoincrement=False),
     Column("username", String(100), primary_key=True),
-    Column("role", String(50), nullable=False))
+    Column("role", String(50), nullable=False),
+)
 
 
 releases_readonly_scheduled_changes_signoffs_history = Table(
-    'releases_readonly_scheduled_changes_signoffs_history', metadata,
+    "releases_readonly_scheduled_changes_signoffs_history",
+    metadata,
     Column("change_id", Integer, primary_key=True, autoincrement=True),
     Column("changed_by", String(100), nullable=False),
     Column("sc_id", Integer, nullable=False),
     Column("username", String(100), nullable=False),
-    Column("role", String(50)))
+    Column("role", String(50)),
+)
 
 
 def upgrade_data(migrate_engine):
@@ -89,10 +101,7 @@ def upgrade_data(migrate_engine):
 
 
 def drop_releases_readonly_columns_sqlite(metadata):
-    tables = ['releases',
-              'releases_history',
-              'releases_scheduled_changes',
-              'releases_scheduled_changes_history']
+    tables = ["releases", "releases_history", "releases_scheduled_changes", "releases_scheduled_changes_history"]
 
     new_tables = []
 
@@ -100,7 +109,7 @@ def drop_releases_readonly_columns_sqlite(metadata):
         db_table = Table(table, metadata, autoload=True)
         new_columns = []
         for column in db_table.c:
-            if column.name not in ['read_only', 'base_read_only']:
+            if column.name not in ["read_only", "base_read_only"]:
                 new_columns.append(column.copy())
         db_table.drop()
         metadata.remove(db_table)
@@ -110,16 +119,16 @@ def drop_releases_readonly_columns_sqlite(metadata):
 
 
 def drop_releases_readonly_columns(metadata):
-    releases = Table('releases', metadata, autoload=True)
+    releases = Table("releases", metadata, autoload=True)
     releases.c.read_only.drop()
 
-    releases_history = Table('releases_history', metadata, autoload=True)
+    releases_history = Table("releases_history", metadata, autoload=True)
     releases_history.c.read_only.drop()
 
-    releases_scheduled_changes = Table('releases_scheduled_changes', metadata, autoload=True)
+    releases_scheduled_changes = Table("releases_scheduled_changes", metadata, autoload=True)
     releases_scheduled_changes.c.base_read_only.drop()
 
-    releases_scheduled_changes_history = Table('releases_scheduled_changes_history', metadata, autoload=True)
+    releases_scheduled_changes_history = Table("releases_scheduled_changes_history", metadata, autoload=True)
     releases_scheduled_changes_history.c.base_read_only.drop()
 
 
@@ -127,50 +136,44 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     bigintType = BigInteger
 
-    if migrate_engine.name == 'sqlite':
+    if migrate_engine.name == "sqlite":
         bigintType = Integer
 
-    releases_readonly_history.append_column(
-        Column('timestamp', bigintType, nullable=False))
+    releases_readonly_history.append_column(Column("timestamp", bigintType, nullable=False))
 
-    releases_readonly_scheduled_changes_history.append_column(
-        Column('timestamp', bigintType, nullable=False))
+    releases_readonly_scheduled_changes_history.append_column(Column("timestamp", bigintType, nullable=False))
 
-    releases_readonly_scheduled_changes_conditions.append_column(
-        Column("when", bigintType))
+    releases_readonly_scheduled_changes_conditions.append_column(Column("when", bigintType))
 
-    releases_readonly_scheduled_changes_conditions_history.append_column(
-        Column('when', bigintType))
-    releases_readonly_scheduled_changes_conditions_history.append_column(
-        Column('timestamp', bigintType, nullable=False))
+    releases_readonly_scheduled_changes_conditions_history.append_column(Column("when", bigintType))
+    releases_readonly_scheduled_changes_conditions_history.append_column(Column("timestamp", bigintType, nullable=False))
 
-    releases_readonly_scheduled_changes_signoffs_history.append_column(
-        Column('timestamp', bigintType, nullable=False))
+    releases_readonly_scheduled_changes_signoffs_history.append_column(Column("timestamp", bigintType, nullable=False))
 
     metadata.create_all()
     upgrade_data(migrate_engine)
 
-    if migrate_engine.name == 'sqlite':
+    if migrate_engine.name == "sqlite":
         drop_releases_readonly_columns_sqlite(metadata)
     else:
         drop_releases_readonly_columns(metadata)
 
 
 def create_releases_readonly_columns(metadata):
-    releases = Table('releases', metadata, autoload=True)
-    read_only_column = Column('read_only', Boolean)
+    releases = Table("releases", metadata, autoload=True)
+    read_only_column = Column("read_only", Boolean)
     read_only_column.create(releases, default=False)
 
-    releases_history = Table('releases_history', metadata, autoload=True)
-    read_only_column_history = Column('read_only', Boolean)
+    releases_history = Table("releases_history", metadata, autoload=True)
+    read_only_column_history = Column("read_only", Boolean)
     read_only_column_history.create(releases_history, default=False)
 
-    releases_scheduled_changes = Table('releases_scheduled_changes', metadata, autoload=True)
-    read_only_column_scheduled_changes = Column('read_only', Boolean)
+    releases_scheduled_changes = Table("releases_scheduled_changes", metadata, autoload=True)
+    read_only_column_scheduled_changes = Column("read_only", Boolean)
     read_only_column_scheduled_changes.create(releases_scheduled_changes, default=False)
 
-    releases_scheduled_changes_history = Table('releases_scheduled_changes_history', metadata, autoload=True)
-    read_only_column_scheduled_changes_history = Column('read_only', Boolean)
+    releases_scheduled_changes_history = Table("releases_scheduled_changes_history", metadata, autoload=True)
+    read_only_column_scheduled_changes_history = Column("read_only", Boolean)
     read_only_column_scheduled_changes_history.create(releases_scheduled_changes_history, default=False)
 
 
@@ -198,14 +201,14 @@ def downgrade(migrate_engine):
 
     create_releases_readonly_columns(metadata)
 
-    if migrate_engine.name != 'sqlite':
+    if migrate_engine.name != "sqlite":
         downgrade_data(migrate_engine)
 
-    Table('releases_readonly', metadata, autoload=True).drop()
-    Table('releases_readonly_history', metadata, autoload=True).drop()
-    Table('releases_readonly_scheduled_changes', metadata, autoload=True).drop()
-    Table('releases_readonly_scheduled_changes_history', metadata, autoload=True).drop()
-    Table('releases_readonly_scheduled_changes_conditions', metadata, autoload=True).drop()
-    Table('releases_readonly_scheduled_changes_conditions_history', metadata, autoload=True).drop()
-    Table('releases_readonly_scheduled_changes_signoffs', metadata, autoload=True).drop()
-    Table('releases_readonly_scheduled_changes_signoffs_history', metadata, autoload=True).drop()
+    Table("releases_readonly", metadata, autoload=True).drop()
+    Table("releases_readonly_history", metadata, autoload=True).drop()
+    Table("releases_readonly_scheduled_changes", metadata, autoload=True).drop()
+    Table("releases_readonly_scheduled_changes_history", metadata, autoload=True).drop()
+    Table("releases_readonly_scheduled_changes_conditions", metadata, autoload=True).drop()
+    Table("releases_readonly_scheduled_changes_conditions_history", metadata, autoload=True).drop()
+    Table("releases_readonly_scheduled_changes_signoffs", metadata, autoload=True).drop()
+    Table("releases_readonly_scheduled_changes_signoffs_history", metadata, autoload=True).drop()

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -334,8 +334,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertEqual(ret.get_data(as_text=True), json.dumps(dict(new_data_version=3)), "Data: %s" % ret.get_data())
 
         # Outdated Data Error on same release
-        ret = self._post('/releases/ee', data=dict(hashFunction="sha512",
-                                                   name='ee', product='ee', data_version=1))
+        ret = self._post("/releases/ee", data=dict(hashFunction="sha512", name="ee", product="ee", data_version=1))
         self.assertStatusCode(ret, 400)
 
         blob = json.loads(blob)
@@ -477,7 +476,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 403)
 
     def testDeleteReadOnlyRelease(self):
-        dbo.releasesReadonly.t.insert().execute({'release_name': 'd', 'data_version': 1})
+        dbo.releasesReadonly.t.insert().execute({"release_name": "d", "data_version": 1})
         ret = self._delete("/releases/d", username="bill", qs=dict(data_version=2))
         self.assertStatusCode(ret, 403)
 
@@ -916,9 +915,9 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 401)
 
     def testLocalePutReadOnlyRelease(self):
-        dbo.releasesReadonly.t.insert().execute({'release_name': 'ab', 'data_version': 1})
+        dbo.releasesReadonly.t.insert().execute({"release_name": "ab", "data_version": 1})
         data = json.dumps({"complete": {"filesize": 435, "from": "*", "hashValue": "abc"}})
-        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
+        ret = self._put("/releases/ab/builds/p/l", data=dict(data=data, product="a", data_version=1, schema_version=1))
         self.assertStatusCode(ret, 403)
 
     def testLocalePutWithProductAdmin(self):
@@ -1836,12 +1835,7 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertEqual(db_data, expected)
 
         base_row = dict(dbo.releases.t.select().where(dbo.releases.name == "a").execute().fetchall()[0])
-        base_expected = {
-            "name": "a",
-            "product": "a",
-            "data": {"name": "a", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"},
-            "data_version": 2,
-        }
+        base_expected = {"name": "a", "product": "a", "data": {"name": "a", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"}, "data_version": 2}
         self.assertEqual(base_row, base_expected)
 
     def testEnactScheduledChangeNewRelease(self):
@@ -1866,12 +1860,7 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertEqual(db_data, expected)
 
         base_row = dict(dbo.releases.t.select().where(dbo.releases.name == "m").execute().fetchall()[0])
-        base_expected = {
-            "name": "m",
-            "product": "m",
-            "data": {"name": "m", "hashFunction": "sha512", "schema_version": 1},
-            "data_version": 1,
-        }
+        base_expected = {"name": "m", "product": "m", "data": {"name": "m", "hashFunction": "sha512", "schema_version": 1}, "data_version": 1}
         self.assertEqual(base_row, base_expected)
 
     def testEnactScheduledChangeDeleteRelease(self):

--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -334,7 +334,8 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertEqual(ret.get_data(as_text=True), json.dumps(dict(new_data_version=3)), "Data: %s" % ret.get_data())
 
         # Outdated Data Error on same release
-        ret = self._post("/releases/ee", data=dict(hashFunction="sha512", read_only=True, name="ee", product="ee", data_version=1))
+        ret = self._post('/releases/ee', data=dict(hashFunction="sha512",
+                                                   name='ee', product='ee', data_version=1))
         self.assertStatusCode(ret, 400)
 
         blob = json.loads(blob)
@@ -342,16 +343,12 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertEqual(len(history_rows), 4)
         self.assertEqual(history_rows[0]["data"], None)
         self.assertEqual(history_rows[0]["data_version"], None)
-        self.assertEqual(history_rows[0]["read_only"], False)
         self.assertEqual(history_rows[1]["data"], {"name": "ee", "schema_version": 1, "hashFunction": "sha512"})
         self.assertEqual(history_rows[1]["data_version"], 1)
-        self.assertEqual(history_rows[1]["read_only"], False)
         self.assertEqual(history_rows[2]["data"], blob)
         self.assertEqual(history_rows[2]["data_version"], 2)
-        self.assertEqual(history_rows[2]["read_only"], False)
         self.assertEqual(history_rows[3]["data"], blob)
         self.assertEqual(history_rows[3]["data_version"], 3)
-        self.assertEqual(history_rows[3]["read_only"], False)
 
     def testReleasePostMismatchedName(self):
         data = json.dumps(dict(name="eee", schema_version=1))
@@ -480,7 +477,7 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 403)
 
     def testDeleteReadOnlyRelease(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "d").execute()
+        dbo.releasesReadonly.t.insert().execute({'release_name': 'd', 'data_version': 1})
         ret = self._delete("/releases/d", username="bill", qs=dict(data_version=2))
         self.assertStatusCode(ret, 403)
 
@@ -919,9 +916,9 @@ class TestReleasesAPI_JSON(ViewTest):
         self.assertStatusCode(ret, 401)
 
     def testLocalePutReadOnlyRelease(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "ab").execute()
+        dbo.releasesReadonly.t.insert().execute({'release_name': 'ab', 'data_version': 1})
         data = json.dumps({"complete": {"filesize": 435, "from": "*", "hashValue": "abc"}})
-        ret = self._put("/releases/ab/builds/p/l", data=dict(data=data, product="a", data_version=1, schema_version=1))
+        ret = self._put('/releases/ab/builds/p/l', data=dict(data=data, product='a', data_version=1, schema_version=1))
         self.assertStatusCode(ret, 403)
 
     def testLocalePutWithProductAdmin(self):
@@ -1412,7 +1409,6 @@ class TestReleasesScheduledChanges(ViewTest):
                     "name": "m",
                     "product": "m",
                     "data": {"name": "m", "hashFunction": "sha512", "schema_version": 1},
-                    "read_only": False,
                     "data_version": None,
                     "signoffs": {},
                     "required_signoffs": {},
@@ -1427,7 +1423,6 @@ class TestReleasesScheduledChanges(ViewTest):
                     "name": "a",
                     "product": "a",
                     "data": {"name": "a", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"},
-                    "read_only": False,
                     "data_version": 1,
                     "signoffs": {"bill": "releng"},
                     "required_signoffs": {"releng": 1},
@@ -1443,7 +1438,6 @@ class TestReleasesScheduledChanges(ViewTest):
                     "name": "ab",
                     "product": None,
                     "data": None,
-                    "read_only": False,
                     "data_version": 1,
                     "signoffs": {"ben": "releng", "bill": "releng"},
                     "required_signoffs": {},
@@ -1468,7 +1462,6 @@ class TestReleasesScheduledChanges(ViewTest):
                     "name": "m",
                     "product": "m",
                     "data": {"name": "m", "hashFunction": "sha512", "schema_version": 1},
-                    "read_only": False,
                     "data_version": None,
                     "signoffs": {},
                     "required_signoffs": {},
@@ -1483,7 +1476,6 @@ class TestReleasesScheduledChanges(ViewTest):
                     "name": "a",
                     "product": "a",
                     "data": {"name": "a", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"},
-                    "read_only": False,
                     "data_version": 1,
                     "signoffs": {"bill": "releng"},
                     "required_signoffs": {"releng": 1},
@@ -1499,7 +1491,6 @@ class TestReleasesScheduledChanges(ViewTest):
                     "name": "b",
                     "product": "b",
                     "data": {"name": "b", "hashFunction": "sha512", "schema_version": 1},
-                    "read_only": False,
                     "data_version": 1,
                     "signoffs": {},
                     "required_signoffs": {},
@@ -1515,7 +1506,6 @@ class TestReleasesScheduledChanges(ViewTest):
                     "name": "ab",
                     "product": None,
                     "data": None,
-                    "read_only": False,
                     "data_version": 1,
                     "signoffs": {"ben": "releng", "bill": "releng"},
                     "required_signoffs": {},
@@ -1548,7 +1538,6 @@ class TestReleasesScheduledChanges(ViewTest):
             "complete": False,
             "data_version": 1,
             "base_product": "d",
-            "base_read_only": False,
             "base_name": "d",
             "base_data": {"name": "d", "hashFunction": "sha256", "schema_version": 1},
             "base_data_version": 1,
@@ -1575,7 +1564,6 @@ class TestReleasesScheduledChanges(ViewTest):
             "complete": False,
             "data_version": 1,
             "base_product": None,
-            "base_read_only": False,
             "base_name": "d",
             "base_data": None,
             "base_data_version": 1,
@@ -1608,7 +1596,6 @@ class TestReleasesScheduledChanges(ViewTest):
             "complete": False,
             "data_version": 1,
             "base_product": "q",
-            "base_read_only": False,
             "base_name": "q",
             "base_data": {"name": "q", "hashFunction": "sha512", "schema_version": 1},
             "base_data_version": None,
@@ -1657,7 +1644,6 @@ class TestReleasesScheduledChanges(ViewTest):
             "scheduled_by": "bill",
             "base_name": "a",
             "base_product": "a",
-            "base_read_only": False,
             "base_data": {"name": "a", "hashFunction": "sha512", "extv": "3.0", "schema_version": 1},
             "base_data_version": 1,
         }
@@ -1687,7 +1673,6 @@ class TestReleasesScheduledChanges(ViewTest):
             "scheduled_by": "bill",
             "base_name": "ab",
             "base_product": None,
-            "base_read_only": False,
             "base_data": None,
             "base_data_version": 1,
         }
@@ -1722,7 +1707,6 @@ class TestReleasesScheduledChanges(ViewTest):
             "scheduled_by": "julie",
             "base_name": "a",
             "base_product": "a",
-            "base_read_only": False,
             "base_data": {"name": "a", "hashFunction": "sha512", "extv": "3.0", "schema_version": 1},
             "base_data_version": 1,
         }
@@ -1779,7 +1763,6 @@ class TestReleasesScheduledChanges(ViewTest):
             "scheduled_by": "bill",
             "base_name": "m",
             "base_product": "m",
-            "base_read_only": False,
             "base_data": {"name": "m", "hashFunction": "sha512", "appv": "4.0", "schema_version": 1},
             "base_data_version": None,
         }
@@ -1813,7 +1796,6 @@ class TestReleasesScheduledChanges(ViewTest):
             "scheduled_by": "bill",
             "base_name": "mm",
             "base_product": "mm",
-            "base_read_only": False,
             "base_data": {"name": "mm", "hashFunction": "sha512", "appv": "4.0", "schema_version": 1},
             "base_data_version": None,
         }
@@ -1848,7 +1830,6 @@ class TestReleasesScheduledChanges(ViewTest):
             "change_type": "update",
             "base_name": "a",
             "base_product": "a",
-            "base_read_only": False,
             "base_data": {"name": "a", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"},
             "base_data_version": 1,
         }
@@ -1858,7 +1839,6 @@ class TestReleasesScheduledChanges(ViewTest):
         base_expected = {
             "name": "a",
             "product": "a",
-            "read_only": False,
             "data": {"name": "a", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"},
             "data_version": 2,
         }
@@ -1880,7 +1860,6 @@ class TestReleasesScheduledChanges(ViewTest):
             "change_type": "insert",
             "base_name": "m",
             "base_product": "m",
-            "base_read_only": False,
             "base_data": {"name": "m", "hashFunction": "sha512", "schema_version": 1},
             "base_data_version": None,
         }
@@ -1890,7 +1869,6 @@ class TestReleasesScheduledChanges(ViewTest):
         base_expected = {
             "name": "m",
             "product": "m",
-            "read_only": False,
             "data": {"name": "m", "hashFunction": "sha512", "schema_version": 1},
             "data_version": 1,
         }
@@ -1912,7 +1890,6 @@ class TestReleasesScheduledChanges(ViewTest):
             "change_type": "delete",
             "base_name": "ab",
             "base_product": None,
-            "base_read_only": False,
             "base_data": None,
             "base_data_version": 1,
         }
@@ -1939,7 +1916,6 @@ class TestReleasesScheduledChanges(ViewTest):
                     "name": "b",
                     "product": "b",
                     "data": {"name": "b", "hashFunction": "sha512", "schema_version": 1},
-                    "read_only": False,
                     "complete": True,
                     "when": 10000000,
                     "sc_data_version": 2,
@@ -1955,7 +1931,6 @@ class TestReleasesScheduledChanges(ViewTest):
                     "name": "b",
                     "product": "b",
                     "data": {"name": "b", "hashFunction": "sha512", "schema_version": 1},
-                    "read_only": False,
                     "complete": False,
                     "when": 10000000,
                     "sc_data_version": 1,
@@ -1974,7 +1949,6 @@ class TestReleasesScheduledChanges(ViewTest):
                 "revisions": [
                     {
                         "change_id": 9,
-                        "read_only": False,
                         "name": "ab",
                         "scheduled_by": "bill",
                         "when": 230000000,
@@ -1990,7 +1964,6 @@ class TestReleasesScheduledChanges(ViewTest):
                     },
                     {
                         "change_id": 7,
-                        "read_only": False,
                         "name": "b",
                         "scheduled_by": "bill",
                         "when": 10000000,
@@ -2011,7 +1984,6 @@ class TestReleasesScheduledChanges(ViewTest):
                 "revisions": [
                     {
                         "change_id": 6,
-                        "read_only": "False",
                         "name": "b",
                         "_different": [],
                         "changed_by": "bill",
@@ -2031,9 +2003,9 @@ class TestReleasesScheduledChanges(ViewTest):
         for index in range(len(revisions)):
             self.assertEqual(revisions[index]["product"], expected_revisions[index]["product"])
             self.assertEqual(revisions[index]["timestamp"], expected_revisions[index]["timestamp"])
-            self.assertEqual(revisions[index]["read_only"], expected_revisions[index]["read_only"])
             self.assertEqual(revisions[index]["data_version"], expected_revisions[index]["data_version"])
             self.assertEqual(revisions[index]["changed_by"], expected_revisions[index]["changed_by"])
+
         self.assertEqual(len(history_data["revisions"]), 1)
 
     @mock.patch("time.time", mock.MagicMock(return_value=100))
@@ -2108,7 +2080,6 @@ class TestReleaseHistoryView(ViewTest):
                     {
                         "name": "b",
                         "change_id": 6,
-                        "read_only": "False",
                         "_time_ago": "48 years ago",
                         "data_version": 1,
                         "_different": [],
@@ -2119,7 +2090,6 @@ class TestReleaseHistoryView(ViewTest):
                     {
                         "name": "d",
                         "change_id": 4,
-                        "read_only": "False",
                         "_time_ago": "48 years ago",
                         "data_version": 1,
                         "_different": ["name", "data", "product"],
@@ -2130,7 +2100,6 @@ class TestReleaseHistoryView(ViewTest):
                     {
                         "name": "ab",
                         "change_id": 2,
-                        "read_only": "False",
                         "_time_ago": "48 years ago",
                         "data_version": 1,
                         "_different": ["name", "data", "product"],
@@ -2185,9 +2154,9 @@ class TestReleaseHistoryView(ViewTest):
         for index in range(len(revisions)):
             self.assertEqual(revisions[index]["product"], expected_revisions[index]["product"])
             self.assertEqual(revisions[index]["timestamp"], expected_revisions[index]["timestamp"])
-            self.assertEqual(revisions[index]["read_only"], expected_revisions[index]["read_only"])
             self.assertEqual(revisions[index]["data_version"], expected_revisions[index]["data_version"])
             self.assertEqual(revisions[index]["changed_by"], expected_revisions[index]["changed_by"])
+
         self.assertEqual(len(history_data["revisions"]), 3)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300000))
@@ -2257,71 +2226,6 @@ class TestSingleColumn_JSON(ViewTest):
     def testGetReleaseColumn404(self):
         ret = self.client.get("/releases/columns/blah")
         self.assertEqual(ret.status_code, 404)
-
-
-class TestReadOnlyView(ViewTest):
-    def testReadOnlyGet(self):
-        ret = self._get("/releases/b/read_only")
-        is_read_only = dbo.releases.t.select(dbo.releases.name == "b").execute().first()["read_only"]
-        self.assertEqual(ret.get_json()["read_only"], is_read_only)
-
-    def testReadOnlySetTrueAdmin(self):
-        data = dict(name="b", read_only=True, product="b", data_version=1)
-        ret = self._put("/releases/b/read_only", username="bill", data=data)
-        self.assertStatusCode(ret, 201)
-        read_only = dbo.releases.isReadOnly(name="b")
-        self.assertEqual(read_only, True)
-
-    def testReadOnlySetTrueNonAdmin(self):
-        data = dict(name="b", read_only=True, product="b", data_version=1)
-        ret = self._put("/releases/b/read_only", username="bob", data=data)
-        self.assertStatusCode(ret, 201)
-        read_only = dbo.releases.isReadOnly(name="b")
-        self.assertEqual(read_only, True)
-
-    def testReadOnlySetFalseAdmin(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "a").execute()
-        data = dict(name="b", read_only="", product="b", data_version=2)
-        ret = self._put("/releases/b/read_only", username="bill", data=data)
-        self.assertStatusCode(ret, 201)
-        read_only = dbo.releases.isReadOnly(name="b")
-        self.assertEqual(read_only, False)
-
-    def testReadOnlyUnsetWithoutPermissionForProduct(self):
-        dbo.releases.t.update(values=dict(read_only=True, data_version=2)).where(dbo.releases.name == "a").execute()
-        data = dict(name="b", read_only="", product="b", data_version=2)
-        ret = self._put("/releases/b/read_only", username="me", data=data)
-        self.assertStatusCode(ret, 403)
-
-    def testReadOnlyAdminSetAndUnsetFlag(self):
-        # Setting flag
-        data = dict(name="b", read_only=True, product="b", data_version=1)
-        ret = self._put("/releases/b/read_only", username="bill", data=data)
-        self.assertStatusCode(ret, 201)
-
-        # Resetting flag
-        data = dict(name="b", read_only="", product="b", data_version=2)
-        ret = self._put("/releases/b/read_only", username="bill", data=data)
-        self.assertStatusCode(ret, 201)
-
-        # Verify reset
-        read_only = dbo.releases.isReadOnly(name="b")
-        self.assertEqual(read_only, False)
-
-    def testReadOnlyNonAdminCanSetFlagButNotUnset(self):
-        # Setting read only flag
-        data_set = dict(name="b", read_only=True, product="b", data_version=1)
-        ret = self._put("/releases/b/read_only", username="bob", data=data_set)
-        self.assertStatusCode(ret, 201)
-
-        # Verifying if flag was set to true
-        read_only = dbo.releases.isReadOnly(name="b")
-        self.assertEqual(read_only, True)
-
-        # Resetting flag, which should fail with 403
-        data_unset = dict(name="b", read_only="", product="b", data_version=2)
-        ret = self._put("/releases/b/read_only", username="bob", data=data_unset)
-        self.assertStatusCode(ret, 403)
 
 
 class TestRuleIdsReturned(ViewTest):

--- a/auslib/test/admin/views/test_releases_readonly.py
+++ b/auslib/test/admin/views/test_releases_readonly.py
@@ -1,0 +1,151 @@
+from auslib.global_state import dbo
+from auslib.test.admin.views.base import ViewTest
+from auslib.blobs.base import createBlob
+
+
+class TestReleasesReadOnly(ViewTest):
+    def setUp(self):
+        super(TestReleasesReadOnly, self).setUp()
+        dbo.productRequiredSignoffs.t.insert().execute(
+            product="K", channel="Z", role="releng", signoffs_required=1, data_version=1)
+        dbo.productRequiredSignoffs.t.insert().execute(
+            product="K", channel="Z", role="relman", signoffs_required=1, data_version=1)
+        dbo.releases.t.insert().execute(
+            name='K', product='K', data_version=1,
+            data=createBlob(dict(name='a', hashFunction="sha512", schema_version=1)))
+        dbo.rules.t.insert().execute(
+            rule_id=42000042, product='K', priority=25, backgroundRate=100,
+            mapping='K', update_type='minor', channel="Z", data_version=1)
+        dbo.releasesReadonly.t.insert().execute(
+            {'release_name': 'K', 'data_version': 1})
+        dbo.releasesReadonly.scheduled_changes.t.insert().execute(
+            sc_id=1, scheduled_by='bill', change_type='delete',
+            data_version=1, base_release_name='K', base_data_version=1)
+        dbo.releasesReadonly.scheduled_changes.conditions.t.insert().execute(
+            sc_id=1, data_version=1, when=1000000)
+
+    def test_set_readonly(self):
+        release_name = 'a'
+        resp = self._post('/releases_readonly/{}'.format(release_name))
+        self.assertStatusCode(resp, 201)
+        release_readonly = dbo.releasesReadonly.select(where={'release_name': release_name})
+        self.assertTrue(release_readonly)
+        self.assertEqual(release_readonly[0]['release_name'], release_name)
+
+    def test_already_readonly(self):
+        release_name = 'a'
+        dbo.releasesReadonly.t.insert().execute(
+            {'release_name': release_name, 'data_version': 1})
+        resp = self._post('/releases_readonly/{}'.format(release_name))
+        self.assertStatusCode(resp, 400)
+
+    def test_set_readonly_release_does_not_exists(self):
+        release_name = 'a42'
+        resp = self._post('/releases_readonly/{}'.format(release_name))
+        self.assertStatusCode(resp, 400)
+
+    def test_set_readonly_no_permission(self):
+        release_name = 'a'
+        resp = self._post('/releases_readonly/{}'.format(release_name), username='julie')
+        self.assertStatusCode(resp, 403)
+
+    def test_set_read_write(self):
+        release_name = 'c'
+        dbo.releasesReadonly.t.insert().execute({'release_name': release_name, 'data_version': 1})
+        resp = self._delete(
+            '/releases_readonly/{}'.format(release_name),
+            qs={'data_version': 1})
+        self.assertStatusCode(resp, 200)
+        release_readonly = dbo.releasesReadonly.select(where={'release_name': release_name})
+        self.assertFalse(release_readonly)
+
+    def test_set_read_write_when_not_readonly(self):
+        release_name = 'a'
+        resp = self._delete('/releases_readonly/{}'.format(release_name), qs={'data_version': 1})
+        self.assertStatusCode(resp, 400)
+
+    def test_set_read_write_no_permission(self):
+        release_name = 'c'
+        dbo.releasesReadonly.t.insert().execute({'release_name': release_name, 'data_version': 1})
+        resp = self._delete(
+            '/releases_readonly/{}'.format(release_name),
+            qs={'data_version': 1},
+            username='julie')
+        self.assertStatusCode(resp, 403)
+        release_readonly = dbo.releasesReadonly.select(where={'release_name': release_name})
+        self.assertTrue(release_readonly)
+
+    def test_get_scheduled_changes_read_write(self):
+        resp = self._get('/scheduled_changes/releases_readonly')
+        self.assertStatusCode(resp, 200)
+        data = resp.get_json()
+        self.assertEqual(data['count'], 1)
+        scheduled_change = data['scheduled_changes'][0]
+        self.assertIn('relman', scheduled_change['required_signoffs'])
+        self.assertIn('releng', scheduled_change['required_signoffs'])
+
+    def test_schedule_read_write(self):
+        release_name = 'a'
+        dbo.releasesReadonly.t.insert().execute(
+            {'release_name': release_name, 'data_version': 1})
+        data = {
+            'release_name': release_name,
+            'data_version': 1,
+            'change_type': 'delete'
+        }
+        resp = self._post('/scheduled_changes/releases_readonly', data=data)
+        self.assertStatusCode(resp, 200)
+
+        sc = dbo.releasesReadonly.scheduled_changes.select(where={'base_release_name': release_name})
+        self.assertTrue(sc)
+
+    def test_delete_scheduled_read_write(self):
+        resp = self._delete(
+            '/scheduled_changes/releases_readonly/1', qs={'data_version': 1})
+        self.assertStatusCode(resp, 200)
+        sc_table = dbo.releasesReadonly.scheduled_changes
+        sc = sc_table.t.select().where(sc_table.sc_id == 1).execute().fetchall()
+        self.assertFalse(sc)
+
+    def test_enact_change_read_write(self):
+        signoffs_table = dbo.releasesReadonly.scheduled_changes.signoffs
+        signoffs_table.t.insert().execute(sc_id=1, username="julie", role="releng")
+        signoffs_table.t.insert().execute(sc_id=1, username="mary", role="relman")
+
+        resp = self._post('/scheduled_changes/releases_readonly/1/enact')
+        self.assertStatusCode(resp, 200)
+        releases_readonly = dbo.releasesReadonly.select(where={'release_name': 'K'})
+        self.assertFalse(releases_readonly)
+
+    def test_enact_change_insufficient_signoffs(self):
+        resp = self._post('/scheduled_changes/releases_readonly/1/enact')
+        self.assertStatusCode(resp, 400)
+        releases_readonly = dbo.releasesReadonly.select(where={'release_name': 'K'})
+        self.assertTrue(releases_readonly)
+
+    def test_signoff(self):
+        sc_id = 1
+        data = {
+            'username': 'julie',
+            'role': 'releng'
+        }
+        resp = self._post(
+            '/scheduled_changes/releases_readonly/{}/signoffs'.format(sc_id),
+            data=data, username='julie')
+        self.assertStatusCode(resp, 200)
+        signoffs = dbo.releasesReadonly.scheduled_changes.signoffs.select(
+            where={'sc_id': sc_id, 'username': 'julie', 'role': 'releng'})
+        self.assertTrue(signoffs)
+
+    def test_remove_signoff(self):
+        sc_id = 1
+        qs = {'username': 'julie'}
+        dbo.releasesReadonly.scheduled_changes.signoffs.t.insert().execute(
+            sc_id=sc_id, username='julie', role='releng')
+        resp = self._delete(
+            '/scheduled_changes/releases_readonly/{}/signoffs'.format(sc_id),
+            qs=qs, username='julie')
+        self.assertStatusCode(resp, 200)
+        sc = dbo.releasesReadonly.scheduled_changes.signoffs.select(
+            where={'sc_id': sc_id})
+        self.assertFalse(sc)

--- a/auslib/test/admin/views/test_releases_readonly.py
+++ b/auslib/test/admin/views/test_releases_readonly.py
@@ -6,113 +6,95 @@ from auslib.blobs.base import createBlob
 class TestReleasesReadOnly(ViewTest):
     def setUp(self):
         super(TestReleasesReadOnly, self).setUp()
-        dbo.productRequiredSignoffs.t.insert().execute(
-            product="K", channel="Z", role="releng", signoffs_required=1, data_version=1)
-        dbo.productRequiredSignoffs.t.insert().execute(
-            product="K", channel="Z", role="relman", signoffs_required=1, data_version=1)
-        dbo.releases.t.insert().execute(
-            name='K', product='K', data_version=1,
-            data=createBlob(dict(name='a', hashFunction="sha512", schema_version=1)))
+        dbo.productRequiredSignoffs.t.insert().execute(product="K", channel="Z", role="releng", signoffs_required=1, data_version=1)
+        dbo.productRequiredSignoffs.t.insert().execute(product="K", channel="Z", role="relman", signoffs_required=1, data_version=1)
+        dbo.releases.t.insert().execute(name="K", product="K", data_version=1, data=createBlob(dict(name="a", hashFunction="sha512", schema_version=1)))
         dbo.rules.t.insert().execute(
-            rule_id=42000042, product='K', priority=25, backgroundRate=100,
-            mapping='K', update_type='minor', channel="Z", data_version=1)
-        dbo.releasesReadonly.t.insert().execute(
-            {'release_name': 'K', 'data_version': 1})
+            rule_id=42000042, product="K", priority=25, backgroundRate=100, mapping="K", update_type="minor", channel="Z", data_version=1
+        )
+        dbo.releasesReadonly.t.insert().execute({"release_name": "K", "data_version": 1})
         dbo.releasesReadonly.scheduled_changes.t.insert().execute(
-            sc_id=1, scheduled_by='bill', change_type='delete',
-            data_version=1, base_release_name='K', base_data_version=1)
-        dbo.releasesReadonly.scheduled_changes.conditions.t.insert().execute(
-            sc_id=1, data_version=1, when=1000000)
+            sc_id=1, scheduled_by="bill", change_type="delete", data_version=1, base_release_name="K", base_data_version=1
+        )
+        dbo.releasesReadonly.scheduled_changes.conditions.t.insert().execute(sc_id=1, data_version=1, when=1000000)
 
     def test_get(self):
-        resp = self._get('/releases_readonly/K')
+        resp = self._get("/releases_readonly/K")
         self.assertStatusCode(resp, 200)
         data = resp.get_json()
-        self.assertEqual(data['release_name'], 'K')
-        self.assertEqual(data['data_version'], 1)
+        self.assertEqual(data["release_name"], "K")
+        self.assertEqual(data["data_version"], 1)
 
     def test_get_not_found(self):
-        resp = self._get('/releases_readonly/ZZZ')
+        resp = self._get("/releases_readonly/ZZZ")
         self.assertStatusCode(resp, 404)
 
     def test_set_readonly(self):
-        release_name = 'a'
-        resp = self._post('/releases_readonly/{}'.format(release_name))
+        release_name = "a"
+        resp = self._post("/releases_readonly/{}".format(release_name))
         self.assertStatusCode(resp, 201)
-        release_readonly = dbo.releasesReadonly.select(where={'release_name': release_name})
+        release_readonly = dbo.releasesReadonly.select(where={"release_name": release_name})
         self.assertTrue(release_readonly)
-        self.assertEqual(release_readonly[0]['release_name'], release_name)
+        self.assertEqual(release_readonly[0]["release_name"], release_name)
 
     def test_already_readonly(self):
-        release_name = 'a'
-        dbo.releasesReadonly.t.insert().execute(
-            {'release_name': release_name, 'data_version': 1})
-        resp = self._post('/releases_readonly/{}'.format(release_name))
+        release_name = "a"
+        dbo.releasesReadonly.t.insert().execute({"release_name": release_name, "data_version": 1})
+        resp = self._post("/releases_readonly/{}".format(release_name))
         self.assertStatusCode(resp, 400)
 
     def test_set_readonly_release_does_not_exists(self):
-        release_name = 'a42'
-        resp = self._post('/releases_readonly/{}'.format(release_name))
+        release_name = "a42"
+        resp = self._post("/releases_readonly/{}".format(release_name))
         self.assertStatusCode(resp, 400)
 
     def test_set_readonly_no_permission(self):
-        release_name = 'a'
-        resp = self._post('/releases_readonly/{}'.format(release_name), username='julie')
+        release_name = "a"
+        resp = self._post("/releases_readonly/{}".format(release_name), username="julie")
         self.assertStatusCode(resp, 403)
 
     def test_set_read_write(self):
-        release_name = 'c'
-        dbo.releasesReadonly.t.insert().execute({'release_name': release_name, 'data_version': 1})
-        resp = self._delete(
-            '/releases_readonly/{}'.format(release_name),
-            qs={'data_version': 1})
+        release_name = "c"
+        dbo.releasesReadonly.t.insert().execute({"release_name": release_name, "data_version": 1})
+        resp = self._delete("/releases_readonly/{}".format(release_name), qs={"data_version": 1})
         self.assertStatusCode(resp, 200)
-        release_readonly = dbo.releasesReadonly.select(where={'release_name': release_name})
+        release_readonly = dbo.releasesReadonly.select(where={"release_name": release_name})
         self.assertFalse(release_readonly)
 
     def test_set_read_write_when_not_readonly(self):
-        release_name = 'a'
-        resp = self._delete('/releases_readonly/{}'.format(release_name), qs={'data_version': 1})
+        release_name = "a"
+        resp = self._delete("/releases_readonly/{}".format(release_name), qs={"data_version": 1})
         self.assertStatusCode(resp, 400)
 
     def test_set_read_write_no_permission(self):
-        release_name = 'c'
-        dbo.releasesReadonly.t.insert().execute({'release_name': release_name, 'data_version': 1})
-        resp = self._delete(
-            '/releases_readonly/{}'.format(release_name),
-            qs={'data_version': 1},
-            username='julie')
+        release_name = "c"
+        dbo.releasesReadonly.t.insert().execute({"release_name": release_name, "data_version": 1})
+        resp = self._delete("/releases_readonly/{}".format(release_name), qs={"data_version": 1}, username="julie")
         self.assertStatusCode(resp, 403)
-        release_readonly = dbo.releasesReadonly.select(where={'release_name': release_name})
+        release_readonly = dbo.releasesReadonly.select(where={"release_name": release_name})
         self.assertTrue(release_readonly)
 
     def test_get_scheduled_changes_read_write(self):
-        resp = self._get('/scheduled_changes/releases_readonly')
+        resp = self._get("/scheduled_changes/releases_readonly")
         self.assertStatusCode(resp, 200)
         data = resp.get_json()
-        self.assertEqual(data['count'], 1)
-        scheduled_change = data['scheduled_changes'][0]
-        self.assertIn('relman', scheduled_change['required_signoffs'])
-        self.assertIn('releng', scheduled_change['required_signoffs'])
+        self.assertEqual(data["count"], 1)
+        scheduled_change = data["scheduled_changes"][0]
+        self.assertIn("relman", scheduled_change["required_signoffs"])
+        self.assertIn("releng", scheduled_change["required_signoffs"])
 
     def test_schedule_read_write(self):
-        release_name = 'a'
-        dbo.releasesReadonly.t.insert().execute(
-            {'release_name': release_name, 'data_version': 1})
-        data = {
-            'release_name': release_name,
-            'data_version': 1,
-            'change_type': 'delete'
-        }
-        resp = self._post('/scheduled_changes/releases_readonly', data=data)
+        release_name = "a"
+        dbo.releasesReadonly.t.insert().execute({"release_name": release_name, "data_version": 1})
+        data = {"release_name": release_name, "data_version": 1, "change_type": "delete"}
+        resp = self._post("/scheduled_changes/releases_readonly", data=data)
         self.assertStatusCode(resp, 200)
 
-        sc = dbo.releasesReadonly.scheduled_changes.select(where={'base_release_name': release_name})
+        sc = dbo.releasesReadonly.scheduled_changes.select(where={"base_release_name": release_name})
         self.assertTrue(sc)
 
     def test_delete_scheduled_read_write(self):
-        resp = self._delete(
-            '/scheduled_changes/releases_readonly/1', qs={'data_version': 1})
+        resp = self._delete("/scheduled_changes/releases_readonly/1", qs={"data_version": 1})
         self.assertStatusCode(resp, 200)
         sc_table = dbo.releasesReadonly.scheduled_changes
         sc = sc_table.t.select().where(sc_table.sc_id == 1).execute().fetchall()
@@ -123,40 +105,30 @@ class TestReleasesReadOnly(ViewTest):
         signoffs_table.t.insert().execute(sc_id=1, username="julie", role="releng")
         signoffs_table.t.insert().execute(sc_id=1, username="mary", role="relman")
 
-        resp = self._post('/scheduled_changes/releases_readonly/1/enact')
+        resp = self._post("/scheduled_changes/releases_readonly/1/enact")
         self.assertStatusCode(resp, 200)
-        releases_readonly = dbo.releasesReadonly.select(where={'release_name': 'K'})
+        releases_readonly = dbo.releasesReadonly.select(where={"release_name": "K"})
         self.assertFalse(releases_readonly)
 
     def test_enact_change_insufficient_signoffs(self):
-        resp = self._post('/scheduled_changes/releases_readonly/1/enact')
+        resp = self._post("/scheduled_changes/releases_readonly/1/enact")
         self.assertStatusCode(resp, 400)
-        releases_readonly = dbo.releasesReadonly.select(where={'release_name': 'K'})
+        releases_readonly = dbo.releasesReadonly.select(where={"release_name": "K"})
         self.assertTrue(releases_readonly)
 
     def test_signoff(self):
         sc_id = 1
-        data = {
-            'username': 'julie',
-            'role': 'releng'
-        }
-        resp = self._post(
-            '/scheduled_changes/releases_readonly/{}/signoffs'.format(sc_id),
-            data=data, username='julie')
+        data = {"username": "julie", "role": "releng"}
+        resp = self._post("/scheduled_changes/releases_readonly/{}/signoffs".format(sc_id), data=data, username="julie")
         self.assertStatusCode(resp, 200)
-        signoffs = dbo.releasesReadonly.scheduled_changes.signoffs.select(
-            where={'sc_id': sc_id, 'username': 'julie', 'role': 'releng'})
+        signoffs = dbo.releasesReadonly.scheduled_changes.signoffs.select(where={"sc_id": sc_id, "username": "julie", "role": "releng"})
         self.assertTrue(signoffs)
 
     def test_remove_signoff(self):
         sc_id = 1
-        qs = {'username': 'julie'}
-        dbo.releasesReadonly.scheduled_changes.signoffs.t.insert().execute(
-            sc_id=sc_id, username='julie', role='releng')
-        resp = self._delete(
-            '/scheduled_changes/releases_readonly/{}/signoffs'.format(sc_id),
-            qs=qs, username='julie')
+        qs = {"username": "julie"}
+        dbo.releasesReadonly.scheduled_changes.signoffs.t.insert().execute(sc_id=sc_id, username="julie", role="releng")
+        resp = self._delete("/scheduled_changes/releases_readonly/{}/signoffs".format(sc_id), qs=qs, username="julie")
         self.assertStatusCode(resp, 200)
-        sc = dbo.releasesReadonly.scheduled_changes.signoffs.select(
-            where={'sc_id': sc_id})
+        sc = dbo.releasesReadonly.scheduled_changes.signoffs.select(where={"sc_id": sc_id})
         self.assertFalse(sc)

--- a/auslib/test/admin/views/test_releases_readonly.py
+++ b/auslib/test/admin/views/test_releases_readonly.py
@@ -24,6 +24,17 @@ class TestReleasesReadOnly(ViewTest):
         dbo.releasesReadonly.scheduled_changes.conditions.t.insert().execute(
             sc_id=1, data_version=1, when=1000000)
 
+    def test_get(self):
+        resp = self._get('/releases_readonly/K')
+        self.assertStatusCode(resp, 200)
+        data = resp.get_json()
+        self.assertEqual(data['release_name'], 'K')
+        self.assertEqual(data['data_version'], 1)
+
+    def test_get_not_found(self):
+        resp = self._get('/releases_readonly/ZZZ')
+        self.assertStatusCode(resp, 404)
+
     def test_set_readonly(self):
         release_name = 'a'
         resp = self._post('/releases_readonly/{}'.format(release_name))

--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -3696,8 +3696,8 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.assertRaises(ValueError, self.releases.delete, {"name": "fallback"}, changed_by="me", old_data_version=1)
 
     def testDeleteReleaseWhenReadOnly(self):
-        self.releasesReadonly.t.insert().execute(release_name='a', data_version=1)
-        self.assertRaises(ReadOnlyError, self.releases.delete, {"name": "a"}, changed_by='me', old_data_version=2)
+        self.releasesReadonly.t.insert().execute(release_name="a", data_version=1)
+        self.assertRaises(ReadOnlyError, self.releases.delete, {"name": "a"}, changed_by="me", old_data_version=2)
 
     # Ideally we'd run these, but they end up raising a ValueError because they are mapped to,
     # so we never see a SignoffRequiredError
@@ -3730,12 +3730,12 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.assertRaises(SignoffRequiredError, self.releases.update, {"name": "h"}, {"data": newBlob}, "bill", 1)
 
     def testIsReadOnly(self):
-        self.releasesReadonly.t.insert().execute(release_name='a', data_version=1)
-        self.assertEqual(self.releases.isReadOnly('a'), True)
+        self.releasesReadonly.t.insert().execute(release_name="a", data_version=1)
+        self.assertEqual(self.releases.isReadOnly("a"), True)
 
     def testProceedIfNotReadOnly(self):
-        self.releasesReadonly.t.insert().execute(release_name='a', data_version=1)
-        self.assertRaises(ReadOnlyError, self.releases._proceedIfNotReadOnly, 'a')
+        self.releasesReadonly.t.insert().execute(release_name="a", data_version=1)
+        self.assertRaises(ReadOnlyError, self.releases._proceedIfNotReadOnly, "a")
 
     def testGetRulesMatchingQueryChannelCheckMinLengthGlobbing(self):
         # To ensure length of ruleChannel is >=3
@@ -3822,87 +3822,69 @@ class TestReleasesReadOnly(unittest.TestCase, MemoryDatabaseMixin):
         self.permissions = dbo.permissions
         self.productRequiredSignoffs = dbo.productRequiredSignoffs
 
-        self.releases.t.insert().execute(
-            name='a', product='a', data=createBlob(
-                dict(name='a', schema_version=1, hashFunction='sha512')), data_version=1)
-        self.releases.t.insert().execute(
-            name='f', product='f', data=createBlob(
-                dict(name='f', schema_version=1, hashFunction='sha512')), data_version=1)
-        self.releases.t.insert().execute(
-            name='k', product='k', data=createBlob(
-                dict(name='k', schema_version=1, hashFunction='sha512')), data_version=1)
+        self.releases.t.insert().execute(name="a", product="a", data=createBlob(dict(name="a", schema_version=1, hashFunction="sha512")), data_version=1)
+        self.releases.t.insert().execute(name="f", product="f", data=createBlob(dict(name="f", schema_version=1, hashFunction="sha512")), data_version=1)
+        self.releases.t.insert().execute(name="k", product="k", data=createBlob(dict(name="k", schema_version=1, hashFunction="sha512")), data_version=1)
 
-        self.rules.t.insert().execute(
-            rule_id=1, product="a", channel="z", mapping="a",
-            backgroundRate=100, priority=100, update_type="minor", data_version=1)
+        self.rules.t.insert().execute(rule_id=1, product="a", channel="z", mapping="a", backgroundRate=100, priority=100, update_type="minor", data_version=1)
 
         self.permissions.t.insert().execute(permission="admin", username="me", data_version=1)
         self.permissions.t.insert().execute(permission="admin", username="bill", data_version=1)
         self.permissions.t.insert().execute(
-            permission="release_read_only", username="bob",
-            options=dict(products=["k"], actions=['set', 'unset']), data_version=1)
-        self.permissions.t.insert().execute(
-            permission="release", username="john", data_version=1)
+            permission="release_read_only", username="bob", options=dict(products=["k"], actions=["set", "unset"]), data_version=1
+        )
+        self.permissions.t.insert().execute(permission="release", username="john", data_version=1)
         self.permissions.user_roles.t.insert().execute(username="bill", role="bar", data_version=1)
         self.permissions.user_roles.t.insert().execute(username="bob", role="bar", data_version=1)
-        self.productRequiredSignoffs.t.insert().execute(
-            product="a", channel="z", role="bar", signoffs_required=2, data_version=1)
+        self.productRequiredSignoffs.t.insert().execute(product="a", channel="z", role="bar", signoffs_required=2, data_version=1)
 
     def test_insert(self):
-        release_readonly = dict(release_name='a')
-        self.releasesReadonly.insert('me', **release_readonly)
-        releases_readonly = self.releasesReadonly.select(where={'release_name': 'a'}, limit=1)
+        release_readonly = dict(release_name="a")
+        self.releasesReadonly.insert("me", **release_readonly)
+        releases_readonly = self.releasesReadonly.select(where={"release_name": "a"}, limit=1)
         self.assertTrue(releases_readonly)
 
     def test_insert_no_admin(self):
-        release_readonly = dict(release_name='k')
-        self.releasesReadonly.insert('bob', **release_readonly)
-        releases_readonly = self.releasesReadonly.select(where={'release_name': 'k'}, limit=1)
+        release_readonly = dict(release_name="k")
+        self.releasesReadonly.insert("bob", **release_readonly)
+        releases_readonly = self.releasesReadonly.select(where={"release_name": "k"}, limit=1)
         self.assertTrue(releases_readonly)
 
     def test_insert_release_not_exists(self):
-        release_readonly = dict(release_name='y')
-        self.assertRaises(
-            ValueError, self.releasesReadonly.insert, changed_by='me', **release_readonly)
+        release_readonly = dict(release_name="y")
+        self.assertRaises(ValueError, self.releasesReadonly.insert, changed_by="me", **release_readonly)
 
     def test_delete(self):
-        self.releasesReadonly.t.insert().execute(release_name='f', data_version=1)
-        self.releasesReadonly.delete(
-            changed_by='me', old_data_version=1, where={'release_name': 'f'})
-        releases_readonly = self.releasesReadonly.select(where={'release_name': 'f'})
+        self.releasesReadonly.t.insert().execute(release_name="f", data_version=1)
+        self.releasesReadonly.delete(changed_by="me", old_data_version=1, where={"release_name": "f"})
+        releases_readonly = self.releasesReadonly.select(where={"release_name": "f"})
         self.assertFalse(releases_readonly)
 
     def test_delete_no_admin(self):
-        self.releasesReadonly.t.insert().execute(release_name='k', data_version=1)
-        self.releasesReadonly.delete(
-            changed_by='bob', old_data_version=1, where={'release_name': 'k'})
-        releases_readonly = self.releasesReadonly.select(where={'release_name': 'k'})
+        self.releasesReadonly.t.insert().execute(release_name="k", data_version=1)
+        self.releasesReadonly.delete(changed_by="bob", old_data_version=1, where={"release_name": "k"})
+        releases_readonly = self.releasesReadonly.select(where={"release_name": "k"})
         self.assertFalse(releases_readonly)
 
     def test_is_readonly(self):
-        self.releasesReadonly.t.insert().execute(release_name='f', data_version=1)
-        self.assertTrue(self.releasesReadonly.is_readonly('f'))
-        self.assertFalse(self.releasesReadonly.is_readonly('k'))
+        self.releasesReadonly.t.insert().execute(release_name="f", data_version=1)
+        self.assertTrue(self.releasesReadonly.is_readonly("f"))
+        self.assertFalse(self.releasesReadonly.is_readonly("k"))
 
     def test_insert_with_no_permission(self):
-        release_readonly = dict(release_name='k')
-        self.assertRaises(
-            PermissionDeniedError, self.releasesReadonly.insert, changed_by='john', **release_readonly)
+        release_readonly = dict(release_name="k")
+        self.assertRaises(PermissionDeniedError, self.releasesReadonly.insert, changed_by="john", **release_readonly)
 
     def test_delete_with_no_permission(self):
-        release_readonly = dict(release_name='k')
-        self.releasesReadonly.t.insert().execute(release_name='k', data_version=1)
-        self.assertRaises(
-            PermissionDeniedError, self.releasesReadonly.delete,
-            changed_by='john', where=release_readonly, old_data_version=1)
+        release_readonly = dict(release_name="k")
+        self.releasesReadonly.t.insert().execute(release_name="k", data_version=1)
+        self.assertRaises(PermissionDeniedError, self.releasesReadonly.delete, changed_by="john", where=release_readonly, old_data_version=1)
 
     def test_delete_require_signoffs(self):
-        self.releasesReadonly.t.insert().execute(release_name='a', data_version=1)
-        signoffs = [{'username': 'bob', 'role': 'bar'},
-                    {'username': 'bill', 'role': 'bar'}]
-        self.releasesReadonly.delete(
-            changed_by='me', old_data_version=1, where={'release_name': 'a'}, signoffs=signoffs)
-        releases_readonly = self.releasesReadonly.select(where={'release_name': 'a'})
+        self.releasesReadonly.t.insert().execute(release_name="a", data_version=1)
+        signoffs = [{"username": "bob", "role": "bar"}, {"username": "bill", "role": "bar"}]
+        self.releasesReadonly.delete(changed_by="me", old_data_version=1, where={"release_name": "a"}, signoffs=signoffs)
+        releases_readonly = self.releasesReadonly.select(where={"release_name": "a"})
         self.assertFalse(releases_readonly)
 
 
@@ -4376,9 +4358,9 @@ class TestReleasesAppReleaseBlobs(unittest.TestCase, MemoryDatabaseMixin):
 
     def testAddRelease(self):
         blob = ReleaseBlobV1(name="d", hashFunction="sha512")
-        self.releases.insert(changed_by="bill", name='d', product='d', data=blob)
-        expected = [('d', 'd', createBlob(dict(name="d", schema_version=1, hashFunction="sha512")), 1)]
-        self.assertEqual(self.releases.t.select().where(self.releases.name == 'd').execute().fetchall(), expected)
+        self.releases.insert(changed_by="bill", name="d", product="d", data=blob)
+        expected = [("d", "d", createBlob(dict(name="d", schema_version=1, hashFunction="sha512")), 1)]
+        self.assertEqual(self.releases.t.select().where(self.releases.name == "d").execute().fetchall(), expected)
 
     def testAddReleaseAlreadyExists(self):
         blob = ReleaseBlobV1(name="a", hashFunction="sha512")
@@ -4387,20 +4369,20 @@ class TestReleasesAppReleaseBlobs(unittest.TestCase, MemoryDatabaseMixin):
     def testUpdateRelease(self):
         blob = ReleaseBlobV1(name="a", hashFunction="sha512")
         self.releases.update({"name": "a"}, {"product": "z", "data": blob}, "bill", 1)
-        expected = [('a', 'z', createBlob(dict(name='a', schema_version=1, hashFunction="sha512")), 2)]
-        self.assertEqual(self.releases.t.select().where(self.releases.name == 'a').execute().fetchall(), expected)
+        expected = [("a", "z", createBlob(dict(name="a", schema_version=1, hashFunction="sha512")), 2)]
+        self.assertEqual(self.releases.t.select().where(self.releases.name == "a").execute().fetchall(), expected)
 
     def testUpdateReleaseWhenReadOnly(self):
         blob = ReleaseBlobV1(name="a", hashFunction="sha512")
         # set release 'a' to read-only
-        self.releasesReadonly.t.insert().execute(release_name='a', data_version=1)
+        self.releasesReadonly.t.insert().execute(release_name="a", data_version=1)
         self.assertRaises(ReadOnlyError, self.releases.update, {"name": "a"}, {"product": "z", "data": blob}, "me", 2)
 
     def testUpdateReleaseWithBlob(self):
         blob = ReleaseBlobV1(name="b", schema_version=1, hashFunction="sha512")
         self.releases.update({"name": "b"}, {"product": "z", "data": blob}, "bill", 1)
-        expected = [('b', 'z', createBlob(dict(name='b', schema_version=1, hashFunction="sha512")), 2)]
-        self.assertEqual(self.releases.t.select().where(self.releases.name == 'b').execute().fetchall(), expected)
+        expected = [("b", "z", createBlob(dict(name="b", schema_version=1, hashFunction="sha512")), 2)]
+        self.assertEqual(self.releases.t.select().where(self.releases.name == "b").execute().fetchall(), expected)
 
     def testUpdateReleaseInvalidBlob(self):
         blob = ReleaseBlobV1(name="2", hashFunction="sha512")
@@ -4679,9 +4661,10 @@ class TestReleasesAppReleaseBlobs(unittest.TestCase, MemoryDatabaseMixin):
 
     def testAddLocaleWhenReadOnly(self):
         data = {"complete": {"filesize": 1, "from": "*", "hashValue": "abc"}}
-        self.releasesReadonly.t.insert().execute(release_name='a', data_version=1)
-        self.assertRaises(ReadOnlyError, self.releases.addLocaleToRelease, name='a', product='a', platform='p', locale='c', data=data, old_data_version=1,
-                          changed_by='bill')
+        self.releasesReadonly.t.insert().execute(release_name="a", data_version=1)
+        self.assertRaises(
+            ReadOnlyError, self.releases.addLocaleToRelease, name="a", product="a", platform="p", locale="c", data=data, old_data_version=1, changed_by="bill"
+        )
 
     def testAddMergeableOutdatedData(self):
         ancestor_blob = createBlob(
@@ -5644,69 +5627,70 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
     def setUpClass(cls):
         cls.db_tables = set(
             [
-            "dockerflow",
-            # TODO: dive into this more
-            # Migrate version only exists in production-like databases.
-            # "migrate_version", # noqa
-            "permissions",
-            "permissions_history",
-            "permissions_scheduled_changes",
-            "permissions_scheduled_changes_conditions",
-            "permissions_scheduled_changes_conditions_history",
-            "permissions_scheduled_changes_history",
-            "permissions_scheduled_changes_signoffs",
-            "permissions_scheduled_changes_signoffs_history",
-            "permissions_req_signoffs",
-            "permissions_req_signoffs_history",
-            "permissions_req_signoffs_scheduled_changes",
-            "permissions_req_signoffs_scheduled_changes_conditions",
-            "permissions_req_signoffs_scheduled_changes_conditions_history",
-            "permissions_req_signoffs_scheduled_changes_history",
-            "permissions_req_signoffs_scheduled_changes_signoffs",
-            "permissions_req_signoffs_scheduled_changes_signoffs_history",
-            "product_req_signoffs",
-            "product_req_signoffs_history",
-            "product_req_signoffs_scheduled_changes",
-            "product_req_signoffs_scheduled_changes_conditions",
-            "product_req_signoffs_scheduled_changes_conditions_history",
-            "product_req_signoffs_scheduled_changes_history",
-            "product_req_signoffs_scheduled_changes_signoffs",
-            "product_req_signoffs_scheduled_changes_signoffs_history",
-            "releases",
-            "releases_history",
-            "releases_scheduled_changes",
-            "releases_scheduled_changes_conditions",
-            "releases_scheduled_changes_conditions_history",
-            "releases_scheduled_changes_history",
-            "releases_scheduled_changes_signoffs",
-            "releases_scheduled_changes_signoffs_history",
-            "rules",
-            "rules_history",
-            "rules_scheduled_changes",
-            "rules_scheduled_changes_conditions",
-            "rules_scheduled_changes_conditions_history",
-            "rules_scheduled_changes_history",
-            "rules_scheduled_changes_signoffs",
-            "rules_scheduled_changes_signoffs_history",
-            "user_roles",
-            "user_roles_history",
-            "emergency_shutoffs",
-            "emergency_shutoffs_history",
-            "emergency_shutoffs_scheduled_changes",
-            "emergency_shutoffs_scheduled_changes_history",
-            "emergency_shutoffs_scheduled_changes_conditions",
-            "emergency_shutoffs_scheduled_changes_conditions_history",
-            "emergency_shutoffs_scheduled_changes_signoffs",
-            "emergency_shutoffs_scheduled_changes_signoffs_history",
-            "releases_readonly",
-            "releases_readonly_history",
-            "releases_readonly_scheduled_changes",
-            "releases_readonly_scheduled_changes_history",
-            "releases_readonly_scheduled_changes_conditions",
-            "releases_readonly_scheduled_changes_conditions_history",
-            "releases_readonly_scheduled_changes_signoffs",
-            "releases_readonly_scheduled_changes_signoffs_history",
-        ])
+                "dockerflow",
+                # TODO: dive into this more
+                # Migrate version only exists in production-like databases.
+                # "migrate_version", # noqa
+                "permissions",
+                "permissions_history",
+                "permissions_scheduled_changes",
+                "permissions_scheduled_changes_conditions",
+                "permissions_scheduled_changes_conditions_history",
+                "permissions_scheduled_changes_history",
+                "permissions_scheduled_changes_signoffs",
+                "permissions_scheduled_changes_signoffs_history",
+                "permissions_req_signoffs",
+                "permissions_req_signoffs_history",
+                "permissions_req_signoffs_scheduled_changes",
+                "permissions_req_signoffs_scheduled_changes_conditions",
+                "permissions_req_signoffs_scheduled_changes_conditions_history",
+                "permissions_req_signoffs_scheduled_changes_history",
+                "permissions_req_signoffs_scheduled_changes_signoffs",
+                "permissions_req_signoffs_scheduled_changes_signoffs_history",
+                "product_req_signoffs",
+                "product_req_signoffs_history",
+                "product_req_signoffs_scheduled_changes",
+                "product_req_signoffs_scheduled_changes_conditions",
+                "product_req_signoffs_scheduled_changes_conditions_history",
+                "product_req_signoffs_scheduled_changes_history",
+                "product_req_signoffs_scheduled_changes_signoffs",
+                "product_req_signoffs_scheduled_changes_signoffs_history",
+                "releases",
+                "releases_history",
+                "releases_scheduled_changes",
+                "releases_scheduled_changes_conditions",
+                "releases_scheduled_changes_conditions_history",
+                "releases_scheduled_changes_history",
+                "releases_scheduled_changes_signoffs",
+                "releases_scheduled_changes_signoffs_history",
+                "rules",
+                "rules_history",
+                "rules_scheduled_changes",
+                "rules_scheduled_changes_conditions",
+                "rules_scheduled_changes_conditions_history",
+                "rules_scheduled_changes_history",
+                "rules_scheduled_changes_signoffs",
+                "rules_scheduled_changes_signoffs_history",
+                "user_roles",
+                "user_roles_history",
+                "emergency_shutoffs",
+                "emergency_shutoffs_history",
+                "emergency_shutoffs_scheduled_changes",
+                "emergency_shutoffs_scheduled_changes_history",
+                "emergency_shutoffs_scheduled_changes_conditions",
+                "emergency_shutoffs_scheduled_changes_conditions_history",
+                "emergency_shutoffs_scheduled_changes_signoffs",
+                "emergency_shutoffs_scheduled_changes_signoffs_history",
+                "releases_readonly",
+                "releases_readonly_history",
+                "releases_readonly_scheduled_changes",
+                "releases_readonly_scheduled_changes_history",
+                "releases_readonly_scheduled_changes_conditions",
+                "releases_readonly_scheduled_changes_conditions_history",
+                "releases_readonly_scheduled_changes_signoffs",
+                "releases_readonly_scheduled_changes_signoffs_history",
+            ]
+        )
 
         # autoincrement isn't tested as Sqlite does not support this outside of INTEGER PRIMARY KEYS.
         # If the testing db is ever switched to mysql, this should be revisited.
@@ -6028,7 +6012,8 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
             "releases_readonly_scheduled_changes_conditions",
             "releases_readonly_scheduled_changes_conditions_history",
             "releases_readonly_scheduled_changes_signoffs",
-            "releases_readonly_scheduled_changes_signoffs_history"]
+            "releases_readonly_scheduled_changes_signoffs_history",
+        ]
         if upgrade:
             for table in release_readonly_tables:
                 self.assertIn(table, metadata.tables)

--- a/auslib/util/signoffs.py
+++ b/auslib/util/signoffs.py
@@ -1,0 +1,7 @@
+def serialize_signoff_requirements(requirements):
+    dct = {}
+    for rs in requirements:
+        signoffs_required = max(dct.get(rs["role"], 0), rs["signoffs_required"])
+        dct[rs["role"]] = signoffs_required
+
+    return dct

--- a/auslib/web/admin/releases_readonly.py
+++ b/auslib/web/admin/releases_readonly.py
@@ -5,104 +5,89 @@ from connexion import problem
 from flask import Response
 
 from auslib.global_state import dbo
-from auslib.web.admin.views.base import (
-    requirelogin, handleGeneralExceptions, transactionHandler)
+from auslib.web.admin.views.base import requirelogin, handleGeneralExceptions, transactionHandler
 
-from auslib.web.admin.views.scheduled_changes import (
-    EnactScheduledChangeView, ScheduledChangeView, ScheduledChangesView, SignoffsView)
+from auslib.web.admin.views.scheduled_changes import EnactScheduledChangeView, ScheduledChangeView, ScheduledChangesView, SignoffsView
 
 
-@handleGeneralExceptions('GET')
+@handleGeneralExceptions("GET")
 def get(release):
     where = dict(release_name=release)
     releases_read_only = dbo.releasesReadonly.select(where=where)
 
     if not releases_read_only:
-        return problem(
-            status=404, title="Not Found",
-            detail="Release readonly not found.",
-            ext={"exception": "Release readonly not found."})
+        return problem(status=404, title="Not Found", detail="Release readonly not found.", ext={"exception": "Release readonly not found."})
 
     release_read_only = releases_read_only[0]
-    headers = {'X-Data-Version': release_read_only['data_version']}
+    headers = {"X-Data-Version": release_read_only["data_version"]}
 
-    return Response(
-        response=json.dumps(release_read_only),
-        headers=headers,
-        mimetype='application/json')
+    return Response(response=json.dumps(release_read_only), headers=headers, mimetype="application/json")
 
 
 @requirelogin
 @transactionHandler
-@handleGeneralExceptions('POST')
+@handleGeneralExceptions("POST")
 def post(release, changed_by, transaction):
     if dbo.releasesReadonly.is_readonly(release):
-        return problem(
-            400, 'Bad Request', 'Releases Readonly',
-            ext={'data': 'Release is already in readonly state.'})
+        return problem(400, "Bad Request", "Releases Readonly", ext={"data": "Release is already in readonly state."})
 
     if not dbo.releasesReadonly.get_release_info(release, transaction=transaction):
-        return problem(
-            400, 'Bad Request', 'Releases Readonly',
-            ext={'data': 'Release {} does not exists.'.format(release)})
+        return problem(400, "Bad Request", "Releases Readonly", ext={"data": "Release {} does not exists.".format(release)})
 
-    dbo.releasesReadonly.insert(
-        changed_by, transaction=transaction, release_name=release)
+    dbo.releasesReadonly.insert(changed_by, transaction=transaction, release_name=release)
 
     return Response(status=201)
 
 
 @requirelogin
 @transactionHandler
-@handleGeneralExceptions('DELETE')
+@handleGeneralExceptions("DELETE")
 def delete(release, data_version, changed_by, transaction, **kwargs):
     if not dbo.releasesReadonly.is_readonly(release):
-        return problem(
-            400, 'Bad Request', 'Releases Readonly',
-            ext={'data': 'Release is not in readonly state.'})
-    where = {'release_name': release}
+        return problem(400, "Bad Request", "Releases Readonly", ext={"data": "Release is not in readonly state."})
+    where = {"release_name": release}
     dbo.releasesReadonly.delete(where, changed_by, data_version)
     return Response(status=200)
 
 
 def scheduled_changes():
-    view = ScheduledChangesView('releases_readonly', dbo.releasesReadonly)
+    view = ScheduledChangesView("releases_readonly", dbo.releasesReadonly)
     return view.get()
 
 
 @requirelogin
 @transactionHandler
 def schedule_release_read_write(sc_release_readonly, changed_by, transaction):
-    if 'csrf_token' in sc_release_readonly:
-        del sc_release_readonly['csrf_token']
+    if "csrf_token" in sc_release_readonly:
+        del sc_release_readonly["csrf_token"]
 
-    change_type = sc_release_readonly.get('change_type')
-    if change_type != 'delete':
+    change_type = sc_release_readonly.get("change_type")
+    if change_type != "delete":
         return problem(400, "Bad Request", "Invalid or missing change_type")
 
-    sc_release_readonly['when'] = (time.time() + 360) * 1000
-    view = ScheduledChangesView('releases_readonly', dbo.releasesReadonly)
+    sc_release_readonly["when"] = (time.time() + 360) * 1000
+    view = ScheduledChangesView("releases_readonly", dbo.releasesReadonly)
     return view._post(sc_release_readonly, transaction, changed_by, change_type)
 
 
 @requirelogin
 @transactionHandler
 def delete_scheduled_release_read_write(sc_id, changed_by, transaction, **kwargs):
-    view = ScheduledChangeView('releases_readonly', dbo.releasesReadonly)
+    view = ScheduledChangeView("releases_readonly", dbo.releasesReadonly)
     return view._delete(sc_id, transaction, changed_by)
 
 
 def scheduled_changes_signoffs(sc_id):
-    view = SignoffsView('releases_readonly', dbo.releasesReadonly)
+    view = SignoffsView("releases_readonly", dbo.releasesReadonly)
     return view.post(sc_id)
 
 
 def scheduled_changes_signoffs_delete(sc_id):
-    view = SignoffsView('releases_readonly', dbo.releasesReadonly)
+    view = SignoffsView("releases_readonly", dbo.releasesReadonly)
     return view.delete(sc_id)
 
 
 @requirelogin
 def enact_release_read_write(sc_id, changed_by):
-    view = EnactScheduledChangeView('releases_readonly', dbo.releasesReadonly)
+    view = EnactScheduledChangeView("releases_readonly", dbo.releasesReadonly)
     return view.post(sc_id, changed_by=changed_by)

--- a/auslib/web/admin/releases_readonly.py
+++ b/auslib/web/admin/releases_readonly.py
@@ -22,7 +22,7 @@ def get(release):
     release_read_only = releases_read_only[0]
     required_signoffs = dbo.releasesReadonly.getPotentialRequiredSignoffs(releases_read_only)
     release_read_only["required_signoffs"] = serialize_signoff_requirements(required_signoffs[release_read_only["release_name"]])
-    
+
     headers = {"X-Data-Version": release_read_only["data_version"]}
 
     return Response(response=json.dumps(release_read_only), headers=headers, mimetype="application/json")
@@ -77,6 +77,7 @@ def schedule_release_read_write(sc_release_readonly, changed_by, transaction):
 
 @requirelogin
 @transactionHandler
+@handleGeneralExceptions("DELETE")
 def delete_scheduled_release_read_write(sc_id, changed_by, transaction, **kwargs):
     view = ScheduledChangeView("releases_readonly", dbo.releasesReadonly)
     return view._delete(sc_id, transaction, changed_by)

--- a/auslib/web/admin/releases_readonly.py
+++ b/auslib/web/admin/releases_readonly.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 from connexion import problem
@@ -9,6 +10,26 @@ from auslib.web.admin.views.base import (
 
 from auslib.web.admin.views.scheduled_changes import (
     EnactScheduledChangeView, ScheduledChangeView, ScheduledChangesView, SignoffsView)
+
+
+@handleGeneralExceptions('GET')
+def get(release):
+    where = dict(release_name=release)
+    releases_read_only = dbo.releasesReadonly.select(where=where)
+
+    if not releases_read_only:
+        return problem(
+            status=404, title="Not Found",
+            detail="Release readonly not found.",
+            ext={"exception": "Release readonly not found."})
+
+    release_read_only = releases_read_only[0]
+    headers = {'X-Data-Version': release_read_only['data_version']}
+
+    return Response(
+        response=json.dumps(release_read_only),
+        headers=headers,
+        mimetype='application/json')
 
 
 @requirelogin

--- a/auslib/web/admin/releases_readonly.py
+++ b/auslib/web/admin/releases_readonly.py
@@ -1,0 +1,87 @@
+import time
+
+from connexion import problem
+from flask import Response
+
+from auslib.global_state import dbo
+from auslib.web.admin.views.base import (
+    requirelogin, handleGeneralExceptions, transactionHandler)
+
+from auslib.web.admin.views.scheduled_changes import (
+    EnactScheduledChangeView, ScheduledChangeView, ScheduledChangesView, SignoffsView)
+
+
+@requirelogin
+@transactionHandler
+@handleGeneralExceptions('POST')
+def post(release, changed_by, transaction):
+    if dbo.releasesReadonly.is_readonly(release):
+        return problem(
+            400, 'Bad Request', 'Releases Readonly',
+            ext={'data': 'Release is already in readonly state.'})
+
+    if not dbo.releasesReadonly.get_release_info(release, transaction=transaction):
+        return problem(
+            400, 'Bad Request', 'Releases Readonly',
+            ext={'data': 'Release {} does not exists.'.format(release)})
+
+    dbo.releasesReadonly.insert(
+        changed_by, transaction=transaction, release_name=release)
+
+    return Response(status=201)
+
+
+@requirelogin
+@transactionHandler
+@handleGeneralExceptions('DELETE')
+def delete(release, data_version, changed_by, transaction, **kwargs):
+    if not dbo.releasesReadonly.is_readonly(release):
+        return problem(
+            400, 'Bad Request', 'Releases Readonly',
+            ext={'data': 'Release is not in readonly state.'})
+    where = {'release_name': release}
+    dbo.releasesReadonly.delete(where, changed_by, data_version)
+    return Response(status=200)
+
+
+def scheduled_changes():
+    view = ScheduledChangesView('releases_readonly', dbo.releasesReadonly)
+    return view.get()
+
+
+@requirelogin
+@transactionHandler
+def schedule_release_read_write(sc_release_readonly, changed_by, transaction):
+    if 'csrf_token' in sc_release_readonly:
+        del sc_release_readonly['csrf_token']
+
+    change_type = sc_release_readonly.get('change_type')
+    if change_type != 'delete':
+        return problem(400, "Bad Request", "Invalid or missing change_type")
+
+    sc_release_readonly['when'] = (time.time() + 360) * 1000
+    view = ScheduledChangesView('releases_readonly', dbo.releasesReadonly)
+    return view._post(sc_release_readonly, transaction, changed_by, change_type)
+
+
+@requirelogin
+@transactionHandler
+def delete_scheduled_release_read_write(sc_id, changed_by, transaction, **kwargs):
+    view = ScheduledChangeView('releases_readonly', dbo.releasesReadonly)
+    return view._delete(sc_id, transaction, changed_by)
+
+
+def scheduled_changes_signoffs(sc_id):
+    view = SignoffsView('releases_readonly', dbo.releasesReadonly)
+    return view.post(sc_id)
+
+
+def scheduled_changes_signoffs_delete(sc_id):
+    view = SignoffsView('releases_readonly', dbo.releasesReadonly)
+    return view.delete(sc_id)
+
+
+@requirelogin
+def enact_release_read_write(sc_id, changed_by):
+    view = EnactScheduledChangeView('releases_readonly', dbo.releasesReadonly)
+    return view.post(sc_id, changed_by=changed_by)

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -717,7 +717,6 @@ paths:
                 - data_version: 2
                   name: XP-Vista-Desupport
                   product: Firefox
-                  read_only: false
                   rule_ids: [468, 498]
 
     post:
@@ -873,91 +872,6 @@ paths:
         '404':
           $ref: '#/responses/resourceNotFound'
 
-  /releases/{release}/read_only:
-    get:
-      summary: Returns whether or not the named Release is marked as read_only
-      description: >
-        Returns whether or not the named Release is marked as read_only. [Docs](http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#releases-release-read-only)
-      tags:
-        - Releases
-      operationId: auslib.web.admin.views.mapper.release_read_only_get
-      consumes: []
-      produces:
-        - application/json
-      externalDocs:
-        url: "http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#releases-release-read-only"
-        description: Returns whether or not the named Release is marked as read_only
-      parameters:
-        - $ref: '#/parameters/releaseParam'
-      responses:
-        '200':
-          description: Returns release object data
-          schema:
-            type: object
-            required:
-              - read_only
-            properties:
-              read_only:
-                description: boolean flag set to True is release is read only else set as False
-                type: boolean
-                example: true
-        '404':
-          $ref: '#/responses/resourceNotFound'
-
-    put:
-      summary: Sets or unsets the read_only flag of the named Release.
-      description: >
-        Sets or unsets the read_only flag of the named Release. Requires release name, data_version and read_only values. [Docs](http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#id15)
-      tags:
-        - Releases
-      operationId: auslib.web.admin.views.mapper.release_read_only_put
-      consumes:
-        - application/json
-      produces:
-        - text/html
-        - application/json
-      externalDocs:
-        url: "http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#id15"
-        description: Sets or unsets the read_only flag of the named Release.
-      parameters:
-        - $ref: '#/parameters/releaseParam'
-        - name: release_read_only_body
-          in: body
-          description: Read Only Release modify Request paramaters
-          required: true
-          schema:
-            required:
-              - data_version
-            allOf:
-              - $ref: '#/definitions/CSRFModel'
-              - $ref: '#/definitions/DataVersionModel'
-              - type: object
-                description: read_only boolean flag
-                required:
-                  - read_only
-                properties:
-                  read_only:
-                    # read_only key is always present when submitted from the UI form.
-                    # In case of false , a blank string i.e. '' is passed as key's value
-                    # hence we have to add type: string along with boolean as list of accepted types
-                    # for read_only.
-                    # TODO: Fix bug in UI and remove type: string below
-                    type: ["boolean", "string"]
-                    description: blank string if read only is true else set to false
-                    example: true
-                # TODO: Fix bug in UI. Currently the UI form sends the entire '#/definitions/ReleaseGET' model in
-                # the request.json when only two values 'read_only' and 'data_version' are needed.
-                additionalProperties: true
-      responses:
-        '201':
-          $ref: '#/responses/updateExistingObject'
-        '401':
-          $ref: '#/responses/unauthenticatedUser'
-        '403':
-          $ref: '#/responses/unauthorizedUser'
-        '404':
-          $ref: '#/responses/resourceNotFound'
-
   /releases/columns/{column}:
     get:
       summary: Returns a JSON Object containing the unique values for the given release column
@@ -1083,11 +997,6 @@ paths:
                         - $ref: '#/definitions/ReleaseName'
                         - type: object
                           properties:
-                            read_only:
-                              description: Flag that indicates whether release is marked read_only or not.
-                              type: string
-                              enum: [ "True", "False"]
-                              example: "True"
                             _different:
                               description: list of columns that were modified in revision
                               type: array
@@ -1106,7 +1015,6 @@ paths:
                         - name
                         - product
                         - data_version
-                        - read_only
                         - _different
                         - _time_ago
         '400':
@@ -2628,7 +2536,6 @@ paths:
                         - $ref: '#/definitions/SCCommonFieldsModel'
                         - $ref: '#/definitions/DataVersionNullable'
                         - $ref: '#/definitions/ProductNullable'
-                        - $ref: '#/definitions/ReleaseReadOnly'
                         - $ref: '#/definitions/ReleaseDataObject'
                         - $ref: '#/definitions/ReleaseName'
                         - properties:
@@ -2638,7 +2545,6 @@ paths:
                                 - $ref: '#/definitions/ReleaseName'
                                 - $ref: '#/definitions/DataVersionNullable'
                                 - $ref: '#/definitions/ProductNullable'
-                                - $ref: '#/definitions/ReleaseReadOnly'
                       required:
                         - change_type
                         - data_version
@@ -2646,7 +2552,6 @@ paths:
                         - product
                         - name
                         - data
-                        - read_only
 
     post:
       summary: create scheduled change for a release.
@@ -2811,7 +2716,6 @@ paths:
                         - $ref: '#/definitions/SCCommonFieldsModel'
                         - $ref: '#/definitions/DataVersionNullable'
                         - $ref: '#/definitions/ProductNullable'
-                        - $ref: '#/definitions/ReleaseReadOnly'
                         - $ref: '#/definitions/ReleaseDataObject'
                         - $ref: '#/definitions/ReleaseName'
                         - $ref: '#/definitions/HistoryModel'
@@ -2822,7 +2726,6 @@ paths:
                         - product
                         - name
                         - data
-                        - read_only
         '404':
           $ref: '#/responses/resourceNotFound'
         '400':
@@ -4130,6 +4033,238 @@ paths:
         '404':
           $ref: '#/responses/resourceNotFound'
 
+  /releases_readonly/{release}:
+    post:
+      summary: Set the release as readonly.
+      description: Set the release as readonly.
+      tags:
+        - Releases
+        - Release Readonly
+      operationId: auslib.web.admin.releases_readonly.post
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/releaseParam'
+      responses:
+        '201':
+          description: Successfully set the release as readonly.
+        '400':
+          $ref: '#/responses/invalidFormData'
+        '401':
+          $ref: '#/responses/unauthenticatedUser'
+        '403':
+          $ref: '#/responses/unauthorizedUser'
+    
+    delete:
+      summary: Set the release as read/write.
+      description: Set the release as read/write.
+      tags:
+        - Releases
+        - Release Readonly
+      operationId: auslib.web.admin.releases_readonly.delete
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/releaseParam'
+        - $ref: '#/parameters/csrfTokenParam'
+        - $ref: '#/parameters/dataVersionParam'
+      responses:
+        '200':
+          description: Successfully set the release as read/write.
+        '400':
+          $ref: '#/responses/invalidFormData'
+        '401':
+          $ref: '#/responses/unauthenticatedUser'
+        '403':
+          $ref: '#/responses/unauthorizedUser'
+
+  /scheduled_changes/releases_readonly:
+    get:
+      summary: Returns scheduled changes for readonly releases.
+      description: >
+        Returns scheduled changes to make a release read/write.
+      tags:
+        - Scheduled Changes
+        - Release readonly
+      operationId: auslib.web.admin.releases_readonly.scheduled_changes
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/allSCParam'
+      responses:
+        '200':
+          description: JSON object with scheduled changes for releases readonly.
+          schema:
+            type: object
+            required:
+              - scheduled_changes
+            allOf:
+              - $ref: "#/definitions/CountModel"
+              - type: object
+                properties:
+                  scheduled_changes:
+                    description: Array where each element is a scheduled change for a readonly release.
+                    type: array
+                    minItems: 0
+                    items:
+                      type: object
+                      allOf:
+                        - $ref: '#/definitions/SCSignoffsModel'
+                        - $ref: '#/definitions/ReleasesReadonlyModel'
+                        - properties:
+                            original_row:
+                              $ref: '#/definitions/ReleasesReadonlyModel'
+
+    post:
+      summary: Create scheduled change to make the release read/write.
+      description: >
+        Create scheduled change to make the release read/write.
+      tags:
+        - Scheduled Changes
+        - Release Readonly
+      operationId: auslib.web.admin.releases_readonly.schedule_release_read_write
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      externalDocs:
+        url: "http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#scheduled-changes-object"
+        description: "create scheduled change for release readonly."
+      parameters:
+        - name: sc_release_readonly
+          in: body
+          description: Request body for release readonly
+          required: true
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/definitions/CSRFModel'
+              # - $ref: '#/definitions/SCTime'
+              - $ref: '#/definitions/ReleasesReadonlyModel'
+            properties:
+              change_type:
+                description: type of change
+                type: string
+                format: ascii
+                enum:
+                  - delete
+                minLength: 1
+                maxLength: 50
+                example: update
+      responses:
+        '200':
+          description: Returns sc_id of change
+          schema:
+            $ref: '#/definitions/SCIdModel'
+        '400':
+          $ref: '#/responses/invalidFormData'
+        '401':
+          $ref: '#/responses/unauthenticatedUser'
+        '403':
+          $ref: '#/responses/unauthorizedUser'
+
+  /scheduled_changes/releases_readonly/{sc_id}:
+    delete:
+      summary: Deletes the given Scheduled Change for a Releases Readonly.
+      description: >
+        Deletes the given Scheduled Change for Releases Readonly. 'data_version' must be provided. [Docs](http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#scheduled-changes-object-sc-id)
+      tags:
+        - Scheduled Changes
+        - Release Readonly
+      operationId: auslib.web.admin.releases_readonly.delete_scheduled_release_read_write
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/sc_id_param'
+        - $ref: '#/parameters/dataVersionParam'
+        - $ref: '#/parameters/csrfTokenParam'
+      responses:
+        '200':
+          description: Successfully deleted the given scheduled change.
+        '400':
+          $ref: '#/responses/invalidFormData'
+        '401':
+          $ref: '#/responses/unauthenticatedUser'
+        '403':
+          $ref: '#/responses/unauthorizedUser'
+        '404':
+          $ref: '#/responses/resourceNotFound'
+
+  /scheduled_changes/releases_readonly/{sc_id}/enact:
+    post:
+      summary: Execute the scheduled change for the release readonly.
+      description: >
+        Execute the scheduled change for the release readonly and mark release as read/write.
+      tags:
+        - Scheduled Changes
+        - Release Readonly
+      operationId: auslib.web.admin.releases_readonly.enact_release_read_write
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/sc_id_param'
+      responses:
+        '200':
+          description: Successfully enacted the scheduled change.
+        '401':
+          $ref: '#/responses/unauthenticatedUser'
+        '403':
+          $ref: '#/responses/unauthorizedUser'
+
+  /scheduled_changes/releases_readonly/{sc_id}/signoffs:
+    post:
+      summary: Signs off on the given release readonly.
+      description: Signs off on the given release readonly.
+      tags:
+        - Scheduled Changes
+        - Release Readonly
+      operationId: auslib.web.admin.releases_readonly.scheduled_changes_signoffs
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/sc_id_param'
+        - $ref: '#/parameters/sc_signoff_post_body_param'
+      responses:
+        '200':
+          description: Successfully signed off on the given scheduled change.
+        '400':
+          $ref: '#/responses/invalidFormData'
+        '401':
+          $ref: '#/responses/unauthenticatedUser'
+        '403':
+          $ref: '#/responses/unauthorizedUser'
+
+    delete:
+      summary: Removes an existing Signoff from the release readonly Scheduled Change.
+      description: Removes an existing Signoff from the release readonly Scheduled Change.
+      tags:
+        - Scheduled Changes
+        - Release Readonly
+      operationId: auslib.web.admin.releases_readonly.scheduled_changes_signoffs_delete
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/sc_id_param'
+        - $ref: '#/parameters/usernameQueryParam'
+        - $ref: '#/parameters/csrfTokenParam'
+      responses:
+        '200':
+          description: Successfully deleted the signoff on the given scheduled change.
+        '401':
+          $ref: '#/responses/unauthenticatedUser'
+        '403':
+          $ref: '#/responses/unauthorizedUser'
+        '404':
+          $ref: '#/responses/resourceNotFound'
+
 definitions:
   CSRFModel:
     title: CSRF Token
@@ -4638,3 +4773,17 @@ definitions:
 
     #Warning: Do NOT add an example object here. Interferes with Example Value during
     # request generation in Swagger-UI
+
+  ReleasesReadonlyModel:
+    title: Release Readonly
+    description: Release to be marked as readonly
+    type: object
+    allOf:
+      - $ref: '#/definitions/DataVersionModel'
+      - type: object
+        properties:
+          release_name:
+            type: string
+            format: ascii
+    required:
+      - release_name

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -4162,7 +4162,6 @@ paths:
             type: object
             allOf:
               - $ref: '#/definitions/CSRFModel'
-              # - $ref: '#/definitions/SCTime'
               - $ref: '#/definitions/ReleasesReadonlyModel'
             properties:
               change_type:
@@ -4173,7 +4172,7 @@ paths:
                   - delete
                 minLength: 1
                 maxLength: 50
-                example: update
+                example: delete
       responses:
         '200':
           description: Returns sc_id of change

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -4034,6 +4034,25 @@ paths:
           $ref: '#/responses/resourceNotFound'
 
   /releases_readonly/{release}:
+    get:
+      summary: Get release readonly.
+      description: Get release marked as readOnly.
+      tags:
+        - Releases
+        - Release Readonly
+      operationId: auslib.web.admin.releases_readonly.get
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/releaseParam'
+      responses:
+        '200':
+          description: Release readonly with data_version.
+        '404':
+          $ref: '#/responses/invalidFormData'
+
     post:
       summary: Set the release as readonly.
       description: Set the release as readonly.

--- a/auslib/web/admin/views/base.py
+++ b/auslib/web/admin/views/base.py
@@ -122,12 +122,3 @@ class AdminView(MethodView):
     def delete(self, *args, **kwargs):
         self.log.debug("processing DELETE request to %s" % request.path)
         return self._delete(*args, **kwargs)
-
-
-def serialize_signoff_requirements(requirements):
-    dct = {}
-    for rs in requirements:
-        signoffs_required = max(dct.get(rs["role"], 0), rs["signoffs_required"])
-        dct[rs["role"]] = signoffs_required
-
-    return dct

--- a/auslib/web/admin/views/mapper.py
+++ b/auslib/web/admin/views/mapper.py
@@ -1,4 +1,5 @@
 from auslib.web.admin.views.csrf import CSRFView
+
 from auslib.web.admin.views.permissions import (
     EnactPermissionScheduledChangeView,
     PermissionScheduledChangeHistoryView,
@@ -16,7 +17,6 @@ from auslib.web.admin.views.releases import (
     ReleaseDiffView,
     ReleaseFieldView,
     ReleaseHistoryView,
-    ReleaseReadOnlyView,
     ReleasesAPIView,
     ReleaseScheduledChangeHistoryView,
     ReleaseScheduledChangeSignoffsView,
@@ -174,16 +174,6 @@ def single_release_put(release):
 def single_release_delete(release):
     """DELETE /releases/:release"""
     return SingleReleaseView().delete(release)
-
-
-def release_read_only_get(release):
-    """GET /releases/:release/read_only"""
-    return ReleaseReadOnlyView().get(release)
-
-
-def release_read_only_put(release):
-    """PUT /releases/:release/read_only"""
-    return ReleaseReadOnlyView().put(release)
 
 
 def release_single_column_get(column):

--- a/auslib/web/admin/views/releases.py
+++ b/auslib/web/admin/views/releases.py
@@ -8,7 +8,8 @@ from sqlalchemy.sql.expression import null
 from auslib.blobs.base import BlobValidationError, createBlob
 from auslib.db import OutdatedDataError, ReadOnlyError
 from auslib.global_state import dbo
-from auslib.web.admin.views.base import AdminView, requirelogin, serialize_signoff_requirements
+from auslib.util.signoffs import serialize_signoff_requirements
+from auslib.web.admin.views.base import AdminView, requirelogin
 from auslib.web.admin.views.history import HistoryView
 from auslib.web.admin.views.problem import problem
 from auslib.web.admin.views.scheduled_changes import (

--- a/auslib/web/admin/views/scheduled_changes.py
+++ b/auslib/web/admin/views/scheduled_changes.py
@@ -2,7 +2,8 @@ import connexion
 from flask import jsonify
 from sqlalchemy.sql.expression import null
 
-from auslib.web.admin.views.base import AdminView, requirelogin, serialize_signoff_requirements
+from auslib.util.signoffs import serialize_signoff_requirements
+from auslib.web.admin.views.base import AdminView, requirelogin
 from auslib.web.admin.views.history import HistoryView
 from auslib.web.admin.views.problem import problem
 from auslib.web.admin.views.validators import is_when_present_and_in_past_validator

--- a/auslib/web/common/swagger/definitions.yml
+++ b/auslib/web/common/swagger/definitions.yml
@@ -123,16 +123,6 @@ definitions:
         maxLength: 100
         example: "Firefox-47.0.2-build2-43.0.1"
 
-  ReleaseReadOnly:
-    title: Release Read Only
-    description: "Release's read_only flag field marks whether release can only be read and not modified"
-    type: object
-    properties:
-      read_only:
-        type: ["boolean", "null"]
-        example: true
-        description: "flag value is true if release is marked as read_only else release is modifiable"
-
   ReleaseGET:
     title: Release form values plus read only and rule ids
     description: "Release Base Model + read only + list of mapped rule_ids"
@@ -141,7 +131,6 @@ definitions:
       - $ref: '#/definitions/DataVersionModel'
       - $ref: '#/definitions/ProductModel'
       - $ref: '#/definitions/ReleaseName'
-      - $ref: '#/definitions/ReleaseReadOnly'
       - type: object
         properties:
           rule_ids:
@@ -157,7 +146,6 @@ definitions:
       - name
       - product
       - data_version
-      - read_only
       - rule_ids
 
   UpdateType:

--- a/auslib/web/public/swagger/public_api_spec.yml
+++ b/auslib/web/public/swagger/public_api_spec.yml
@@ -58,7 +58,6 @@ paths:
                 - data_version: 2
                   name: XP-Vista-Desupport
                   product: Firefox
-                  read_only: false
                   rule_ids: [468, 498]
 
   /api/v1/releases/{release}:
@@ -126,11 +125,6 @@ paths:
                         - $ref: '#/definitions/ReleaseName'
                         - type: object
                           properties:
-                            read_only:
-                              description: Flag that indicates whether release is marked read_only or not.
-                              type: string
-                              enum: [ "True", "False"]
-                              example: "True"
                             _different:
                               description: list of columns that were modified in revision
                               type: array
@@ -149,7 +143,6 @@ paths:
                         - name
                         - product
                         - data_version
-                        - read_only
                         - _different
                         - _time_ago
         '400':

--- a/ui/app/js/controllers/release_read_only_controller.js
+++ b/ui/app/js/controllers/release_read_only_controller.js
@@ -1,36 +1,72 @@
 angular.module('app').controller('ReleaseReadOnlyCtrl',
-function ($scope, $modalInstance, CSRF, Releases, release) {
-
-  $scope.release = release;
+function ($scope, $modalInstance, CSRF, ReleasesReadonly, release) {
+  $scope.loading = true;
+  $scope.failed = false;
   $scope.saving = false;
+  $scope.release = release;
+
+  if(release.read_only) {
+    ReleasesReadonly.getReleaseReadonly(release.name)
+      .then(function(response) {
+        $scope.release_readonly = response.data;
+      })
+      .finally(function () {
+        $scope.loading = false;
+      });
+  }
+
+  $scope.makeReadonly = function(csrf_token) {
+    ReleasesReadonly.makeReadonly($scope.release.name, csrf_token)
+      .success(function() {
+        sweetAlert(
+          'Release', 'Release was set to readonly successfully!', 'success');
+
+        $scope.release.read_only = true;
+        $modalInstance.close();
+      })
+      .error($scope.responseError)
+      .finally($scope.operationComplete);
+  };
+
+  $scope.makeReadWrite = function(csrf_token) {
+    ReleasesReadonly.makeReadWrite(
+        $scope.release_readonly.release_name, $scope.release_readonly.data_version, csrf_token)
+      .success(function() {
+        sweetAlert(
+          'Release', 'Release was set to modifiable successfully!', 'success');
+        
+        $scope.release.read_only = false;
+        $modalInstance.close();
+      })
+      .error($scope.responseError)
+      .finally($scope.operationComplete);
+  };
+
+  $scope.responseError = function(response) {
+    if (typeof response === 'object') {
+      $scope.errors = response;
+      sweetAlert(
+        'Form submission error',
+        'See fields highlighted in red.',
+        'error'
+      );
+    }
+  };
+
+  $scope.operationComplete = function () {
+    $scope.saving = false;
+  };
 
   $scope.saveChanges = function () {
     $scope.saving = true;
-    var data = $scope.release;
-    data.read_only = release.read_only ? "" : true;
 
     CSRF.getToken()
-    .then(function(csrf_token) {
-      Releases.changeReadOnly($scope.release.name, data, csrf_token)
-      .success(function(response) {
-        $scope.release.data_version = response.new_data_version;
-        $scope.release.read_only = data.read_only;
-        $scope.saving = false;
-        $modalInstance.close();
-      })
-      .error(function(response) {
-        if (typeof response === 'object') {
-          $scope.errors = response;
-          sweetAlert(
-            "Form submission error",
-            "See fields highlighted in red.",
-            "error"
-          );
+      .then(function(csrf_token) {
+        if($scope.release.read_only) {
+          $scope.makeReadWrite(csrf_token);
+        } else {
+          $scope.makeReadonly(csrf_token);
         }
-      })
-      .finally(function() {
-        $scope.saving = false;
-      });
     });
   };
 

--- a/ui/app/js/controllers/release_scheduled_change_delete_controller.js
+++ b/ui/app/js/controllers/release_scheduled_change_delete_controller.js
@@ -1,7 +1,8 @@
 angular.module("app").controller("DeleteReleaseScheduledChangeCtrl",
-function ($scope, $modalInstance, CSRF, Releases, sc, scheduled_changes) {
+function ($scope, $modalInstance, CSRF, service, object_name, sc, scheduled_changes) {
 
   $scope.sc = sc;
+  $scope.object_name = object_name;
   $scope.scheduled_changes = scheduled_changes;
   $scope.saving = false;
   $scope.formatMoment = formatMoment;
@@ -10,7 +11,7 @@ function ($scope, $modalInstance, CSRF, Releases, sc, scheduled_changes) {
     $scope.saving = true;
     CSRF.getToken()
     .then(function(csrf_token) {
-      Releases.deleteScheduledChange($scope.sc.sc_id, $scope.sc, csrf_token)
+      service.deleteScheduledChange($scope.sc.sc_id, $scope.sc, csrf_token)
       .success(function(response) {
         $scope.scheduled_changes.splice($scope.scheduled_changes.indexOf($scope.sc), 1);
         $modalInstance.close();

--- a/ui/app/js/controllers/release_scheduled_changes_controller.js
+++ b/ui/app/js/controllers/release_scheduled_changes_controller.js
@@ -81,7 +81,7 @@ function($scope, $routeParams, $location, $timeout, Search, $modal, $route, Rele
 
   function mergeScheduledChangesReleaseReadonly(releaseReadonlySC) {
     if(!$scope.scheduled_changes) {
-      $scope.scheduled_changes = []
+      $scope.scheduled_changes = [];
     }
     releaseReadonlySC.isReadonlyStateChange = true;
     $scope.scheduled_changes.push(releaseReadonlySC);
@@ -122,7 +122,7 @@ function($scope, $routeParams, $location, $timeout, Search, $modal, $route, Rele
                       sc.product = releases[0].product;
                     }                    
                   }, handleLoadingError);
-              })
+              });
           }, handleLoadingError)
           .then(function() {
             $scope.scheduled_changes.forEach(function(sc) {
@@ -132,7 +132,7 @@ function($scope, $routeParams, $location, $timeout, Search, $modal, $route, Rele
                 } else {
                   return this.name;
                 }
-              }
+              };
             });
           });
       })
@@ -227,10 +227,10 @@ function($scope, $routeParams, $location, $timeout, Search, $modal, $route, Rele
       backdrop: "static",
       resolve: {
         object_name: function() {
-          return "Release";
+          return sc.isReadonlyStateChange ? "ReleasesReadonly" : "Release";
         },
         service: function() {
-          return Releases;
+          return sc.isReadonlyStateChange ? ReleasesReadonly : Releases;
         },
         current_user: function() {
           return $scope.current_user;
@@ -245,7 +245,7 @@ function($scope, $routeParams, $location, $timeout, Search, $modal, $route, Rele
           return sc;
         },
         pk: function() {
-          return {"name": sc["name"]};
+          return {"name": sc.getName()};
         },
         // todo: add more stuff here
         data: function() {
@@ -264,10 +264,10 @@ function($scope, $routeParams, $location, $timeout, Search, $modal, $route, Rele
       backdrop: "static",
       resolve: {
         object_name: function() {
-          return "Release";
+          return sc.isReadonlyStateChange ? "ReleasesReadonly" : "Release";
         },
         service: function() {
-          return Releases;
+          return sc.isReadonlyStateChange ? ReleasesReadonly : Releases;
         },
         current_user: function() {
           return $scope.current_user;
@@ -276,7 +276,7 @@ function($scope, $routeParams, $location, $timeout, Search, $modal, $route, Rele
           return sc;
         },
         pk: function() {
-          return {"name": sc["name"]};
+          return {"name": sc.getName()};
         },
         data: function() {
           return {
@@ -310,6 +310,12 @@ function($scope, $routeParams, $location, $timeout, Search, $modal, $route, Rele
       resolve: {
         sc: function() {
           return sc;
+        },
+        object_name: function() {
+          return sc.isReadonlyStateChange ? "ReleasesReadonly" : "Release";
+        },
+        service: function() {
+          return sc.isReadonlyStateChange ? ReleasesReadonly : Releases;
         },
         scheduled_changes: function() {
           return $scope.scheduled_changes;

--- a/ui/app/js/services/releases_readonly_service.js
+++ b/ui/app/js/services/releases_readonly_service.js
@@ -20,6 +20,18 @@ angular.module('app').factory('ReleasesReadonly', function($http, ScheduledChang
             };
             return $http.delete('/api/releases_readonly/' + encodeURIComponent(release_name), config);
         },
+        
+        scheduleReadWriteReleaseChange: function(release_readonly, csrf_token) {
+            when = new Date();
+            when.setSeconds(when.getSeconds() + 10);
+
+            data = angular.copy(release_readonly);
+            data.change_type = 'delete';
+            data.csrf_token = csrf_token;
+            data.when = when.getTime();
+
+            return $http.post('/api/scheduled_changes/releases_readonly', data);
+        },
 
         signoff: function(sc_id, csrf_token) {
 

--- a/ui/app/js/services/releases_readonly_service.js
+++ b/ui/app/js/services/releases_readonly_service.js
@@ -1,15 +1,24 @@
 angular.module('app').factory('ReleasesReadonly', function($http, ScheduledChanges) {
     var services = {
-        getReleasesReadonly: function() {
-
+        getReleaseReadonly: function(release_name) {
+            return $http.get('/api/releases_readonly/' + encodeURIComponent(release_name));
         },
 
-        makeReadonly: function(releaseReadonly, csrf_token) {
-
+        makeReadonly: function(release_name, csrf_token) {
+            data = {
+                csrf_token: csrf_token
+            };
+            return $http.post('/api/releases_readonly/' + encodeURIComponent(release_name), data);
         },
 
-        makeReadWrite: function(releaseReadonly, csrf_token) {
-
+        makeReadWrite: function(release_name, data_version, csrf_token) {
+            config = {
+                params: {
+                    data_version: data_version,
+                    csrf_token: csrf_token
+                }
+            };
+            return $http.delete('/api/releases_readonly/' + encodeURIComponent(release_name), config);
         },
 
         signoff: function(sc_id, csrf_token) {

--- a/ui/app/js/services/releases_readonly_service.js
+++ b/ui/app/js/services/releases_readonly_service.js
@@ -22,13 +22,9 @@ angular.module('app').factory('ReleasesReadonly', function($http, ScheduledChang
         },
         
         scheduleReadWriteReleaseChange: function(release_readonly, csrf_token) {
-            when = new Date();
-            when.setSeconds(when.getSeconds() + 10);
-
             data = angular.copy(release_readonly);
             data.change_type = 'delete';
             data.csrf_token = csrf_token;
-            data.when = when.getTime();
 
             return $http.post('/api/scheduled_changes/releases_readonly', data);
         },

--- a/ui/app/js/services/releases_readonly_service.js
+++ b/ui/app/js/services/releases_readonly_service.js
@@ -33,6 +33,10 @@ angular.module('app').factory('ReleasesReadonly', function($http, ScheduledChang
             return $http.post('/api/scheduled_changes/releases_readonly', data);
         },
 
+        scheduledChanges: function() {
+            return $http.get('/api/scheduled_changes/releases_readonly');
+        },
+
         signoff: function(sc_id, csrf_token) {
 
         },

--- a/ui/app/js/services/releases_readonly_service.js
+++ b/ui/app/js/services/releases_readonly_service.js
@@ -1,0 +1,25 @@
+angular.module('app').factory('ReleasesReadonly', function($http, ScheduledChanges) {
+    var services = {
+        getReleasesReadonly: function() {
+
+        },
+
+        makeReadonly: function(releaseReadonly, csrf_token) {
+
+        },
+
+        makeReadWrite: function(releaseReadonly, csrf_token) {
+
+        },
+
+        signoff: function(sc_id, csrf_token) {
+
+        },
+
+        revokeSignoff: function(sc_id, csrf_token) {
+
+        }
+    };
+
+    return services;
+});

--- a/ui/app/js/services/releases_readonly_service.js
+++ b/ui/app/js/services/releases_readonly_service.js
@@ -37,12 +37,22 @@ angular.module('app').factory('ReleasesReadonly', function($http, ScheduledChang
             return $http.get('/api/scheduled_changes/releases_readonly');
         },
 
-        signoff: function(sc_id, csrf_token) {
-
+        deleteScheduledChange: function(sc_id, data, csrf_token) {
+            var url = "/api/scheduled_changes/releases_readonly/" + sc_id;
+            url += '?data_version=' + data.sc_data_version;
+            url += '&csrf_token=' + encodeURIComponent(csrf_token);
+            return $http.delete(url);
         },
 
-        revokeSignoff: function(sc_id, csrf_token) {
+        signoffOnScheduledChange: function(sc_id, data) {
+            var url = ScheduledChanges.signoffsUrl("releases_readonly", sc_id);
+            return $http.post(url, data);
+        },
 
+        revokeSignoffOnScheduledChange: function(sc_id, data) {
+            var url = ScheduledChanges.signoffsUrl("releases_readonly", sc_id);
+            url += "?csrf_token=" + encodeURIComponent(data["csrf_token"]);
+            return $http.delete(url, data);
         }
     };
 

--- a/ui/app/js/services/releases_service.js
+++ b/ui/app/js/services/releases_service.js
@@ -15,6 +15,10 @@ angular.module("app").factory('Releases', function($http, $q, ScheduledChanges, 
     getReleases: function() {
       return $http.get('/api/releases');
     },
+    getReleasesByName: function(namePrefix) {
+      url = '/api/releases?name_prefix=' + encodeURIComponent(namePrefix);
+      return $http.get(url);
+    },
     getProducts: function(){
       return $http.get('/api/releases/columns/product');
     },

--- a/ui/app/templates/release_read_only_modal.html
+++ b/ui/app/templates/release_read_only_modal.html
@@ -12,12 +12,16 @@
   </dl>
 
 </div>
-<div class="form-group" ng-class="{'has-error': errors.detail}">
+<div class="form-group" style="margin: 10px;" ng-class="{'has-error': errors.detail}">
     <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
 </div>
-<div class="form-group" ng-class="{'has-error': errors.exception}">
+<div class="form-group" style="margin: 10px;" ng-class="{'has-error': errors.exception}">
     <p class="help-block" ng-show="errors.exception">{{ errors.exception }}</p>
 </div>
+
+<show-signoff-requirements style="margin: 10px;" ng-if="changeRequiresSignoffs()" requirements="release_readonly.required_signoffs"></show-signoff-requirements>
+
+
 <div class="modal-footer">
   <div ng-show="saving" small-loader></div>
   <button class="btn btn-primary" ng-show="!saving" ng-click="saveChanges()">Yes</button>

--- a/ui/app/templates/release_scheduled_change_delete_modal.html
+++ b/ui/app/templates/release_scheduled_change_delete_modal.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-    <h3 class="modal-title">Are you sure you want to delete this release?</h3>
+    <h3 class="modal-title">Are you sure you want to delete this {{object_name}} ?</h3>
 </div>
 <div class="modal-body">
 
@@ -9,7 +9,7 @@
     <dt>Product:</dt>
     <dd>{{ sc.product }}</dd>
     <dt>Name:</dt>
-    <dd>{{ sc.name }}</dd>
+    <dd>{{ sc.getName() }}</dd>
   </dl>
 
 </div>

--- a/ui/app/templates/release_scheduled_changes.html
+++ b/ui/app/templates/release_scheduled_changes.html
@@ -61,15 +61,16 @@
             Revoke your Signoff
           </button>
         </span>
-        <button class="btn btn-default btn-xs" ng-click="openDataModal(sc)">View Data</button>
+        <button class="btn btn-default btn-xs" ng-show="!sc.isReadonlyStateChange" ng-click="openDataModal(sc)">View Data</button>
         <span ng-show="auth0.isAuthenticated()">
-          <button ng-show="!scheduled_changes_count && !sc.complete" class="btn btn-default btn-xs" ng-click="openUpdateModal(sc)">Update</button>
+          <button ng-show="!scheduled_changes_count && !sc.complete && !sc.isReadonlyStateChange" class="btn btn-default btn-xs" ng-click="openUpdateModal(sc)">Update</button>
           <button ng-show="!scheduled_changes_count && !sc.complete" class="btn btn-default btn-xs" ng-click="openDeleteModal(sc)">Delete</button>
         </span>
-        <a ng-show="!scheduled_changes_count" class="btn btn-default btn-xs" ng-href="/scheduled_changes/releases/{{ sc.sc_id }}">History</a>
+        <a ng-show="!scheduled_changes_count && !sc.isReadonlyStateChange" class="btn btn-default btn-xs" ng-href="/scheduled_changes/releases/{{ sc.sc_id }}">History</a>
       </div>
 
-      <i title="Product" ng-show="sc.name">{{ sc.name }}</i>
+      <i title="Product" ng-show="sc.getName()">{{ sc.getName() }}</i>
+      <strong ng-show="sc.isReadonlyStateChange"><i>[Changing the release state to read/write]</i></strong>
     </h3>
   </div>
   <div class="panel-body">


### PR DESCRIPTION
@nthomas-mozilla, @mozbhearsum,
I finished the initial changes to the database for bug 1492603. I opened the PR in WIP state to validate my first approach:

- I moved the release `read_only` information to another table, the main reason was to isolate all the scheduled changes and the required signoff flows in a single domain for readonly information, leaving the release `update` flow untouched.

- The `releases_readonly` (and related tables) was introduced. In this way, inserting an entry means the release is readonly. By removing the entry, the release turns modifiable.

- This allows user accounts to hold only the necessary permissons to set a release as readonly.

- For products that require signoffs, scheduling an ASAP change, to delete a row from `releases_readonly` table is enough to set release as modifiable.

What do you think?