### PR TITLE
Fix build issues with production Dockerfiles + taskcluster; add CI tests for docker builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ cef.log
 .swp
 *.egg-info
 .pytest_cache
+pip-wheel-metadata
 
 build
 generated

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -146,6 +146,48 @@ tasks:
               owner: ${owner_email}
               source: ${repo_url}
 
+          - taskId: {$eval: as_slugid("agent-docker-build")}
+            created: {$fromNow: ''}
+            deadline: {$fromNow: '2 hours'}
+            provisionerId: aws-provisioner-v1
+            workerType: github-worker
+            routes: []
+            payload:
+              maxRunTime: 3600
+              image: "taskcluster/image_builder:0.1.3"
+              command:
+                - "/bin/bash"
+                - "-c"
+                - "git clone ${repo_url} balrog && cd balrog && git checkout ${head_sha} && cd agent && docker build ."
+              features:
+                dind: true
+            metadata:
+              name: Balrog agent docker build
+              description: Balrog agent docker build
+              owner: ${owner_email}
+              source: ${repo_url}
+
+          - taskId: {$eval: as_slugid("backend-docker-build")}
+            created: {$fromNow: ''}
+            deadline: {$fromNow: '2 hours'}
+            provisionerId: aws-provisioner-v1
+            workerType: github-worker
+            routes: []
+            payload:
+              maxRunTime: 3600
+              image: "taskcluster/image_builder:0.1.3"
+              command:
+                - "/bin/bash"
+                - "-c"
+                - "git clone ${repo_url} balrog && cd balrog && git checkout ${head_sha} && docker build ."
+              features:
+                dind: true
+            metadata:
+              name: Balrog backend docker build
+              description: Balrog backend docker build
+              owner: ${owner_email}
+              source: ${repo_url}
+
           - taskId: {$eval: as_slugid("old-ui-tests")}
             created: {$fromNow: ''}
             deadline: {$fromNow: '2 hours'}

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY src/ /app/src/
 COPY ui/ /app/ui/
 COPY uwsgi/ /app/uwsgi/
 COPY scripts/manage-db.py scripts/run-batch-deletes.sh scripts/run.sh scripts/reset-stage-db.sh scripts/get-prod-db-dump.py /app/scripts/
-COPY version.json /app/
+COPY setup.py version.json version.txt /app/
 
 RUN python setup.py install
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include pyproject.toml
+include setup.py
 include tox.ini
 include version.txt
 

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,6 +1,4 @@
-ARG PYTHON_VERSION
-
-FROM python:${PYTHON_VERSION}-stretch
+FROM python:3.7-stretch
 
 MAINTAINER bhearsum@mozilla.com
 


### PR DESCRIPTION
The Agent build broke because taskcluster's version of Docker doesn't support `ARG`. The backend build broke because we were missing some files from the `COPY` instructions.