### PR TITLE
bug 1564442: Raise if an error occured getting a token.

### DIFF
--- a/client/balrogclient/api.py
+++ b/client/balrogclient/api.py
@@ -56,6 +56,7 @@ def _get_auth0_token(secrets, session):
     payload = dict(client_id=secrets["client_id"], client_secret=secrets["client_secret"], audience=secrets["audience"], grant_type="client_credentials")
     headers = {"Content-Type": "application/json"}
     request = session.post(url, data=json.dumps(payload), headers=headers)
+    request.raise_for_status()
     response = request.json()
     # In order to know exact expiration we would need to decode the token, what
     # requires more dependencies. Instead we use the returned "expires_in" in

--- a/client/setup.py
+++ b/client/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="balrogclient",
-    version="0.5.0",
+    version="0.6.0",
     description="Balrog Admin API Client",
     author="Mozilla Release Engineers",
     author_email="release+python@mozilla.com",


### PR DESCRIPTION
Turns out we don't noticed errors when talking to auth0. What ends up happening is we cache the response but not the token (because it doesn't exist in the response), and then cascade because we can't find the token in the cache upon retry.