### PR TITLE
Don't require google.json to be present for local dev

### DIFF
--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -66,7 +66,7 @@ if not os.environ.get("LOCALDEV"):
         log.critical("GOOGLE_APPLICATION_CREDENTIALS provided, but does not exist")
         sys.exit(1)
 
-if os.environ.get("LOCALDEV") and not os.path.exists(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", ""))):
+if os.environ.get("LOCALDEV") and not os.path.exists(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")):
     storage_client = storage.Client.create_anonymous_client()
 else:
     storage_client = storage.Client()

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -66,7 +66,7 @@ if not os.environ.get("LOCALDEV"):
         log.critical("GOOGLE_APPLICATION_CREDENTIALS provided, but does not exist")
         sys.exit(1)
 
-if os.environ.get("LOCALDEV") and "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
+if os.environ.get("LOCALDEV") and ("GOOGLE_APPLICATION_CREDENTIALS" not in os.environ or not os.path.exists(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"))):
     storage_client = storage.Client.create_anonymous_client()
 else:
     storage_client = storage.Client()

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -66,7 +66,7 @@ if not os.environ.get("LOCALDEV"):
         log.critical("GOOGLE_APPLICATION_CREDENTIALS provided, but does not exist")
         sys.exit(1)
 
-if os.environ.get("LOCALDEV") and ("GOOGLE_APPLICATION_CREDENTIALS" not in os.environ or not os.path.exists(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"))):
+if os.environ.get("LOCALDEV") and not os.path.exists(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", ""))):
     storage_client = storage.Client.create_anonymous_client()
 else:
     storage_client = storage.Client()


### PR DESCRIPTION
This is a small follow-up to #971, where we stopped using `GOOGLE_APPLICATION_CREDENTIALS` for dev/stage/prod. That patch made it such that if the environment variable is present for local dev, we'd require the file to exist. Previously, we'd allow the the variable to exist, but only use the credentials if the file existed on disk (to avoid the need to make local code changes when testing writes to releases history).