### PR TITLE
Insert a few permissions, roles, and required signoffs into the database to provide better sample data

### DIFF
--- a/scripts/initdb_and_run.sh
+++ b/scripts/initdb_and_run.sh
@@ -8,6 +8,11 @@ if [ ! -e /app/$CACHEDIR/mysql/db.done ]; then
 
     xz -d -c $LOCAL_DUMP | mysql -h $DB_HOST -u balrogadmin --password=balrogadmin balrog
     mysql -h $DB_HOST -u balrogadmin --password=balrogadmin -e 'insert into permissions (username, permission, options, data_version) values ("balrogagent", "scheduled_change", "{\"actions\": [\"enact\"]}", 1)' balrog
+    mysql -h $DB_HOST -u balrogadmin --password=balrogadmin -e 'insert into permissions (username, permission, options, data_version) values ("bob@mozilla.com", "release", "{\"actions\": [\"get\"]}", 1)' balrog
+    mysql -h $DB_HOST -u balrogadmin --password=balrogadmin -e 'insert into permissions (username, permission, options, data_version) values ("janet@mozilla.com", "release", "{\"actions\": [\"get\"]}", 1)' balrog
+    mysql -h $DB_HOST -u balrogadmin --password=balrogadmin -e 'insert into user_roles (username, role, data_version) values ("bob@mozilla.com", "releng", 1);' balrog
+    mysql -h $DB_HOST -u balrogadmin --password=balrogadmin -e 'insert into user_roles (username, role, data_version) values ("janet@mozilla.com", "releng", 1);' balrog
+    mysql -h $DB_HOST -u balrogadmin --password=balrogadmin -e 'insert into product_req_signoffs (product, channel, role, signoffs_required, data_version) values ("Firefox", "release", "releng", 1, 1);' balrog
     touch /app/$CACHEDIR/mysql/db.done
     echo "Done"
 


### PR DESCRIPTION
@helfi92 requested this when doing some early work on the new Balrog UI, I don't think there's any harm in having these? The two permissions aren't ever going to be used, since nobody can log in as those users (presumably), but they're useful for testing UI around permissions.