### PR TITLE
Add more debug lines to merge_dicts errors.

### DIFF
--- a/auslib/blobs/base.py
+++ b/auslib/blobs/base.py
@@ -109,6 +109,9 @@ def merge_dicts(ancestor, left, right):
         else:
             if key in ancestor:
                 if key in left and key in right and ancestor[key] != left[key] and ancestor[key] != right[key]:
+                    log.warning("Ancestor is: %s", ancestor)
+                    log.warning("Left is: %s", left)
+                    log.warning("Right is: %s", right)
                     raise ValueError("Cannot merge blobs: left and right are both changing '{}'".format(encoded_str_key))
                 if key in left and ancestor[key] != left.get(key):
                     result[key] = left[key]
@@ -118,6 +121,9 @@ def merge_dicts(ancestor, left, right):
                     result[key] = ancestor[key]
             else:
                 if key in left and key in right and left[key] != right[key]:
+                    log.warning("Ancestor is: %s", ancestor)
+                    log.warning("Left is: %s", left)
+                    log.warning("Right is: %s", right)
                     raise ValueError("Cannot merge blobs: left and right are both changing '{}'".format(encoded_str_key))
                 if key in left:
                     result[key] = left[key]


### PR DESCRIPTION
Adding logging to show the full versions of the dictionaries that we're merging should give us some more insight into the issues from https://bugzilla.mozilla.org/show_bug.cgi?id=1585321. Note that this shouldn't log full blobs, because merge errors tend to be deep inside the blobs (usually the platforms section) - it will only log the sub-dictionaries that actually have differing keys between left and right.