### PR TITLE
bug 1501167: Print extra information about successful merges in certain conditions.

### DIFF
--- a/auslib/blobs/base.py
+++ b/auslib/blobs/base.py
@@ -78,9 +78,17 @@ def merge_dicts(ancestor, left, right):
      * A type mismatch of unicode vs string is OK as long as the text is the same
        (Any other type mismatches result in a failure to merge.)
     """
+    # We can't use "logging" directly, because it ignores our custom code in log.py
+    log = logging.getLogger(__name__)
     result = {}
     dicts = (ancestor, left, right)
     for key in set(key for d in dicts for key in d.keys()):
+        # Extra logging information to help debug https://bugzilla.mozilla.org/show_bug.cgi?id=1501167
+        # This is a very large message, so we limit it as much as possible to reduce spam.
+        if key == "completes" and ancestor.get("appVersion") and "a1" not in ancestor["appVersion"]:
+            log.warning("Ancestor is: %s", ancestor.get(key))
+            log.warning("Left is: %s", left.get(key))
+            log.warning("Right is: %s", right.get(key))
         key_types = set([type(d.get(key)) for d in dicts])
         key_types.discard(type(None))
         encoded_str_key = str(text_type(key.encode('ascii', 'replace'), 'utf-8'))

--- a/auslib/db.py
+++ b/auslib/db.py
@@ -2013,6 +2013,10 @@ class Releases(AUSTable):
                     try:
                         what['data'] = createBlob(merge_dicts(ancestor_blob, tip_blob, blob))
                         self.log.warning("Successfully merged release %s at data_version %s with the latest version.", name, old_data_version)
+                        # ancestor_change is checked for None a few lines up
+                        self.log.warning("ancestor_change is change_id %s, data_version %s",
+                                         ancestor_change.get("change_id"), ancestor_change.get("data_version"))
+                        self.log.warning("tip release is data_version %s", tip_release.get("data_version"))
                     except ValueError:
                         self.log.exception("Couldn't merge release %s at data_version %s with the latest version.", name, old_data_version)
                         # ancestor_change is checked for None a few lines up


### PR DESCRIPTION
This adds some extra logging messages during merges under very specific conditions. I expect this will cause some log spam with every release, but I think it will be helpful in debugging https://bugzilla.mozilla.org/show_bug.cgi?id=1501167 the next time it happens.

We could also consider limiting by product (ie: to exclude Thunderbird and Devedition) to further limit the spam.