### PR TITLE
Revert patch bug 1492603, because it can empty out release data in some situations

### DIFF
--- a/auslib/test/test_db.py
+++ b/auslib/test/test_db.py
@@ -3550,11 +3550,6 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         self.permissions.user_roles.t.insert().execute(username="bill", role="bar", data_version=1)
         self.permissions.user_roles.t.insert().execute(username="me", role="bar", data_version=1)
         dbo.productRequiredSignoffs.t.insert().execute(product="b", channel="h", role="bar", signoffs_required=2, data_version=1)
-        dbo.productRequiredSignoffs.t.insert().execute(product="Z", channel="a", role="foo", signoffs_required=1, data_version=1)
-        dbo.productRequiredSignoffs.t.insert().execute(product="Z", channel="b", role="bar", signoffs_required=2, data_version=1)
-        dbo.productRequiredSignoffs.t.insert().execute(product="Z", channel="b", role="foo", signoffs_required=2, data_version=1)
-        dbo.productRequiredSignoffs.t.insert().execute(product="Z", channel="c", role="baz", signoffs_required=1, data_version=1)
-        dbo.productRequiredSignoffs.t.insert().execute(product="Z", channel="d", role="bar", signoffs_required=4, data_version=1)
 
     def tearDown(self):
         dbo.reset()
@@ -3801,22 +3796,6 @@ class TestReleases(unittest.TestCase, MemoryDatabaseMixin):
         )
         rules = self._stripNullColumns(rules)
         self.assertEqual(rules, expected)
-
-    def testGetPotentialRequiredSignoffsForProduct(self):
-        release = {"name": "Z", "product": "Z"}
-        signoffs_required = self.releases.getPotentialRequiredSignoffsForProduct(release["product"])
-        self.assertIn("rs", signoffs_required)
-        self.assertEqual(len(signoffs_required["rs"]), 3)
-        signoffs_by_role = {rs["role"]: rs["signoffs_required"] for signoffs in signoffs_required.values() for rs in signoffs}
-        self.assertEqual(signoffs_by_role["foo"], 2)
-        self.assertEqual(signoffs_by_role["bar"], 4)
-        self.assertEqual(signoffs_by_role["baz"], 1)
-
-    def testGetPotentialRequiredSignoffsForProductNoSignoffsRequired(self):
-        release = {"name": "ZA", "product": "ZA"}
-        signoffs_required = self.releases.getPotentialRequiredSignoffsForProduct(release["product"])
-        self.assertIn("rs", signoffs_required)
-        self.assertEqual(len(signoffs_required["rs"]), 0)
 
 
 @pytest.mark.usefixtures("current_db_schema")

--- a/auslib/web/admin/swagger/api.yaml
+++ b/auslib/web/admin/swagger/api.yaml
@@ -895,33 +895,6 @@ paths:
         '404':
           $ref: '#/responses/resourceNotFound'
 
-  /releases/{release}/read_only/product/required_signoffs:
-    get:
-      summary: Returns required signoffs for make a release r+w based on product
-      description: >
-        Returns required signoffs for make a release r+w based on product, regardless of channel.
-      tags:
-        - Releases
-        - Required Signoffs
-      operationId: auslib.web.admin.views.mapper.release_read_only_product_required_signoffs_get
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/releaseParam'
-      responses:
-        '200':
-          description: Returns metadata about Releases
-          schema:
-            type: array
-            items:
-              type: object
-              properties:
-                required_signoffs:
-                  description: Object mapping roles to the number of signoffs required to change the release
-                  type: object
-        '404':
-          $ref: '#/responses/resourceNotFound'
-
   /releases/columns/{column}:
     get:
       summary: Returns a JSON Object containing the unique values for the given release column
@@ -2561,7 +2534,6 @@ paths:
               - $ref: '#/definitions/ReleaseDataField'
               - $ref: '#/definitions/ProductModel'
               - $ref: '#/definitions/ReleaseName'
-              - $ref: '#/definitions/ReleaseReadOnly'
             required:
               - change_type
               - name

