### PR TITLE
Print docker digest and change build URL

### DIFF
--- a/scripts/push-dockerimage.sh
+++ b/scripts/push-dockerimage.sh
@@ -31,7 +31,7 @@ cat > version.json <<EOF
     "commit": "${commit}",
     "version": "${version}",
     "source": "https://github.com/mozilla/balrog",
-    "build": "https://tools.taskcluster.net/task-inspector/#${TASK_ID}"
+    "build": "https://tools.taskcluster.net/tasks/${TASK_ID}"
 }
 EOF
 
@@ -45,6 +45,9 @@ for tag in ${tags[*]}; do
     docker tag buildtemp "mozilla/balrog:${tag}"
     echo "Pushing Docker image tagged with ${tag}"
     docker push mozilla/balrog:${tag}
+    # Pull the image to print its digest. cloudops-deploylib verifies the
+    # images comparing their digests to the digests in the logs
+    docker pull mozilla/balrog:${tag}
 done
 
 sha256=$(docker images --no-trunc mozilla/balrog | grep "${tags[0]}" | awk '/^mozilla/ {print $3}')


### PR DESCRIPTION
According to
https://github.com/mozilla-services/cloudops-infra-deploylib/blob/7d668384e41fbf936af3b706a9a3cce2d10499ff/deploylib/docker.py#L152
the digest of the docker image should be in the log. The digest printed
using the locally built image doesn't produce the same sha256 with the
one pushed to Docker Hub, because Taskcluster uses an older version of
docker.