### PR TITLE
Run coverage for python 3 again.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
 deps = -rrequirements-test.txt
 commands=
     flake8 api-tests auslib *.py scripts uwsgi
-    py.test -n auto --no-cov {posargs:auslib}
+    py.test -n auto --cov {posargs:auslib}
     coverage run -a scripts/test-rules.py
 
 [flake8]


### PR DESCRIPTION
I was surprised to see that we were still submitting to coveralls, it just wasn't reporting here. It looks like coveralls doesn't update PRs/commits unless it actually receives coverage data.