### PR TITLE
Include MANIFEST.in and pyproject.toml in production Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY src/ /app/src/
 COPY ui/ /app/ui/
 COPY uwsgi/ /app/uwsgi/
 COPY scripts/manage-db.py scripts/run-batch-deletes.sh scripts/run.sh scripts/reset-stage-db.sh scripts/get-prod-db-dump.py /app/scripts/
-COPY setup.py version.json version.txt /app/
+COPY MANIFEST.in pyproject.toml setup.py version.json version.txt /app/
 
 RUN python setup.py install
 


### PR DESCRIPTION
This should fix an issue that has come up where the migration files and JSON schemas are not available (because they weren't installed when `python setup.py install` was run).