### PR TITLE
balrogclient: Don't send data unless it's not None

### DIFF
--- a/client/balrogclient/api.py
+++ b/client/balrogclient/api.py
@@ -162,7 +162,12 @@ class API(object):
         before = time.time()
         access_token = _get_auth0_token(self.auth0_secrets)
         auth = BearerAuth(access_token)
-        req = self.session.request(method=method, url=url, data=json.dumps(data), timeout=self.timeout, verify=self.verify, auth=auth, headers=headers)
+        # Don't dump data to json unless it actually exists. Otherwise we end up with a string of
+        # 'None', which is not intended, and is not actually supported by some servers for HEAD/GET
+        # requests.
+        if data:
+            data = json.dumps(data)
+        req = self.session.request(method=method, url=url, data=data, timeout=self.timeout, verify=self.verify, auth=auth, headers=headers)
         try:
             if self.raise_exceptions:
                 req.raise_for_status()

--- a/client/setup.py
+++ b/client/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="balrogclient",
-    version="0.2.0",
+    version="0.3.0",
     description="Balrog Admin API Client",
     author="Mozilla Release Engineers",
     author_email="release+python@mozilla.com",


### PR DESCRIPTION
I found this bug while testing the new GCP instance. Google throws a mysterious error if you pass a request body with GETs.