### PR TITLE
Allow a list of allowed CORS origins to be passed to the admin app

### DIFF
--- a/auslib/test/admin/views/base.py
+++ b/auslib/test/admin/views/base.py
@@ -49,6 +49,7 @@ class ViewTest(unittest.TestCase):
         app.config["AUTH_DOMAIN"] = "balrog.test.dev"
         app.config["AUTH_AUDIENCE"] = "balrog test"
         app.config["M2M_ACCOUNT_MAPPING"] = {}
+        app.config["CORS_ORIGINS"] = "*"
         with open(self.version_file, "w+") as f:
             f.write(
                 """

--- a/auslib/test/admin/views/test_base.py
+++ b/auslib/test/admin/views/test_base.py
@@ -27,3 +27,8 @@ class TestJsonLogFormatter(ViewTest):
     def testContentSecurityPolicyIsSet(self):
         ret = self.client.get("/rules")
         self.assertEqual(ret.headers.get("Content-Security-Policy"), "default-src 'none'; frame-ancestors 'none'")
+
+    def testCORSIsSet(self):
+        ret = self.client.get("/rules")
+        self.assertEqual(ret.headers.get("Access-Control-Allow-Headers"), "Authorization")
+        self.assertEqual(ret.headers.get("Access-Control-Allow-Origin"), "*")

--- a/auslib/web/admin/base.py
+++ b/auslib/web/admin/base.py
@@ -81,8 +81,11 @@ def add_security_headers(response):
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["Strict-Transport-Security"] = app.config.get("STRICT_TRANSPORT_SECURITY", "max-age=31536000;")
-    response.headers["Access-Control-Allow-Origin"] = "*"
     response.headers["Access-Control-Allow-Headers"] = "Authorization"
+    if "*" in app.config["CORS_ORIGINS"]:
+        response.headers["Access-Control-Allow-Origin"] = "*"
+    elif request.headers["Origin"] in app.config["CORS_ORIGINS"]:
+        response.headers["Access-Control-Allow-Origin"] = request.headers["Origin"]
     if re.match("^/ui/", request.path):
         # This enables swagger-ui to dynamically fetch and
         # load the swagger specification JSON file containing API definition and examples.

--- a/auslib/web/admin/base.py
+++ b/auslib/web/admin/base.py
@@ -81,6 +81,8 @@ def add_security_headers(response):
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["Strict-Transport-Security"] = app.config.get("STRICT_TRANSPORT_SECURITY", "max-age=31536000;")
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Headers"] = "Authorization"
     if re.match("^/ui/", request.path):
         # This enables swagger-ui to dynamically fetch and
         # load the swagger specification JSON file containing API definition and examples.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - AUTH0_AUDIENCE=balrog-localdev
       - AUTH0_RESPONSE_TYPE=token id_token
       - AUTH0_SCOPE=full-user-credentials openid profile email
+      - CORS_ORIGINS=*
       # Grab mail information from the local environment
       - SMTP_HOST
       - SMTP_PORT

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -106,6 +106,11 @@ if not os.environ.get("INSECURE_SESSION_COOKIE"):
 # https://www.owasp.org/index.php/HttpOnly#What_is_HttpOnly.3F
 application.config["SESSION_COOKIE_HTTPONLY"] = True
 
+# This isn't needed for the current UI, which is hosted at the same origin
+# as the API. When we roll out the new, React-based UI, it may be hosted
+# elsewhere in which case we'll need CloudOps to set this for us.
+# In the meantime, this allows us to set it to "*" for local development
+# to enable the new UI to work there.
 application.config["CORS_ORIGINS"] = os.environ.get("CORS_ORIGINS", "").split()
 
 # Strict Samesite cookies means that the session cookie will never be sent

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -106,6 +106,8 @@ if not os.environ.get("INSECURE_SESSION_COOKIE"):
 # https://www.owasp.org/index.php/HttpOnly#What_is_HttpOnly.3F
 application.config["SESSION_COOKIE_HTTPONLY"] = True
 
+application.config["CORS_ORIGINS"] = os.environ.get("CORS_ORIGINS", "").split()
+
 # Strict Samesite cookies means that the session cookie will never be sent
 # when loading any page or making any request where the referrer is some
 # other site. For example, a link to Balrog from Gmail will not send the session


### PR DESCRIPTION
We haven't needed this historically because the API & UI have always been on the same origin. While testing the new UI, we realized that we need to set this to alow it to talk to the API. If we end up with it on the same origin later, we can remove this.