### PR TITLE
Implement disableBITS flag

### DIFF
--- a/auslib/blobs/schemas/apprelease-v9.yml
+++ b/auslib/blobs/schemas/apprelease-v9.yml
@@ -101,6 +101,9 @@
               promptWaitTime:
                 type: number
                 description: The number of seconds to wait before showing the dialog which prompts users to restart, overrides the in-app preference
+              disableBITS:
+                type: boolean
+                description: Whether or not to disable background downloads with BITS on the client
     # Top level fileUrls are useful primarily for release style builds,
     # where the URLs are predictable and only vary by locale and platform.
     # It"s worth noting that while we normally serve different channels

--- a/auslib/blobs/schemas/apprelease-v9.yml
+++ b/auslib/blobs/schemas/apprelease-v9.yml
@@ -103,6 +103,8 @@
                 description: The number of seconds to wait before showing the dialog which prompts users to restart, overrides the in-app preference
               disableBITS:
                 type: boolean
+                enum:
+                  - true
                 description: Whether or not to disable background downloads with BITS on the client
     # Top level fileUrls are useful primarily for release style builds,
     # where the URLs are predictable and only vary by locale and platform.

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -3561,6 +3561,7 @@ class TestSchema9Blob(unittest.TestCase):
 }
 """
         )
+        blob.validate("h", self.whitelistedDomains)
         updateQuery = {
             "product": "b",
             "buildID": "23",
@@ -3578,6 +3579,66 @@ class TestSchema9Blob(unittest.TestCase):
             '<update appVersion="68.0" buildID="50" detailsURL="http://example.org/bitsdetails/en-US" disableBITS="true" displayVersion="68.0" type="minor">'
         )
         self.assertEqual(returned_header.strip(), expected_header.strip())
+
+    def testDisableBITSFalseNotAllowed(self):
+        blob = ReleaseBlobV9()
+        blob.loadJSON(
+            """
+{
+    "name": "bbb",
+    "schema_version": 9,
+    "hashFunction": "sha512",
+    "appVersion": "68.0",
+    "displayVersion": "68.0",
+    "updateLine": [
+        {
+            "for": {},
+            "fields": {
+                "detailsURL": "http://example.org/bitsdetails/%LOCALE%",
+                "disableBITS": false,
+                "type": "minor"
+            }
+        }
+    ],
+    "fileUrls": {
+        "*": {
+            "partials": {
+                "bb": "http://a.com/bb-partial"
+            },
+            "completes": {
+                "*": "http://a.com/complete"
+            }
+        }
+    },
+    "platforms": {
+        "p": {
+            "buildID": 50,
+            "OS_FTP": "p",
+            "OS_BOUNCER": "p",
+            "locales": {
+                "en-US": {
+                    "partials": [
+                        {
+                            "filesize": 8,
+                            "from": "h1",
+                            "hashValue": "9"
+                        }
+                    ],
+                    "completes": [
+                        {
+                            "filesize": 40,
+                            "from": "*",
+                            "hashValue": "41"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+"""
+        )
+        self.assertRaises(BlobValidationError, blob.validate, "h", self.whitelistedDomains)
 
 
 @pytest.mark.parametrize(

--- a/auslib/test/blobs/test_apprelease.py
+++ b/auslib/test/blobs/test_apprelease.py
@@ -3503,6 +3503,82 @@ class TestSchema9Blob(unittest.TestCase):
         expected_footer = "</update>"
         self.assertEqual(returned_footer.strip(), expected_footer.strip())
 
+    def testDisableBITS(self):
+        blob = ReleaseBlobV9()
+        blob.loadJSON(
+            """
+{
+    "name": "bbb",
+    "schema_version": 9,
+    "hashFunction": "sha512",
+    "appVersion": "68.0",
+    "displayVersion": "68.0",
+    "updateLine": [
+        {
+            "for": {},
+            "fields": {
+                "detailsURL": "http://example.org/bitsdetails/%LOCALE%",
+                "disableBITS": true,
+                "type": "minor"
+            }
+        }
+    ],
+    "fileUrls": {
+        "*": {
+            "partials": {
+                "bb": "http://a.com/bb-partial"
+            },
+            "completes": {
+                "*": "http://a.com/complete"
+            }
+        }
+    },
+    "platforms": {
+        "p": {
+            "buildID": 50,
+            "OS_FTP": "p",
+            "OS_BOUNCER": "p",
+            "locales": {
+                "en-US": {
+                    "partials": [
+                        {
+                            "filesize": 8,
+                            "from": "h1",
+                            "hashValue": "9"
+                        }
+                    ],
+                    "completes": [
+                        {
+                            "filesize": 40,
+                            "from": "*",
+                            "hashValue": "41"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+"""
+        )
+        updateQuery = {
+            "product": "b",
+            "buildID": "23",
+            "version": "65.0",
+            "buildTarget": "p",
+            "locale": "en-US",
+            "channel": "release",
+            "osVersion": "a",
+            "distribution": "a",
+            "distVersion": "a",
+            "force": None,
+        }
+        returned_header = blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        expected_header = (
+            '<update appVersion="68.0" buildID="50" detailsURL="http://example.org/bitsdetails/en-US" disableBITS="true" displayVersion="68.0" type="minor">'
+        )
+        self.assertEqual(returned_header.strip(), expected_header.strip())
+
 
 @pytest.mark.parametrize(
     "for1,for2",


### PR DESCRIPTION
This flag allows us to disable BITS background downloading remotely, on the off chance that something goes wrong when it rolls with 68.0b1. https://bugzilla.mozilla.org/show_bug.cgi?id=1540191 and https://bugzilla.mozilla.org/show_bug.cgi?id=1546106 have additional background.