### PR TITLE
Add ability to skip toplevel keys & only sync whitelisted releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get install -q --yes gcc && \
 COPY auslib/ /app/auslib/
 COPY ui/ /app/ui/
 COPY uwsgi/ /app/uwsgi/
-COPY scripts/manage-db.py scripts/run-batch-deletes.sh scripts/run.sh scripts/reset-stage-db.sh scripts/get-prod-db-dump.py /app/scripts/
+COPY scripts/manage-db.py scripts/run-batch-deletes.sh scripts/run.sh scripts/reset-stage-db.sh scripts/get-prod-db-dump.py scripts/releases-history-to-gcs.py /app/scripts/
 COPY version.json /app/
 
 WORKDIR /app


### PR DESCRIPTION
@oremj and I were chatting last week about ways to improve the sync. In the end, there's two things that should make things a lot better:
1) Make it possible to skip top level keys that already exist in GCS. This mode lets us very quickly skip releases (as opposed to the checksum comparison, which has to pull md5s from GCS & blobs from balrog for every revision).
2) A way to provide a specific list of releases to sync.

The idea is that the top level key skip will make incremental syncs faster, and then we can figure out the exact list of final releases to sync near cutover time, and sync those with the whitelist. The logs from the sync script and admin web traffic should have enough information to construct that list.