### PR TITLE
Fix STAGING/LOCALDEV environment check

### DIFF
--- a/auslib/web/admin/base.py
+++ b/auslib/web/admin/base.py
@@ -34,7 +34,7 @@ spec = (
 
 validator_map = {"body": BalrogRequestBodyValidator}
 
-connexion_app = connexion.App(__name__, debug=False)
+connexion_app = connexion.App(__name__, debug=False, options={"swagger_ui": False})
 connexion_app.add_api(spec, validator_map=validator_map, strict_validation=True)
 app = connexion_app.app
 sentry = Sentry()

--- a/auslib/web/public/base.py
+++ b/auslib/web/public/base.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 AUS = AUS()
 sentry = Sentry()
 
-connexion_app = connexion.App(__name__, specification_dir=".")
+connexion_app = connexion.App(__name__, specification_dir=".", options={"swagger_ui": False})
 app = connexion_app.app
 
 current_dir = path.dirname(__file__)

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -3,6 +3,9 @@ import os
 
 from auslib.log import configure_logging
 
+STAGING = bool(int(os.environ.get("STAGING", 0)))
+LOCALDEV = bool(int(os.environ.get("LOCALDEV", 0)))
+
 SPECIAL_FORCE_HOSTS = ["http://download.mozilla.org"]
 DOMAIN_WHITELIST = {
     "download.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird"),
@@ -16,7 +19,7 @@ DOMAIN_WHITELIST = {
     "ftp.mozilla.org": ("SystemAddons",),
     "fpn.firefox.com": ("Guardian",),
 }
-if os.environ.get("STAGING") or os.environ.get("LOCALDEV"):
+if STAGING or LOCALDEV:
     DOMAIN_WHITELIST.update(
         {
             "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
@@ -81,5 +84,5 @@ if os.environ.get("SENTRY_DSN"):
 if os.environ.get("CACHE_CONTROL"):
     application.config["CACHE_CONTROL"] = os.environ["CACHE_CONTROL"]
 
-if os.environ.get("STAGING"):
+if STAGING:
     application.config["SWAGGER_DEBUG"] = True


### PR DESCRIPTION
When we were still in AWS, `STAGING` was not present in the environment, so simply checking for its existence was enough. When we switched to GCP we started setting it to `0`, which means we've been allowing staging domains on production for awhile now.