### PR TITLE
Revert upgrade to Python 3.7 because it broke docker image build.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -74,7 +74,7 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && bash run-tests.sh backend py37"
+        - "git clone $GITHUB_HEAD_REPO_URL balrog && cd balrog && git checkout $GITHUB_HEAD_BRANCH && bash run-tests.sh backend py36"
       features:
         dind: true
         taskclusterProxy: true
@@ -89,7 +89,7 @@ tasks:
         branches:
           - master
     metadata:
-      name: Balrog Python 3.7 back-end tests
+      name: Balrog Python 3.6 back-end tests
       description: Balrog Python tests
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -1,13 +1,13 @@
-FROM python:3.7-slim-stretch
+FROM python:3.6-slim-jessie
 
 MAINTAINER bhearsum@mozilla.com
 
-# Some versions of the python:3.7 Docker image remove libpcre3, which uwsgi needs for routing support to be enabled.
+# Some versions of the python:3.6 Docker image remove libpcre3, which uwsgi needs for routing support to be enabled.
 # Node and npm are to build the frontend. nodejs-legacy is needed by this version of npm. These will get removed after building.
-# default-libmysqlclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
+# libmysqlclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
 # xz-utils is needed to compress production database dumps
 RUN apt-get -q update \
-    && apt-get -q --yes install libpcre3 libpcre3-dev default-libmysqlclient-dev mysql-client xz-utils \
+    && apt-get -q --yes install libpcre3 libpcre3-dev libmysqlclient-dev mysql-client xz-utils \
     && apt-get clean
 
 WORKDIR /app

--- a/Dockerfile.py3.dev
+++ b/Dockerfile.py3.dev
@@ -1,12 +1,12 @@
-FROM python:3.7-slim-stretch
+FROM python:3.6-slim-jessie
 
 MAINTAINER bhearsum@mozilla.com
 
-# Some versions of the python:3.7 Docker image remove libpcre3, which uwsgi needs for routing support to be enabled.
+# Some versions of the python:3.6 Docker image remove libpcre3, which uwsgi needs for routing support to be enabled.
 # mysql-client is needed to import sample data
-# default-libmysqlclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
+# libmysqlclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
 RUN apt-get -q update \
-    && apt-get -q --yes install netcat libpcre3 libpcre3-dev nodejs nodejs-legacy default-libmysqlclient-dev mysql-client curl gcc xz-utils \
+    && apt-get -q --yes install netcat libpcre3 libpcre3-dev nodejs nodejs-legacy libmysqlclient-dev mysql-client curl gcc xz-utils \
     && apt-get clean
 
 WORKDIR /app

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-stretch
+FROM python:3.6-slim
 
 MAINTAINER bhearsum@mozilla.com
 

--- a/agent/tox.ini
+++ b/agent/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py36
 
 [testenv]
 # ignore_errors makes sure all commands get run, which means this won't abort if flake8 fails.

--- a/client/Dockerfile.dev
+++ b/client/Dockerfile.dev
@@ -1,10 +1,9 @@
-FROM python:3.7-stretch
+
+FROM mozillareleases/python-test-runner
 
 WORKDIR /app
-
-RUN apt-get update
-RUN apt-get -y install tox
 
 COPY balrogclient/ /app/balrogclient/
 COPY setup.py /app/
 COPY tox.ini /app/
+

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py37
+envlist = py27,py35
 
 [base]
 deps =
@@ -22,11 +22,13 @@ commands =
 basepython = python2.7
 deps =
     {[base]deps}
+    
 
-[testenv:py37]
-basepython = python3.7
+[testenv:py35]
+basepython = python3.5
 deps =
     {[base]deps}
+
 
 [testenv:py27-coveralls]
 basepython = python2.7
@@ -35,8 +37,8 @@ deps=
 commands=
     coveralls
 
-[testenv:py37-coveralls]
-basepython = python3.7
+[testenv:py35-coveralls]
+basepython = python3.5
 deps=
     python-coveralls==2.4.3
 commands=

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -6,7 +6,7 @@ PYTHON_VERSION=${2:-py27}
 if [[ $PYTHON_VERSION == "py27" ]];
 then
     docker build  -t balrogtest -f Dockerfile.dev .
-elif [[ $PYTHON_VERSION == "py37" ]];
+elif [[ $PYTHON_VERSION == "py36" ]];
 then
     docker build  -t balrogtest -f Dockerfile.py3.dev .
 else

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py37
+envlist = py27, py36
 
 [testenv]
 # ignore_errors makes sure all commands get run, which means this won't abort if flake8 fails.
@@ -10,7 +10,7 @@ setenv =
 deps = -rrequirements-test.txt
 commands=
     flake8 auslib scripts uwsgi
-    py37: py.test -n auto --no-cov {posargs:auslib}
+    py36: py.test -n auto --no-cov {posargs:auslib}
     py27: py.test -n auto --cov --doctest-modules {posargs:auslib}
     py27: coverage run -a scripts/test-rules.py
 


### PR DESCRIPTION
This is a backout of #867, which broke Python 3.7 image building on master, most likely due to the Debian version upgrade:
```
Step 12 : RUN cd ui &&     apt-get -q --yes install nodejs nodejs-legacy npm &&     npm install &&     npm run build &&     apt-get -q --yes remove nodejs nodejs-legacy npm &&     apt-get -q --yes autoremove &&     apt-get clean &&     rm -rf /root/.npm /tmp/phantomjs &&     find . -maxdepth 1 -not -name dist -exec rm -rf {} \;
 ---> Running in 671c14e0e5d9
Reading package lists...
Building dependency tree...
Reading state information...
[91mE[0m[91m: Unable to locate package npm
[0m[34mINFO[0m[0154] The command [/bin/sh -c cd ui &&     apt-get -q --yes install nodejs nodejs-legacy npm &&     npm install &&     npm run build &&     apt-get -q --yes remove nodejs nodejs-legacy npm &&     apt-get -q --yes autoremove &&     apt-get clean &&     rm -rf /root/.npm /tmp/phantomjs &&     find . -maxdepth 1 -not -name dist -exec rm -rf {} \;] returned a non-zero code: 100 
```

Full log at https://taskcluster-artifacts.net/DGBVItXLRweoUxlCSbZzzw/0/public/logs/live_backing.log