--- a/auslib/web/admin/views/mapper.py
+++ b/auslib/web/admin/views/mapper.py
@@ -14,7 +14,6 @@ from auslib.web.admin.views.permissions import (
 from auslib.web.admin.views.releases import (
     EnactReleaseScheduledChangeView,
     ReleaseReadOnlyView,
-    ReleaseReadOnlyProductRequiredSignoffsView,
     ReleasesAPIView,
     ReleaseScheduledChangeHistoryView,
     ReleaseScheduledChangeSignoffsView,
@@ -172,11 +171,6 @@ def release_read_only_get(release):
 def release_read_only_put(release):
     """PUT /releases/:release/read_only"""
     return ReleaseReadOnlyView().put(release)
-
-
-def release_read_only_product_required_signoffs_get(release):
-    """PUT /releases/:release/read_only/product/required_signoffs"""
-    return ReleaseReadOnlyProductRequiredSignoffsView().get(release)
 
 
 def release_single_column_get(column):

--- a/ui/app/js/controllers/release_read_only_controller.js
+++ b/ui/app/js/controllers/release_read_only_controller.js
@@ -1,96 +1,40 @@
 angular.module('app').controller('ReleaseReadOnlyCtrl',
 function ($scope, $modalInstance, CSRF, Releases, release) {
+
+  $scope.release = release;
+  $scope.saving = false;
+
   $scope.saveChanges = function () {
     $scope.saving = true;
+    var data = $scope.release;
+    data.read_only = release.read_only ? "" : true;
 
     CSRF.getToken()
     .then(function(csrf_token) {
-      var data = angular.copy($scope.release);
-      data.read_only = release.read_only ? "" : true;
-
-      if ($scope.changeRequiresSignoffs()) {
-        $scope.scheduleReadWriteReleaseChange(data, csrf_token);
-      } else {
-        $scope.changeReadOnly(data, csrf_token);
-      }
-    });
-  };
-
-  $scope.changeReadOnly = function(release, csrf_token) {
-    Releases.changeReadOnly(release.name, release, csrf_token)
-    .success(function(response) {
-      $scope.release.data_version = response.new_data_version;
-      $scope.release.read_only = release.read_only;
-      $modalInstance.close();
-    })
-    .error($scope.responseError)
-    .finally($scope.operationComplete);
-  };
-
-  $scope.scheduleReadWriteReleaseChange = function(release, csrf_token) {
-    var when = new Date();
-    when.setSeconds(when.getSeconds() + 10);
-
-    var sc = {
-      change_type: 'update',
-      name: release.name,
-      product: release.product,
-      read_only: false,
-      when: when,
-      data_version: release.data_version
-    };
-
-    Releases.addScheduledChange(sc, csrf_token)
+      Releases.changeReadOnly($scope.release.name, data, csrf_token)
       .success(function(response) {
-        sc.sc_data_version = 1;
-        sc.sc_id = response.sc_id;
-        $scope.release.sc = sc;
-        sweetAlert(
-          'Release', 'Release was scheduled to be modifiable successfully!', 'success');
+        $scope.release.data_version = response.new_data_version;
+        $scope.release.read_only = data.read_only;
+        $scope.saving = false;
         $modalInstance.close();
       })
-      .error($scope.responseError)
-      .finally($scope.operationComplete);
-  };
-
-  $scope.operationComplete = function () {
-    $scope.saving = false;
-  };
-
-  $scope.responseError = function(response) {
-    if (typeof response === 'object') {
-      $scope.errors = response;
-      sweetAlert(
-        'Form submission error',
-        'See fields highlighted in red.',
-        'error'
-      );
-    }
-  };
-
-  $scope.changeRequiresSignoffs = function() {
-    return $scope.release.read_only &&
-      $scope.release.required_signoffs &&
-      $scope.release.required_signoffs.length > 0;
+      .error(function(response) {
+        if (typeof response === 'object') {
+          $scope.errors = response;
+          sweetAlert(
+            "Form submission error",
+            "See fields highlighted in red.",
+            "error"
+          );
+        }
+      })
+      .finally(function() {
+        $scope.saving = false;
+      });
+    });
   };
 
   $scope.cancel = function () {
       $modalInstance.dismiss('cancel');
   };
-
-  (function(){
-    if(!release.required_signoffs || release.required_signoffs.length === 0) {
-      Releases.getRequiredSignoffsForProduct(release.name).success(function(response) {
-        release.required_signoffs = {
-          length: Object.keys(response.required_signoffs).length,
-          roles: response.required_signoffs
-        };
-      })
-      .error($scope.responseError)
-      .finally($scope.operationComplete);
-    }
-
-    $scope.release = release;
-    $scope.saving = false;
-  })();
 });

