### PR TITLE
Fix pytest invocation so it respects test path.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
 deps = -rrequirements-test.txt
 commands=
     flake8 api-tests auslib *.py scripts uwsgi
-    py.test -n auto --cov {posargs:auslib}
+    py.test -n auto --cov auslib {posargs:auslib}
     coverage run -a scripts/test-rules.py
 
 [flake8]


### PR DESCRIPTION
I think this broke at some point during the Python 3 migration/ripping out Python 2 code. `--cov` takes an argument, so it ends up eating the positional arg or default.