### PR TITLE
Add support for getting scheduled changes by sc_id

### DIFF
--- a/auslib/test/admin/views/test_releases.py
+++ b/auslib/test/admin/views/test_releases.py
@@ -1540,6 +1540,27 @@ class TestReleasesScheduledChanges(ViewTest):
         }
         self.assertDictEqual(ret.get_json(), expected)
 
+    def testGetScheduledChangeByScId(self):
+        ret = self._get("/scheduled_changes/releases/2")
+        expected = {
+            "scheduled_change": {
+                "sc_id": 2,
+                "when": 6000000000,
+                "scheduled_by": "bill",
+                "change_type": "update",
+                "complete": False,
+                "sc_data_version": 1,
+                "name": "a",
+                "product": "a",
+                "data": {"name": "a", "hashFunction": "sha512", "schema_version": 1, "extv": "2.0"},
+                "read_only": False,
+                "data_version": 1,
+                "signoffs": {"bill": "releng"},
+                "required_signoffs": {"releng": 1},
+            }
+        }
+        self.assertDictEqual(ret.get_json(), expected)
+
     @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testAddScheduledChangeExistingRelease(self):
         data = {

--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -1792,6 +1792,48 @@ class TestRuleScheduledChanges(ViewTest):
         }
         self.assertEqual(ret.get_json(), expected)
 
