### PR TITLE
Add button to show access token, and an easy way to copy it.

### DIFF
--- a/ui/app/js/controllers/parent_controller.js
+++ b/ui/app/js/controllers/parent_controller.js
@@ -57,7 +57,9 @@ function($scope, $window, $location, $http, Page, Auth0) {
     // humanizeDate turns it into something more understandable for humans
     var expiresAt = localStorage.getItem("expiresAt");
     var accessToken = localStorage.getItem("accessToken");
-    var validUntil = humanizeDate(moment(parseInt(expiresAt)));
+    // Calculate how much longer the token is valid for, in minutes
+    var validUntilMinutes = parseInt((moment(parseInt(expiresAt)) - moment()) / 1000 / 60);
+    var validUntilTime = moment(parseInt(expiresAt)).format("HH:mm");
     // This is also a kindof ridiculous chain of elements. SweetAlert only allows
     // one element in the content, so we need to create a single root element that contains
     // all the things we need in it. In our case, an <input> and <button> that shows/copies
@@ -85,7 +87,7 @@ function($scope, $window, $location, $http, Page, Auth0) {
     div.append(input);
     div.append(span);
     sweetAlert({
-      title: "Your access token is valid until " + validUntil,
+      title: "Your access token is valid for " + validUntilMinutes + " minutes, expiring at " + validUntilTime + ".",
       content: {
         element: div,
       },

--- a/ui/app/js/controllers/parent_controller.js
+++ b/ui/app/js/controllers/parent_controller.js
@@ -50,6 +50,48 @@ function($scope, $window, $location, $http, Page, Auth0) {
   $scope.formatMoment = formatMoment;
   $scope.auth0 = Auth0;
   $scope.loc = $location;
+  $scope.showAccessToken = function() {
+    // This is a seemingly ridiculous chain of calls just to get a human readable date.
+    // We need the moment(parseInt(...)) because Javascript's Date object won't parse
+    // unix time as best I can tell, and moment won't take unix time in string form.
+    // humanizeDate turns it into something more understandable for humans
+    var expiresAt = localStorage.getItem("expiresAt");
+    var accessToken = localStorage.getItem("accessToken");
+    var validUntil = humanizeDate(moment(parseInt(expiresAt)));
+    // This is also a kindof ridiculous chain of elements. SweetAlert only allows
+    // one element in the content, so we need to create a single root element that contains
+    // all the things we need in it. In our case, an <input> and <button> that shows/copies
+    // the accessToken to the clipboard.
+    var div = document.createElement("div");
+    var input = document.createElement("input");
+    var span = document.createElement("span");
+    var button = document.createElement("button");
+    var glyphicon = document.createElement("i");
+    div.className = "input-group";
+    input.className = "form-control";
+    input.type = "text";
+    input.value = accessToken;
+    span.className = "input-group-btn";
+    button.className = "btn";
+    button.type = "button";
+    button.title = "Copy to Clipboard";
+    button.onclick = function() {
+      input.select();
+      navigator.clipboard.writeText(accessToken);
+    };
+    glyphicon.className = "glyphicon glyphicon-share";
+    button.append(glyphicon);
+    span.append(button);
+    div.append(input);
+    div.append(span);
+    sweetAlert({
+      title: "Your access token is valid until " + validUntil,
+      content: {
+        element: div,
+      },
+      icon: "info",
+    });
+  };
   function updateHttpDefaults() {
     $http.defaults.headers.common["Authorization"] = "Bearer " + localStorage.getItem("accessToken");
   }

--- a/ui/app/pages/index.us
+++ b/ui/app/pages/index.us
@@ -59,6 +59,7 @@
               -->
               <img style="height: 50px" ng-show="auth0.isAuthenticated()" ng-src="{{ auth0.getPicture() }}"></img><span ng-show="auth0.isAuthenticated()" class="caret"></span>
               <ul class="dropdown-menu dropdown-menu-right">
+                  <li><a ng-click="showAccessToken()">Show Access Token</a></li>
                   <li><a ng-click="auth0.logout()">Sign out</a></li>
               </ul>
             </li>


### PR DESCRIPTION
While @rehandalal was testing Auth0 in Stage it came up that there are some scripts that he and @mythmon run on their laptops to make changes to SystemAddons. @gdestuynder suggested using https://auth0.com/docs/api-auth/tutorials/authorization-code-grant-pkce to support this use case, but I'm not certain that's going to work for our use case (I looked into it, and couldn't see how it would).

In the short term at least, adding an easy way to copy one's access token should be OK, which is what this PR does.