### PR TITLE
Fix logging message omission.

### DIFF
--- a/auslib/log.py
+++ b/auslib/log.py
@@ -118,7 +118,7 @@ class JsonLogFormatter(logging.Formatter):
         # and is not already a JSON blob.
         message = record.getMessage()
         if message:
-            if not message.startswith("{") and not message.endswith("}"):
+            if not message.startswith("{") or not message.endswith("}"):
                 fields["message"] = message
 
         # If there is an error, format it for nice output.


### PR DESCRIPTION
While trying to debug https://bugzilla.mozilla.org/show_bug.cgi?id=1587992 I found that the log messages from https://github.com/mozilla/balrog/blob/master/auslib/blobs/base.py#L113 ended up omitting `message` -- there was 3 in a row that only had `requestid` in the fields. It looks to me like this logging code is slightly buggy - it wants to not print JSON, but it considers anything starting _or_ ending with a curly brace to be JSON. I'm not entirely certain why we're omitting these in the first place (this code was copied from elsewhere...), so I don't want to make the leap and remove the condition altogether.

This minor change should get us logging the message we need, without increasing spam too much.