### PR TITLE
Fix release dumps and cleanup

### DIFF
--- a/scripts/manage-db.py
+++ b/scripts/manage-db.py
@@ -172,7 +172,7 @@ def extract_active_data(trans, url, dump_location="dump.sql"):
             for batched_release_list in batch_generator:
                 query = ", ".join("'" + names + "'" for names in batched_release_list)
                 cmd = mysql_data_only_command(host, user, password, db, "releases").split()
-                cmd.append('--where=releases.name IN ({})'.format(query))
+                cmd.append("--where=releases.name IN ({})".format(query))
                 run(cmd, stdout=dump_file, check=True)
 
         cmd = mysql_data_only_command(host, user, password, db, "releases_history").split()

--- a/scripts/manage-db.py
+++ b/scripts/manage-db.py
@@ -172,7 +172,7 @@ def extract_active_data(trans, url, dump_location="dump.sql"):
             for batched_release_list in batch_generator:
                 query = ", ".join("'" + names + "'" for names in batched_release_list)
                 cmd = mysql_data_only_command(host, user, password, db, "releases").split()
-                cmd.append('--where="releases.name IN ({})"'.format(query))
+                cmd.append('--where=releases.name IN ({})'.format(query))
                 run(cmd, stdout=dump_file, check=True)
 
         cmd = mysql_data_only_command(host, user, password, db, "releases_history").split()

--- a/scripts/run-batch-deletes.sh
+++ b/scripts/run-batch-deletes.sh
@@ -26,7 +26,12 @@ while true; do
 
     printf "Deleting..."
     # DBURI and MAX_AGE should be in the environment
-    DELETED=$(python ./manage-db.py -d "$DBURI" cleanup "$MAX_AGE" 2>/dev/null | awk '/Total/ {print $3}')
+    DELETED=$(python ./manage-db.py -d "$DBURI" cleanup "$MAX_AGE" 2>/dev/null)
+    if ! [ "$?" -eq "0" ]; then
+        echo "manage-db.py didn't exit cleanly"
+        continue
+    fi
+    DELETED=$(echo "$DELETED" | awk '/Total/ {print $3}')
     ORIG_DELETED=$DELETED
     # Sometimes DELETED ends up not being set for some reason, which breaks
     # the `expr` expressions below, and gets the script stuck in a loop.

--- a/scripts/run-batch-deletes.sh
+++ b/scripts/run-batch-deletes.sh
@@ -27,10 +27,17 @@ while true; do
     printf "Deleting..."
     # DBURI and MAX_AGE should be in the environment
     DELETED=$(python ./manage-db.py -d "$DBURI" cleanup "$MAX_AGE" 2>/dev/null | awk '/Total/ {print $3}')
+    ORIG_DELETED=$DELETED
+    # Sometimes DELETED ends up not being set for some reason, which breaks
+    # the `expr` expressions below, and gets the script stuck in a loop.
+    if ! [ "$DELETED" -eq "$DELETED" ] 2>/dev/null; then
+        DELETED=0
+    fi
     TOTAL=$(expr $TOTAL + $DELETED)
     NOW=$(date '+%s')
     printf "%d rows removed >>> %d seconds remaining. %d deleted.\n" $DELETED $(expr $TIL - $NOW) $TOTAL
 
+    echo "Original value for \$DELETED: $ORIG_DELETED"
     if [ $DELETED -eq 0 ]; then
         echo "Nothing left to do"
         exit 0


### PR DESCRIPTION
Release dumps been broken since #902 landed, because we included quotes around an argument that didn't need them (which meant the argument didn't work properly).

While investigating this, I also noticed that our cleanup script sometimes ends up with errors like `"/app/scripts/run-batch-deletes.sh: 34: [: -eq: unexpected operator"`, which appear to be caused by $DELETED not being an integer (for reasons I haven't been able to figure out). I _think_ this will fix them, or at the very least provide some debugging info.