--- a/ui/app/js/controllers/release_scheduled_changes_controller.js
+++ b/ui/app/js/controllers/release_scheduled_changes_controller.js
@@ -38,10 +38,6 @@ function($scope, $routeParams, $location, $timeout, Search, $modal, $route, Rele
     });
   }
 
-  $scope.isScheduledToBeModifiable = function(sc) {
-    return sc.change_type === 'update' && !sc.data && sc.hasOwnProperty('read_only') && !sc.read_only;
-  };
-
   $scope.openDataModal = function(release) { 
     var modalInstance = $modal.open({
       templateUrl: 'release_scheduled_change_data_modal.html',
@@ -91,13 +87,6 @@ function($scope, $routeParams, $location, $timeout, Search, $modal, $route, Rele
       if (sc.when !== null) {
         sc.when = new Date(sc.when);
       }
-
-      if (!sc.complete && $scope.isScheduledToBeModifiable(sc)) {
-        Releases.getRequiredSignoffsForProduct(sc.name).success(function(response) {
-          sc.required_signoffs = response.required_signoffs;
-        });
-      }
-
       return sc;
     });
   })

--- a/ui/app/js/controllers/releases_controller.js
+++ b/ui/app/js/controllers/releases_controller.js
@@ -43,21 +43,6 @@ function($scope, $routeParams, $location, $timeout, Releases, Search, $modal, Pa
       $scope.page_size_pair = [{id: 20, name: '20'},
         {id: 50, name: '50'}, 
         {id: $scope.releases_count, name: 'All'}];
-
-      if ($scope.releases && $scope.releases.length > 0) {
-        Releases.getScheduledChanges().success(function(sc_response) {
-          if (sc_response.count > 0) {
-            $scope.releases.forEach(function(release) {
-              var scheduled_change = sc_response.scheduled_changes.find(function(sc) {
-                return sc.name === release.name;
-              });
-              if (scheduled_change) {
-                release.sc = scheduled_change;
-              }
-            });
-          }
-        });
-      }
     })
     .error(function() {
       console.error(arguments);
@@ -332,11 +317,4 @@ function($scope, $routeParams, $location, $timeout, Releases, Search, $modal, Pa
     });
   };
   /* End openReadOnlyModal */
-
-  $scope.isScheduledToBeModifiable = function(release) {
-    return release.read_only &&
-      !!release.sc &&
-      !release.sc.complete &&
-      !release.sc.read_only;
-  };
 });

