### PR TITLE
Allow emergency_shutoff to be used in permission scheduled changes.

### DIFF
--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -4144,6 +4144,7 @@ definitions:
         maxLength: 50
         enum:
           - admin
+          - emergency_shutoff
           - rule
           - release
           - release_read_only


### PR DESCRIPTION
@helfi92 discovered this while working on the new UI. Looks like it was missed in #450.