+    def testGetScheduledChangeByScId(self):
+        ret = self._get("/scheduled_changes/rules/3")
+        expected = {
+            "scheduled_change": {
+                "sc_id": 3,
+                "when": 2900000,
+                "scheduled_by": "bill",
+                "complete": False,
+                "sc_data_version": 2,
+                "rule_id": None,
+                "priority": 150,
+                "backgroundRate": 100,
+                "channel": "a",
+                "mapping": "ghi",
+                "update_type": "minor",
+                "version": None,
+                "jaws": None,
+                "buildTarget": None,
+                "alias": None,
+                "product": None,
+                "buildID": None,
+                "locale": None,
+                "osVersion": None,
+                "memory": None,
+                "mig64": None,
+                "distribution": None,
+                "fallbackMapping": None,
+                "distVersion": None,
+                "headerArchitecture": None,
+                "comment": None,
+                "data_version": None,
+                "instructionSet": None,
+                "telemetry_product": None,
+                "telemetry_channel": None,
+                "telemetry_uptake": None,
+                "change_type": "insert",
+                "signoffs": {"bill": "releng", "mary": "relman"},
+                "required_signoffs": {"releng": 1},
+            }
+        }
+        self.assertEqual(ret.get_json(), expected)
+
     @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testAddScheduledChangeExistingRule(self):
         data = {

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -2550,6 +2550,54 @@ paths:
           $ref: '#/responses/unauthorizedUser'
 
   /scheduled_changes/releases/{sc_id}:
+    get:
+      summary: Return the scheduled change requested
+      description: >
+        Endpoint to get a Scheduled Change for a Release. [Docs](http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#scheduled-changes)
+      tags:
+        - Scheduled Changes
+      operationId: auslib.web.admin.views.mapper.scheduled_change_releases_get_by_id
+      consumes: []
+      produces:
+        - application/json
+      externalDocs:
+        url: "http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#scheduled-changes-object"
+        description: Returns a scheduled change for a release.
+      parameters:
+        - $ref: '#/parameters/sc_id_param'
+      responses:
+        '200':
+          description: Returns the scheduled change with the id specified
+          schema:
+            type: object
+            required:
+              - scheduled_change
+            allOf:
+              - $ref: "#/definitions/CountModel"
+              - type: object
+                properties:
+                  scheduled_change:
+                    description: array where each element is a scheduled change for a Release.
+                    allOf:
+                      - $ref: '#/definitions/SCChangeType'
+                      - $ref: '#/definitions/SCTime'
+                      - $ref: '#/definitions/SCIdModel'
+                      - $ref: '#/definitions/SCDataVersion'
+                      - $ref: '#/definitions/SCSignoffsModel'
+                      - $ref: '#/definitions/SCCommonFieldsModel'
+                      - $ref: '#/definitions/DataVersionNullable'
+                      - $ref: '#/definitions/ProductNullable'
+                      - $ref: '#/definitions/ReleaseReadOnly'
+                      - $ref: '#/definitions/ReleaseDataObject'
+                      - $ref: '#/definitions/ReleaseName'
+                    required:
+                      - change_type
+                      - data_version
+                      - when
+                      - product
+                      - name
+                      - data
+                      - read_only
     post:
       summary: Modifies existing scheduled change for a Release.
       description: >

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -2039,7 +2039,7 @@ paths:
               - type: object
                 properties:
                   scheduled_change:
-                    description: A single element array containing the scheduled change
+                    description: An object containing the scheduled change with the id specified
                     type: object
                     allOf:
                       - $ref: '#/definitions/SCSignoffsModel'
@@ -2577,7 +2577,7 @@ paths:
               - type: object
                 properties:
                   scheduled_change:
-                    description: array where each element is a scheduled change for a Release.
+                    description: An object containing the scheduled change with the id specified
                     allOf:
                       - $ref: '#/definitions/SCChangeType'
                       - $ref: '#/definitions/SCTime'

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -2013,6 +2013,37 @@ paths:
           $ref: '#/responses/unauthorizedUser'
 
   /scheduled_changes/rules/{sc_id}:
+    get:
+      summary: Return the scheduled change requested
+      description: >
+        Endpoint to get a Scheduled Change for a Rule. [Docs](http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#scheduled-changes)
+      tags:
+        - Scheduled Changes
+      operationId: auslib.web.admin.views.mapper.scheduled_change_rules_get_by_id
+      consumes: []
+      produces:
+        - application/json
+      externalDocs:
+        url: "http://mozilla-balrog.readthedocs.io/en/latest/admin_api.html#scheduled-changes-object"
+        description: Returns a scheduled change for a rule.
+      parameters:
+        - $ref: '#/parameters/sc_id_param'
+      responses:
+        '200':
+          description: Returns the scheduled change with the id specified
+          schema:
+            type: object
+            required:
+              - scheduled_change
+            allOf:
+              - type: object
+                properties:
+                  scheduled_change:
+                    description: A single element array containing the scheduled change
+                    type: object
+                    allOf:
+                      - $ref: '#/definitions/SCSignoffsModel'
+                      - $ref: '#/definitions/SCRulesItemBase'
     post:
       summary: Modifies existing scheduled change for a Rule.
       description: >

--- a/auslib/web/admin/views/mapper.py
+++ b/auslib/web/admin/views/mapper.py
@@ -372,6 +372,10 @@ def scheduled_change_permissions_delete(sc_id):
     return PermissionScheduledChangeView().delete(sc_id)
 
 
+def scheduled_change_releases_get_by_id(sc_id):
+    return ReleaseScheduledChangeView().get(sc_id)
+
+
 def scheduled_change_releases_post(sc_id):
     """POST /scheduled_changes/releases/<int:sc_id>"""
     return ReleaseScheduledChangeView().post(sc_id)

--- a/auslib/web/admin/views/mapper.py
+++ b/auslib/web/admin/views/mapper.py
@@ -348,6 +348,10 @@ def scheduled_change_permissions_rs_signoffs_delete(sc_id):
     return PermissionsRequiredSignoffScheduledChangeSignoffsView().delete(sc_id)
 
 
+def scheduled_change_rules_get_by_id(sc_id):
+    return RuleScheduledChangeView().get(sc_id)
+
+
 def scheduled_change_rules_post(sc_id):
     """POST /scheduled_changes/rules/<int:sc_id>"""
     return RuleScheduledChangeView().post(sc_id)

--- a/auslib/web/admin/views/scheduled_changes.py
+++ b/auslib/web/admin/views/scheduled_changes.py
@@ -103,7 +103,6 @@ class ScheduledChangeView(AdminView):
         scheduled_change = add_signoff_information(sc[0], self.table, self.sc_table)
         return jsonify({"scheduled_change": scheduled_change})
 
-
     def _post(self, sc_id, what, transaction, changed_by, old_sc_data_version):
         if is_when_present_and_in_past_validator(what):
             return problem(400, "Bad Request", "Changes may not be scheduled in the past")


### PR DESCRIPTION
Similar to #950, but for querying by `sc_id` to support frontend development.