### PR TITLE
Add more required CORS headers.

### DIFF
--- a/auslib/test/admin/views/test_base.py
+++ b/auslib/test/admin/views/test_base.py
@@ -30,5 +30,6 @@ class TestJsonLogFormatter(ViewTest):
 
     def testCORSIsSet(self):
         ret = self.client.get("/rules")
-        self.assertEqual(ret.headers.get("Access-Control-Allow-Headers"), "Authorization")
+        self.assertEqual(ret.headers.get("Access-Control-Allow-Headers"), "Authorization, Content-Type")
         self.assertEqual(ret.headers.get("Access-Control-Allow-Origin"), "*")
+        self.assertEqual(ret.headers.get("Access-Control-Allow-Methods"), "OPTIONS, GET, POST, PUT, DELETE")

--- a/auslib/web/admin/base.py
+++ b/auslib/web/admin/base.py
@@ -81,7 +81,8 @@ def add_security_headers(response):
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["Strict-Transport-Security"] = app.config.get("STRICT_TRANSPORT_SECURITY", "max-age=31536000;")
-    response.headers["Access-Control-Allow-Headers"] = "Authorization"
+    response.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type"
+    response.headers["Access-Control-Allow-Methods"] = "OPTIONS, GET, POST, PUT, DELETE"
     if "*" in app.config["CORS_ORIGINS"]:
         response.headers["Access-Control-Allow-Origin"] = "*"
     elif "Origin" in request.headers and request.headers["Origin"] in app.config["CORS_ORIGINS"]:


### PR DESCRIPTION
While working on the new UI locally I discovered that the CORS work that was done previously was not quite complete enough for the new UI to work. Specifically, the UI uses a value for Content-Type that is not whitelisted, and we also need to allow specific methods. https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests has more details on the requirements here.