### PR TITLE
bug 1512174: Logging: requestid field is None when traceback occurs

### DIFF
--- a/auslib/log.py
+++ b/auslib/log.py
@@ -30,7 +30,7 @@ class BalrogLogger(logging.Logger):
                 # Sometimes requests that happen around the same time will
                 # end up with the same value here. Possibly only when the
                 # query strings are the same, or srcip?
-                requestid = id(request._get_current_object())
+                requestid = str(id(request._get_current_object()))
             # RuntimeError will be raised if there's no active request.
             except RuntimeError:
                 pass


### PR DESCRIPTION
This should fix the issue that @oremj has been seeing when requestid is 'None'. An alternative here would be to set it to 0 or -1 (or some other int/float) as a default -- I'm happy either way.