--- a/ui/app/js/services/releases_service.js
+++ b/ui/app/js/services/releases_service.js
@@ -83,9 +83,6 @@ angular.module("app").factory('Releases', function($http, $q, ScheduledChanges, 
     getReadOnly: function(name) {
       return $http.get('/api/releases/' + encodeURIComponent(name) + '/read_only');
     },
-    getRequiredSignoffsForProduct: function(name) {
-      return $http.get('/api/releases/' + encodeURIComponent(name) + '/read_only/product/required_signoffs');
-    },
     getData: function(link) {
       var deferred = $q.defer();
       $http.get(link)

--- a/ui/app/templates/release_read_only_modal.html
+++ b/ui/app/templates/release_read_only_modal.html
@@ -12,15 +12,12 @@
   </dl>
 
 </div>
-<div class="form-group" style="margin: 10px;" ng-class="{'has-error': errors.detail}">
+<div class="form-group" ng-class="{'has-error': errors.detail}">
     <p class="help-block" ng-show="errors.detail">{{ errors.detail }}</p>
 </div>
-<div class="form-group" style="margin: 10px;" ng-class="{'has-error': errors.exception}">
+<div class="form-group" ng-class="{'has-error': errors.exception}">
     <p class="help-block" ng-show="errors.exception">{{ errors.exception }}</p>
 </div>
-
-<show-signoff-requirements style="margin: 10px;" ng-if="changeRequiresSignoffs()" requirements="release.required_signoffs"></show-signoff-requirements>
-
 <div class="modal-footer">
   <div ng-show="saving" small-loader></div>
   <button class="btn btn-primary" ng-show="!saving" ng-click="saveChanges()">Yes</button>

--- a/ui/app/templates/release_scheduled_changes.html
+++ b/ui/app/templates/release_scheduled_changes.html
@@ -61,9 +61,9 @@
             Revoke your Signoff
           </button>
         </span>
-        <button ng-show="!isScheduledToBeModifiable(sc)" class="btn btn-default btn-xs" ng-click="openDataModal(sc)">View Data</button>
+        <button class="btn btn-default btn-xs" ng-click="openDataModal(sc)">View Data</button>
         <span ng-show="auth0.isAuthenticated()">
-          <button ng-show="!scheduled_changes_count && !isScheduledToBeModifiable(sc) && !sc.complete" class="btn btn-default btn-xs" ng-click="openUpdateModal(sc)">Update</button>
+          <button ng-show="!scheduled_changes_count && !sc.complete" class="btn btn-default btn-xs" ng-click="openUpdateModal(sc)">Update</button>
           <button ng-show="!scheduled_changes_count && !sc.complete" class="btn btn-default btn-xs" ng-click="openDeleteModal(sc)">Delete</button>
         </span>
         <a ng-show="!scheduled_changes_count" class="btn btn-default btn-xs" ng-href="/scheduled_changes/releases/{{ sc.sc_id }}">History</a>
@@ -106,8 +106,7 @@
       <h5 title="Data Version">
         Data version: <b>{{ sc.sc_data_version }}</b>
       </h5>
-      <button ng-if="!isScheduledToBeModifiable(sc) && sc.change_type==='update'" class="btn btn-default btn-xs" ng-click="openDiffModal(sc)">View Diff</button>
-      <strong style="color: red;" ng-show="isScheduledToBeModifiable(sc) && sc.change_type==='update'">Updating release state to modifiable</strong>
+      <button ng-if="sc.change_type==='update'" class="btn btn-default btn-xs" ng-click="openDiffModal(sc)">View Diff</button>
     </div>
 
     <dl class="dl-horizontal" style="float:right">

--- a/ui/app/templates/releases.html
+++ b/ui/app/templates/releases.html
@@ -85,15 +85,11 @@
           <button ng-show="!release_name && !release.required_signoffs.length" class="btn btn-default btn-xs" ng-click="openDeleteModal(release)">Delete</button>
         </span>
         <a ng-show="!release_name" class="btn btn-default btn-xs" ng-href="/releases/{{ release.name }}">History</a>
-
-        <span ng-show="isScheduledToBeModifiable(release)">
-          <a class="btn btn-xs btn-warning" href="/releases/scheduled_changes">Modifiable Pending...</a>
-        </span>
-        <span ng-show="auth0.isAuthenticated() && !isScheduledToBeModifiable(release)">
+        <span ng-show="auth0.isAuthenticated()">
           <button ng-show="!release_name && !release.read_only" class="btn btn-xs btn-success" ng-click="openReadOnlyModal(release)">Modifiable</button>
           <button ng-show="!release_name && release.read_only" class="btn btn-xs btn-danger" ng-click="openReadOnlyModal(release)">Read Only</button>
         </span>
-        <span ng-show="!auth0.isAuthenticated() && !isScheduledToBeModifiable(release)">
+        <span ng-show="!auth0.isAuthenticated()">
           <button ng-show="!release_name && !release.read_only" class="btn btn-xs btn-success" disabled>Modifiable</button>
           <button ng-show="!release_name && release.read_only" class="btn btn-xs btn-danger" disabled>Read Only</button>
         </span>

--- a/ui/spec/controllers/releases_controller_spec.js
+++ b/ui/spec/controllers/releases_controller_spec.js
@@ -61,29 +61,6 @@ var sample_releases = {
   "count": 3
 };
 
-var sample_scheduled_changes = {
-  "count": 1,
-  "scheduled_changes": [
-      {
-          "change_type": "update",
-          "complete": false,
-          "data": null,
-          "data_version": 79,
-          "name": "Fennec-mozilla-aurora-nightly-20140410004003",
-          "product": "Fennec",
-          "read_only": false,
-          "required_signoffs": {
-              "relman": 2
-          },
-          "sc_data_version": 1,
-          "sc_id": 19,
-          "scheduled_by": "user@user.com",
-          "signoffs": {},
-          "when": 1563661722982
-      }
-  ]
-};
-
 var release = sample_releases.releases[0];
 
 describe("controller: ReleasesController", function() {
@@ -120,16 +97,11 @@ describe("controller: ReleasesController", function() {
     it("should return all releases", function() {
       this.$httpBackend.expectGET('/api/releases')
       .respond(200, JSON.stringify(sample_releases));
-      this.$httpBackend.expectGET('/api/scheduled_changes/releases?all=1')
-      .respond(200, JSON.stringify(sample_scheduled_changes));
       this.$httpBackend.flush();
       expect(this.scope.releases.length).toEqual(3);
       var transformedReleases = angular.copy(sample_releases.releases);
       transformedReleases.forEach(function(release) {
         release.required_signoffs = {length: 0, roles: {}};
-        if (release.name === "Fennec-mozilla-aurora-nightly-20140410004003") {
-          release.sc = sample_scheduled_changes['scheduled_changes'][0];
-        }
       });
       expect(this.scope.releases).toEqual(transformedReleases);
     });
@@ -195,8 +167,6 @@ describe("controller: ReleasesController", function() {
     it("should be possible to change ordering", function() {
       this.$httpBackend.expectGET('/api/releases')
       .respond(200, JSON.stringify(sample_releases));
-      this.$httpBackend.expectGET('/api/scheduled_changes/releases?all=1')
-      .respond(200, '{}');
       this.$httpBackend.flush();
 
       var $scope = this.scope;
@@ -215,8 +185,6 @@ describe("controller: ReleasesController", function() {
     it("should notice if filters are on", function() {
       this.$httpBackend.expectGET('/api/releases')
       .respond(200, JSON.stringify(sample_releases));
-      this.$httpBackend.expectGET('/api/scheduled_changes/releases?all=1')
-      .respond(200, '{}');
       this.$httpBackend.flush();
 
       var $scope = this.scope;
@@ -231,8 +199,6 @@ describe("controller: ReleasesController", function() {
     it("should be possible to open the add modal", function() {
       this.$httpBackend.expectGET('/api/releases')
       .respond(200, JSON.stringify(sample_releases));
-      this.$httpBackend.expectGET('/api/scheduled_changes/releases?all=1')
-      .respond(200, '{}');
       this.$httpBackend.flush();
       // this.$httpBackend.expectGET('/api/releases?names_only=1')
       // .respond(200, JSON.stringify({names: ['Name1', 'Name2']}));
@@ -247,8 +213,6 @@ describe("controller: ReleasesController", function() {
     it("should be possible to open the edit modal", function() {
       this.$httpBackend.expectGET('/api/releases')
       .respond(200, JSON.stringify(sample_releases));
-      this.$httpBackend.expectGET('/api/scheduled_changes/releases?all=1')
-      .respond(200, '{}');
       this.$httpBackend.flush();
       this.scope.openUpdateModal(sample_releases.releases[0]);
       this.$httpBackend.expectGET('/api/releases/columns/product')
@@ -258,8 +222,6 @@ describe("controller: ReleasesController", function() {
     it("should be possible to open the delete modal", function() {
       this.$httpBackend.expectGET('/api/releases')
       .respond(200, JSON.stringify(sample_releases));
-      this.$httpBackend.expectGET('/api/scheduled_changes/releases?all=1')
-      .respond(200, '{}');
       this.$httpBackend.flush();
       this.scope.openDeleteModal(sample_releases.releases[0]);
     });
@@ -267,8 +229,6 @@ describe("controller: ReleasesController", function() {
     it("should be possible to open the data modal", function() {
       this.$httpBackend.expectGET('/api/releases')
       .respond(200, JSON.stringify(sample_releases));
-      this.$httpBackend.expectGET('/api/scheduled_changes/releases?all=1')
-      .respond(200, '{}');
       this.$httpBackend.flush();
 
       this.$httpBackend.expectGET('/api/releases/' + release.name)
@@ -280,8 +240,6 @@ describe("controller: ReleasesController", function() {
     it("should be possible to open the diff modal", function() {
       this.$httpBackend.expectGET('/api/releases')
       .respond(200, JSON.stringify(sample_releases));
-      this.$httpBackend.expectGET('/api/scheduled_changes/releases?all=1')
-      .respond(200, '{}');
       this.$httpBackend.flush();
 
       this.$httpBackend.expectGET('/api/releases/' + release.name)


### PR DESCRIPTION
I noticed this issue today, which wasn't caught by any of the tests (or by me in review of #936). Steps to reproduce:
1) Find a Release that requires signoff to change, and mark it read-only
2) Schedule a change to mark it read-write
3) Fulfill the signoff requirements
4) Wait for the agent to enact it

It will end up setting the `data` column to null. This happens because:
* We don't set `data` in the scheduled change to mark it read-write
* When we enact the change, we copy the entire release row from the scheduled changes table to the releases table (including the `null` for `data`).

cc @allan-silva 

We need to get this backed out ASAP.