### PR TITLE
Small doc updates.

### DIFF
--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -32,12 +32,7 @@ By creating a fork, you are able to generate a *pull request* so that the change
 Usage
 -----
 
-If you have access to it, set up the machine token for the Agent. If you don't have access to it, just skip this step. The Agent will not function, but everything else will work.
-
-::
-    $ export AUTH0_M2M_CLIENT_SECRET=abcdef123456
-
-Now, run the following command to create and run the necessary images:
+Run the following command to create and run the necessary images:
 
 ::
 

--- a/docs/source/withoutdocker.rst
+++ b/docs/source/withoutdocker.rst
@@ -14,6 +14,7 @@ To initialize a new Balrog database, run the following:
 ::
 
     docker run --entrypoint python mozilla/balrog /app/scripts/manage-db.py -d DBURI create
+    docker run -e "DBURI=<database uri>" -e "LOCAL_ADMIN=<email address of initial admin>" mozilla/balrog create-local-admin
 
 Similarly, to upgrade the schema of an existing Balrog database, run the following:
 


### PR DESCRIPTION
Small doc updates after the Auth0 work. This should address your comment about `withoutdocker.rst', as well as removing the now-unnecessary comment about the M2M token for the Agent.